### PR TITLE
Fixing Minor version setting

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
@@ -40,7 +40,7 @@ OvEditor::Core::Context::Context(const std::string& p_projectPath, const std::st
 	/* Settings */
 	OvWindowing::Settings::DeviceSettings deviceSettings;
 	deviceSettings.contextMajorVersion = 4;
-	deviceSettings.contextMajorVersion = 3;
+	deviceSettings.contextMinorVersion = 3;
 	windowSettings.title = "Overload Editor";
 	windowSettings.width = 1280;
 	windowSettings.height = 720;


### PR DESCRIPTION
Fixing the OpenGL Minor version setting in the Context class from Editor

Fixes https://github.com/adriengivry/Overload-Sources/issues/4