### PR TITLE
Open with Overload supported

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
@@ -27,11 +27,16 @@ void UpdateWorkingDirectory(const std::string& p_executablePath)
 	}
 }
 
-#ifdef _DEBUG
-	int main(int argc, char** argv)
-#else
+int main(int argc, char** argv);
+
+#ifndef _DEBUG
 INT WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nCmdShow)
+{
+	main(__argc, __argv);
+}
 #endif
+
+int main(int argc, char** argv)
 {
 	UpdateWorkingDirectory(argv[0]);
 


### PR DESCRIPTION
In Windows, you can right click on a file and select "Open With...". This features add the possibility to directly open a .ovproject with Overload.

The project path (_xxx/xxx/xxx.ovproject_) is automatically received as second argument in the main of a C++ project (The first argument being the .exe path itself). 

The feature simply consist into checking the second argument (argv[1]) and, if it exists, skip the project hub to directly open the project. I had to change the working directory to always be at the .exe location, otherwise the program won't find the resources necessary to launch the engine.

![image](https://user-images.githubusercontent.com/33324216/64302775-ebb0a100-cf52-11e9-82fc-e7740e75643e.png)

If you want to quickly test this feature using Visual Studio you can specify command line arguments to emulate the "Open With..." behaviour:

![image](https://user-images.githubusercontent.com/33324216/64468178-54348500-d0ef-11e9-9207-34e1bbb00862.png)

Closes https://github.com/adriengivry/Overload-Sources/issues/14