### PR TITLE
Framebuffer wrapping implemented

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/AView.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/AView.h
@@ -10,6 +10,7 @@
 #include <OvUI/Panels/PanelWindow.h>
 #include <OvUI/Widgets/Visual/Image.h>
 #include <OvRendering/Buffers/UniformBuffer.h>
+#include <OvRendering/Buffers/Framebuffer.h>
 #include <OvRendering/LowRenderer/Camera.h>
 
 namespace OvEditor::Core { class EditorRenderer; }
@@ -34,11 +35,6 @@ namespace OvEditor::Panels
 			bool p_opened,
 			const OvUI::Settings::PanelWindowSettings& p_windowSettings
 		);
-
-		/**
-		* Destructor
-		*/
-		~AView();
 
 		/**
 		* Update the view
@@ -117,8 +113,6 @@ namespace OvEditor::Panels
 		OvMaths::FVector3 m_gridColor = OvMaths::FVector3::One;
 
 	private:
-		uint32_t m_fbo;
-		uint32_t m_renderTexture;
-		uint32_t m_depthStencilBuffer;
+		OvRendering::Buffers::Framebuffer m_fbo;
 	};
 }

--- a/Sources/Overload/OvRendering/OvRendering.vcxproj
+++ b/Sources/Overload/OvRendering/OvRendering.vcxproj
@@ -129,6 +129,7 @@ xcopy "$(SolutionDir)..\..\Dependencies\assimp\bin\*.dll" "$(SolutionDir)..\..\B
   <ItemGroup>
     <ClInclude Include="include\OvRendering\API\Export.h" />
     <ClInclude Include="include\OvRendering\Buffers\EAccessSpecifier.h" />
+    <ClInclude Include="include\OvRendering\Buffers\Framebuffer.h" />
     <ClInclude Include="include\OvRendering\Buffers\IndexBuffer.h" />
     <ClInclude Include="include\OvRendering\Buffers\ShaderStorageBuffer.h" />
     <ClInclude Include="include\OvRendering\Buffers\UniformBuffer.h" />
@@ -163,6 +164,7 @@ xcopy "$(SolutionDir)..\..\Dependencies\assimp\bin\*.dll" "$(SolutionDir)..\..\B
     <ClInclude Include="include\OvRendering\Settings\ETextureFilteringMode.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\OvRendering\Buffers\Framebuffer.cpp" />
     <ClCompile Include="src\OvRendering\Core\ShapeDrawer.cpp" />
     <ClCompile Include="src\OvRendering\Buffers\IndexBuffer.cpp" />
     <ClCompile Include="src\OvRendering\Buffers\ShaderStorageBuffer.cpp" />

--- a/Sources/Overload/OvRendering/OvRendering.vcxproj.filters
+++ b/Sources/Overload/OvRendering/OvRendering.vcxproj.filters
@@ -117,6 +117,9 @@
     <ClInclude Include="include\OvRendering\Core\ShapeDrawer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\OvRendering\Buffers\Framebuffer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\OvRendering\Context\Driver.cpp">
@@ -168,6 +171,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\OvRendering\Core\ShapeDrawer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\OvRendering\Buffers\Framebuffer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Sources/Overload/OvRendering/include/OvRendering/Buffers/Framebuffer.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Buffers/Framebuffer.h
@@ -1,0 +1,70 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @restrictions: This software may not be resold, redistributed or otherwise conveyed to a third party.
+*/
+
+#pragma once
+
+#include <vector>
+
+#include "OvRendering/Context/Driver.h"
+
+namespace OvRendering::Buffers
+{
+	/**
+	* Wraps OpenGL EBO
+	*/
+	class API_OVRENDERING Framebuffer
+	{
+	public:
+		/**
+		* Create the framebuffer
+		* @param p_width
+		* @param p_height
+		*/
+		Framebuffer(uint16_t p_width = 0, uint16_t p_height = 0);
+
+		/**
+		* Destructor
+		*/
+		~Framebuffer();
+
+		/**
+		* Bind the framebuffer
+		*/
+		void Bind();
+
+		/**
+		* Unbind the framebuffer
+		*/
+		void Unbind();
+
+		/**
+		* Defines a new size for the framebuffer
+		* @param p_width
+		* @param p_height
+		*/
+		void Resize(uint16_t p_width, uint16_t p_height);
+
+		/**
+		* Returns the ID of the OpenGL framebuffer
+		*/
+		uint32_t GetID();
+
+		/**
+		* Returns the ID of the OpenGL render texture
+		*/
+		uint32_t GetTextureID();
+
+		/**
+		* Returns the ID of the OpenGL render buffer
+		*/
+		uint32_t GetRenderBufferID();
+
+	private:
+		uint32_t m_bufferID = 0;
+		uint32_t m_renderTexture = 0;
+		uint32_t m_depthStencilBuffer = 0;
+	};
+}

--- a/Sources/Overload/OvRendering/src/OvRendering/Buffers/Framebuffer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Buffers/Framebuffer.cpp
@@ -1,0 +1,82 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @restrictions: This software may not be resold, redistributed or otherwise conveyed to a third party.
+*/
+
+#include <GL/glew.h>
+
+#include "OvRendering/Buffers/Framebuffer.h"
+
+OvRendering::Buffers::Framebuffer::Framebuffer(uint16_t p_width, uint16_t p_height)
+{
+	/* Generate OpenGL objects */
+	glGenFramebuffers(1, &m_bufferID);
+	glGenTextures(1, &m_renderTexture);
+	glGenRenderbuffers(1, &m_depthStencilBuffer);
+
+	/* Setup texture */
+	glBindTexture(GL_TEXTURE_2D, m_renderTexture);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glBindTexture(GL_TEXTURE_2D, 0);
+
+	/* Setup framebuffer */
+	Bind();
+	glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, m_renderTexture, 0);
+	Unbind();
+
+	Resize(p_width, p_height);
+}
+
+OvRendering::Buffers::Framebuffer::~Framebuffer()
+{
+	/* Destroy OpenGL objects */
+	glDeleteBuffers(1, &m_bufferID);
+	glDeleteTextures(1, &m_renderTexture);
+	glGenRenderbuffers(1, &m_depthStencilBuffer);
+}
+
+void OvRendering::Buffers::Framebuffer::Bind()
+{
+	glBindFramebuffer(GL_FRAMEBUFFER, m_bufferID);
+}
+
+void OvRendering::Buffers::Framebuffer::Unbind()
+{
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void OvRendering::Buffers::Framebuffer::Resize(uint16_t p_width, uint16_t p_height)
+{
+	/* Resize texture */
+	glBindTexture(GL_TEXTURE_2D, m_renderTexture);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, p_width, p_height, 0, GL_RGB, GL_UNSIGNED_BYTE, 0);
+	glBindTexture(GL_TEXTURE_2D, 0);
+
+	/* Setup depth-stencil buffer (24 + 8 bits) */
+	glBindRenderbuffer(GL_RENDERBUFFER, m_depthStencilBuffer);
+	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_STENCIL, p_width, p_height);
+	glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+	/* Attach depth and stencil buffer to the framebuffer */
+	Bind();
+	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilBuffer);
+	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilBuffer);
+	Unbind();
+}
+
+uint32_t OvRendering::Buffers::Framebuffer::GetID()
+{
+	return m_bufferID;
+}
+
+uint32_t OvRendering::Buffers::Framebuffer::GetTextureID()
+{
+	return m_renderTexture;
+}
+
+uint32_t OvRendering::Buffers::Framebuffer::GetRenderBufferID()
+{
+	return m_depthStencilBuffer;
+}


### PR DESCRIPTION
A simple wrapping for FBO has been implemented. We use this wrapped
framebuffer only in `AView` for now. There is not a lot of settings
attached to the FBO for now but it is enough to handle the scene view.

Closes https://github.com/adriengivry/Overload-Sources/issues/9