### PR TITLE
Scene actor picking implemented

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Core/EditorRenderer.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/EditorRenderer.h
@@ -39,10 +39,27 @@ namespace OvEditor::Core
 		void InitMaterials();
 
 		/**
+		* Prepare the picking material by send it the color corresponding to the given actor
+		* @param p_actor
+		*/
+		void PreparePickingMaterial(OvCore::ECS::Actor& p_actor);
+
+		/**
+		* Calculate the model matrix for a camera attached to the given actor
+		* @param p_actor
+		*/
+		OvMaths::FMatrix4 CalculateCameraModelMatrix(OvCore::ECS::Actor& p_actor);
+
+		/**
 		* Render the scene
 		* @param p_cameraPosition
 		*/
 		void RenderScene(const OvMaths::FVector3& p_cameraPosition);
+
+		/**
+		* Render the scene for actor picking (Unlit version of the scene with colors indicating actor IDs)
+		*/
+		void RenderSceneForActorPicking();
 
 		/**
 		* Render the User Interface
@@ -131,5 +148,6 @@ namespace OvEditor::Core
 		OvCore::Resources::Material m_cameraMaterial;
 		OvCore::Resources::Material m_guizmoArrowMaterial;
 		OvCore::Resources::Material m_guizmoBallMaterial;
+		OvCore::Resources::Material m_actorPickingMaterial;
 	};
 }

--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/AView.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/AView.h
@@ -43,16 +43,6 @@ namespace OvEditor::Panels
 		virtual void Update(float p_deltaTime);
 
 		/**
-		* Bind the FBO attached to the view
-		*/
-		void Bind();
-
-		/**
-		* Unbind the FBO attached to the view
-		*/
-		void Unbind();
-
-		/**
 		* Custom implementation of the draw method
 		*/
 		void _Draw_Impl() override;
@@ -112,7 +102,6 @@ namespace OvEditor::Panels
 
 		OvMaths::FVector3 m_gridColor = OvMaths::FVector3::One;
 
-	private:
 		OvRendering::Buffers::Framebuffer m_fbo;
 	};
 }

--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/SceneView.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/SceneView.h
@@ -27,17 +27,23 @@ namespace OvEditor::Panels
 		);
 
 		/**
-		* Update the scene view (Inputs logic)
-		* @param p_deltaTime
-		*/
-		virtual void Update(float p_deltaTime) override;
-
-		/**
 		* Custom implementation of the render method
 		*/
 		virtual void _Render_Impl() override;
 
+		/**
+		* Render the actual scene
+		* @param p_defaultRenderState
+		*/
+		void RenderScene(uint8_t p_defaultRenderState);
+
+		/**
+		* Render the scene for actor picking and handle the logic behind it
+		*/
+		void HandleActorPicking();
+
 	private:
 		OvCore::SceneSystem::SceneManager& m_sceneManager;
+		OvRendering::Buffers::Framebuffer m_actorPickingFramebuffer;
 	};
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -82,8 +82,8 @@ void OvEditor::Core::Editor::PreUpdate()
 void OvEditor::Core::Editor::Update(float p_deltaTime)
 {
 	UpdateCurrentEditorMode(p_deltaTime);
-	UpdateEditorPanels(p_deltaTime);
 	PrepareRendering(p_deltaTime);
+	UpdateEditorPanels(p_deltaTime);
 	RenderViews(p_deltaTime);
 	RenderEditorUI(p_deltaTime);
 	m_editorActions.ExecuteDelayedActions();

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
@@ -25,29 +25,11 @@ OvEditor::Panels::AView::AView
 
 void OvEditor::Panels::AView::Update(float p_deltaTime)
 {
-	Bind();
-
 	auto[winWidth, winHeight] = GetSafeSize();
 
 	m_image->size = OvMaths::FVector2(static_cast<float>(winWidth), static_cast<float>(winHeight));
 
 	m_fbo.Resize(winWidth, winHeight);
-
-	Unbind();
-}
-
-void OvEditor::Panels::AView::Bind()
-{
-	auto[winWidth, winHeight] = GetSafeSize();
-
-	glViewport(0, 0, winWidth, winHeight);
-
-	m_fbo.Bind();
-}
-
-void OvEditor::Panels::AView::Unbind()
-{
-	m_fbo.Unbind();
 }
 
 void OvEditor::Panels::AView::_Draw_Impl()
@@ -67,10 +49,9 @@ void OvEditor::Panels::AView::Render()
 	auto projection = m_camera.GetProjectionMatrix(winWidth, winHeight);
 	auto view = m_camera.GetViewMatrix(m_cameraPosition);
 	EDITOR_CONTEXT(shapeDrawer)->SetViewProjection(projection * view);
+	glViewport(0, 0, winWidth, winHeight); // TODO: Move this OpenGL call to OvRendering
 
-	Bind();
 	_Render_Impl();
-	Unbind();
 }
 
 void OvEditor::Panels::AView::SetCameraPosition(const OvMaths::FVector3 & p_position)

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetView.cpp
@@ -49,6 +49,8 @@ void OvEditor::Panels::AssetView::_Render_Impl()
 {
 	auto& baseRenderer = *EDITOR_CONTEXT(renderer).get();
 
+	m_fbo.Bind();
+
 	baseRenderer.SetStencilMask(0xFF);
 	baseRenderer.Clear(m_camera);
 	baseRenderer.SetStencilMask(0x00);
@@ -68,6 +70,8 @@ void OvEditor::Panels::AssetView::_Render_Impl()
 		m_editorRenderer.RenderMaterialAsset(**pval);
 
 	baseRenderer.ApplyStateMask(glState);
+
+	m_fbo.Unbind();
 }
 
 void OvEditor::Panels::AssetView::SetResource(ViewableResource p_resource)

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/GameView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/GameView.cpp
@@ -45,6 +45,8 @@ void OvEditor::Panels::GameView::Update(float p_deltaTime)
 void OvEditor::Panels::GameView::_Render_Impl()
 {
 	auto& baseRenderer = *EDITOR_CONTEXT(renderer).get();
+	
+	m_fbo.Bind();
 
 	baseRenderer.Clear(m_camera);
 
@@ -54,5 +56,8 @@ void OvEditor::Panels::GameView::_Render_Impl()
 	if (m_hasCamera)
 		m_editorRenderer.RenderScene(m_cameraPosition);
 
+
 	baseRenderer.ApplyStateMask(glState);
+
+	m_fbo.Unbind();
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
@@ -32,33 +32,28 @@ OvEditor::Panels::SceneView::SceneView
 	};
 }
 
-void OvEditor::Panels::SceneView::Update(float p_deltaTime)
-{
-	AViewControllable::Update(p_deltaTime);
-
-	if (IsHovered() && EDITOR_CONTEXT(inputManager)->IsMouseButtonPressed(OvWindowing::Inputs::EMouseButton::MOUSE_BUTTON_LEFT))
-	{
-		/* Prevent losing focus on actor while resizing a window */
-		if (auto cursor = ImGui::GetMouseCursor();
-			cursor != ImGuiMouseCursor_ResizeEW &&
-			cursor != ImGuiMouseCursor_ResizeNS &&
-			cursor != ImGuiMouseCursor_ResizeNWSE &&
-			cursor != ImGuiMouseCursor_ResizeNESW &&
-			cursor != ImGuiMouseCursor_ResizeAll)
-		EDITOR_EXEC(UnselectActor());
-	}
-}
-
 void OvEditor::Panels::SceneView::_Render_Impl()
 {
 	auto& baseRenderer = *EDITOR_CONTEXT(renderer).get();
 
+	uint8_t glState = baseRenderer.FetchGLState();
+	baseRenderer.ApplyStateMask(glState);
+
+	RenderScene(glState);
+	baseRenderer.ApplyStateMask(glState);
+	HandleActorPicking();
+	baseRenderer.ApplyStateMask(glState);
+}
+
+void OvEditor::Panels::SceneView::RenderScene(uint8_t p_defaultRenderState)
+{
+	auto& baseRenderer = *EDITOR_CONTEXT(renderer).get();
+
+	m_fbo.Bind();
+
 	baseRenderer.SetStencilMask(0xFF);
 	baseRenderer.Clear(m_camera);
 	baseRenderer.SetStencilMask(0x00);
-
-	uint8_t glState = baseRenderer.FetchGLState();
-	baseRenderer.ApplyStateMask(glState);
 
 	m_editorRenderer.RenderGrid(m_cameraPosition, m_gridColor);
 	m_editorRenderer.RenderCameras();
@@ -71,14 +66,63 @@ void OvEditor::Panels::SceneView::_Render_Impl()
 		if (selectedActor.IsActive())
 		{
 			m_editorRenderer.RenderActorAsSelected(selectedActor, true);
-			baseRenderer.ApplyStateMask(glState);
+			baseRenderer.ApplyStateMask(p_defaultRenderState);
 			m_editorRenderer.RenderActorAsSelected(selectedActor, false);
 		}
 
-		baseRenderer.ApplyStateMask(glState);
+		baseRenderer.ApplyStateMask(p_defaultRenderState);
 		baseRenderer.Clear(false, true, false);
 		m_editorRenderer.RenderGuizmo(selectedActor.transform.GetWorldPosition(), selectedActor.transform.GetWorldRotation());
 	}
 
-	baseRenderer.ApplyStateMask(glState);
+	m_fbo.Unbind();
+}
+
+void OvEditor::Panels::SceneView::HandleActorPicking()
+{
+	if (IsHovered() && EDITOR_CONTEXT(inputManager)->IsMouseButtonPressed(OvWindowing::Inputs::EMouseButton::MOUSE_BUTTON_LEFT))
+	{
+		/* Prevent losing focus on actor while resizing a window */
+		if (auto cursor = ImGui::GetMouseCursor();
+			cursor != ImGuiMouseCursor_ResizeEW &&
+			cursor != ImGuiMouseCursor_ResizeNS &&
+			cursor != ImGuiMouseCursor_ResizeNWSE &&
+			cursor != ImGuiMouseCursor_ResizeNESW &&
+			cursor != ImGuiMouseCursor_ResizeAll)
+		{
+			auto& baseRenderer = *EDITOR_CONTEXT(renderer).get();
+
+			auto [winWidth, winHeight] = GetSafeSize();
+
+			m_actorPickingFramebuffer.Resize(winWidth, winHeight);
+			m_actorPickingFramebuffer.Bind();
+			baseRenderer.SetClearColor(1.0f, 1.0f, 1.0f);
+			baseRenderer.Clear();
+			m_editorRenderer.RenderSceneForActorPicking();
+
+			// Look actor under mouse
+			auto mousePosition = EDITOR_CONTEXT(inputManager)->GetMousePosition();
+			auto mouseX = static_cast<uint16_t>(mousePosition.first);
+			auto mouseY = static_cast<uint16_t>(mousePosition.second);
+			mouseX -= static_cast<uint16_t>(m_position.x);
+			mouseY -= static_cast<uint16_t>(m_position.y);
+			mouseY = GetSafeSize().second - mouseY + 25;
+
+			uint8_t pixels[3];
+			glReadPixels(static_cast<int>(mouseX), static_cast<int>(mouseY), 1, 1, GL_RGB, GL_UNSIGNED_BYTE, pixels);
+			m_actorPickingFramebuffer.Unbind();
+
+			uint32_t actorID = (0 << 24) | (pixels[2] << 16) | (pixels[1] << 8) | (pixels[0] << 0);
+
+			if (auto actor = EDITOR_CONTEXT(sceneManager).GetCurrentScene()->FindActorByID(actorID))
+			{
+				EDITOR_EXEC(SelectActor(*actor));
+			}
+			else
+			{
+				EDITOR_EXEC(UnselectActor());
+			}
+
+		}
+	}
 }


### PR DESCRIPTION
The current system **only consider models and camera** (Only pickable elements). As it is **render based**, we can't pick colliders and lights for now. We can add billboard later. The current system is limited to 16,581,374 actors (`255 * 255 * 255 - 1`) due to the fact that our framebuffer elements are 24 bits (One byte per color components : R, G, B) and that one color is reserved for the background.

![actor_picking](https://user-images.githubusercontent.com/33324216/64468094-5ba75e80-d0ee-11e9-9e77-545c966e5294.gif)

Closes https://github.com/adriengivry/Overload-Sources/issues/1