### PR TITLE
Project added to hub when received as program args

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Core/ProjectHub.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/ProjectHub.h
@@ -36,6 +36,12 @@ namespace OvEditor::Core
 		*/
 		void SetupContext();
 
+		/**
+		* Register the project (identified from the given path) into the project hub
+		* @param p_path
+		*/
+		void RegisterProject(const std::string& p_path);
+
 	private:
 		std::unique_ptr<OvWindowing::Context::Device>		m_device;
 		std::unique_ptr<OvWindowing::Window>				m_window;

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/ProjectHub.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/ProjectHub.cpp
@@ -307,3 +307,8 @@ void OvEditor::Core::ProjectHub::SetupContext()
 	m_uiManager->EnableEditorLayoutSave(false);
 	m_uiManager->EnableDocking(false);
 }
+
+void OvEditor::Core::ProjectHub::RegisterProject(const std::string& p_path)
+{
+	static_cast<ProjectHubPanel*>(m_mainPanel.get())->RegisterProject(p_path);
+}

--- a/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
@@ -64,6 +64,8 @@ int main(int argc, char** argv)
 				projectName = OvTools::Utils::PathParser::GetElementName(projectFile);
 				OvTools::Utils::String::Replace(projectName, ".ovproject", "");
 			}
+
+			hub.RegisterProject(projectPath);
 		}
 	}
 


### PR DESCRIPTION
When you open a project with program arguments (Command line arguments or with "Open With Overload" on windows), this project is now added into the project.ini file.

Closes https://github.com/adriengivry/Overload-Sources/issues/28