### PR TITLE
Implementing a simple hierarchy finder

### DIFF
--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/TreeNode.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/TreeNode.h
@@ -38,6 +38,11 @@ namespace OvUI::Widgets::Layout
 		*/
 		void Close();
 
+		/**
+		* Returns true if the TreeNode is currently opened
+		*/
+		bool IsOpened() const;
+
 	protected:
 		virtual void _Draw_Impl() override;
 

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/TreeNode.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/TreeNode.cpp
@@ -26,6 +26,11 @@ void OvUI::Widgets::Layout::TreeNode::Close()
 	m_shouldOpen = false;
 }
 
+bool OvUI::Widgets::Layout::TreeNode::IsOpened() const
+{
+	return m_opened;
+}
+
 void OvUI::Widgets::Layout::TreeNode::_Draw_Impl()
 {
 	bool prevOpened = m_opened;


### PR DESCRIPTION
We can now search for an actor by name with the hierarchy search bar.
Actors that matches the input string are shown in the hierarchy and
other actors are hidden. I also noticed m_widgetActorLink was never
cleared so I added it. It seems to be fixing the duplication crash that
we had.

![HierarchySearch](https://user-images.githubusercontent.com/33324216/65367595-e1083400-dc01-11e9-88dc-e1fa52b224e4.gif)

Closes https://github.com/adriengivry/Overload-Sources/issues/42
Fixes https://github.com/adriengivry/Overload-Sources/issues/6

