### PR TITLE
Gizmo snapping implemented

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Core/GizmoBehaviour.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/GizmoBehaviour.h
@@ -27,6 +27,11 @@ namespace OvEditor::Core
 			Y,
 			Z
 		};
+		
+		/**
+		* Returns true if the snapping behaviour is enabled
+		*/
+		bool IsSnappedBehaviourEnabled() const;
 
 		/**
 		* Starts the gizmo picking behaviour for the given target in the given direction

--- a/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
@@ -77,5 +77,8 @@ namespace OvEditor::Settings
 		inline static Property<bool> ShowLightBounds = { false };
 		inline static Property<bool> ShowGeometryFrustumCullingInSceneView = { false };
 		inline static Property<bool> ShowLightFrustumCullingInSceneView = { false };
+		inline static Property<float> TranslationSnapUnit = { 1.0f };
+		inline static Property<float> RotationSnapUnit = { 15.0f };
+		inline static Property<float> ScalingSnapUnit = { 1.0f };
 	};
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
@@ -20,6 +20,7 @@
 
 #include <OvUI/Widgets/Visual/Separator.h>
 #include <OvUI/Widgets/Sliders/SliderInt.h>
+#include <OvUI/Widgets/Drags/DragFloat.h>
 #include <OvUI/Widgets/Selection/ColorEdit.h>
 
 #include "OvEditor/Panels/MenuBar.h"
@@ -199,6 +200,11 @@ void OvEditor::Panels::MenuBar::CreateSettingsMenu()
 		EDITOR_PANEL(Panels::AssetView, "Asset View").SetGridColor(OvMaths::FVector3::One);
 		assetViewGridPicker.color = OvUI::Types::Color::White;
 	};
+
+	auto& snappingMenu = settingsMenu.CreateWidget<MenuList>("Snapping");
+	snappingMenu.CreateWidget<Drags::DragFloat>(0.001f, 999999.0f, Settings::EditorSettings::TranslationSnapUnit, 0.05f, "Translation Unit").ValueChangedEvent += [this](float p_value) { Settings::EditorSettings::TranslationSnapUnit = p_value; };
+	snappingMenu.CreateWidget<Drags::DragFloat>(0.001f, 999999.0f, Settings::EditorSettings::RotationSnapUnit, 1.0f, "Rotation Unit").ValueChangedEvent += [this](float p_value) { Settings::EditorSettings::RotationSnapUnit = p_value; };
+	snappingMenu.CreateWidget<Drags::DragFloat>(0.001f, 999999.0f, Settings::EditorSettings::ScalingSnapUnit, 0.05f, "Scaling Unit").ValueChangedEvent += [this](float p_value) { Settings::EditorSettings::ScalingSnapUnit = p_value; };
 
 	auto& debuggingMenu = settingsMenu.CreateWidget<MenuList>("Debugging");
 	debuggingMenu.CreateWidget<MenuItem>("Show geometry bounds", "", true, Settings::EditorSettings::ShowGeometryBounds).ValueChangedEvent += [this](bool p_value) { Settings::EditorSettings::ShowGeometryBounds = p_value; };


### PR DESCRIPTION
Gizmo behaviour can now be changed by pressing the CTRL key. While this
key is pressed, any translation, rotation or scaling will be subject to
snapping. The snapping units for each operation can be defined in the
settings drop down menu.

![GizmoSnapping](https://user-images.githubusercontent.com/33324216/65380329-4104e600-dca7-11e9-8008-58610865957c.gif)

Closes https://github.com/adriengivry/Overload-Sources/issues/37