### PR TITLE
Adding texture and model metadata customization

### DIFF
--- a/Sources/Overload/OvAudio/include/OvAudio/Resources/Loaders/SoundLoader.h
+++ b/Sources/Overload/OvAudio/include/OvAudio/Resources/Loaders/SoundLoader.h
@@ -30,6 +30,13 @@ namespace OvAudio::Resources::Loaders
 		static Sound* Create(const std::string& p_filepath);
 
 		/**
+		* Reload a sound
+		* @param p_sound
+		* @param p_path
+		*/
+		static void Reload(Sound& p_sound, const std::string& p_path);
+
+		/**
 		* Destroy a sound
 		* @param p_soundInstance
 		*/

--- a/Sources/Overload/OvAudio/src/OvAudio/Resources/Loaders/SoundLoader.cpp
+++ b/Sources/Overload/OvAudio/src/OvAudio/Resources/Loaders/SoundLoader.cpp
@@ -11,6 +11,11 @@ OvAudio::Resources::Sound* OvAudio::Resources::Loaders::SoundLoader::Create(cons
 	return new Sound(p_filepath);
 }
 
+void OvAudio::Resources::Loaders::SoundLoader::Reload(Sound& p_sound, const std::string& p_path)
+{
+	*const_cast<std::string*>(&p_sound.path) = p_path;
+}
+
 bool OvAudio::Resources::Loaders::SoundLoader::Destroy(Sound*& p_soundInstance)
 {
 	if (p_soundInstance)

--- a/Sources/Overload/OvCore/include/OvCore/ResourceManagement/AResourceManager.h
+++ b/Sources/Overload/OvCore/include/OvCore/ResourceManagement/AResourceManager.h
@@ -40,6 +40,12 @@ namespace OvCore::ResourceManagement
 		bool MoveResource(const std::string& p_previousPath, const std::string& p_newPath);
 
 		/**
+		* Reload a resource
+		* @param p_path
+		*/
+		void ReloadResource(const std::string& p_path);
+
+		/**
 		* Return true if the resource exists (= Is registered)
 		* @param p_path
 		*/
@@ -97,6 +103,7 @@ namespace OvCore::ResourceManagement
 	protected:
 		virtual T* CreateResource(const std::string& p_path) = 0;
 		virtual void DestroyResource(T* p_resource) = 0;
+		virtual void ReloadResource(T* p_resource, const std::string& p_path) = 0;
 		std::string GetRealPath(const std::string& p_path) const;
 
 	private:

--- a/Sources/Overload/OvCore/include/OvCore/ResourceManagement/AResourceManager.inl
+++ b/Sources/Overload/OvCore/include/OvCore/ResourceManagement/AResourceManager.inl
@@ -52,6 +52,15 @@ namespace OvCore::ResourceManagement
 	}
 
 	template<typename T>
+	inline void AResourceManager<T>::ReloadResource(const std::string& p_path)
+	{
+		if (auto resource = GetResource(p_path, false); resource)
+		{
+			ReloadResource(resource, p_path);
+		}
+	}
+
+	template<typename T>
 	inline bool AResourceManager<T>::IsResourceRegistered(const std::string & p_path)
 	{
 		return m_resources.find(p_path) != m_resources.end();

--- a/Sources/Overload/OvCore/include/OvCore/ResourceManagement/MaterialManager.h
+++ b/Sources/Overload/OvCore/include/OvCore/ResourceManagement/MaterialManager.h
@@ -28,5 +28,12 @@ namespace OvCore::ResourceManagement
 		* @param p_resource
 		*/
 		virtual void DestroyResource(OvCore::Resources::Material* p_resource) override;
+
+		/**
+		* Reload the given resource
+		* @param p_resource
+		* @param p_path
+		*/
+		virtual void ReloadResource(OvCore::Resources::Material* p_resource, const std::string& p_path) override;
 	};
 }

--- a/Sources/Overload/OvCore/include/OvCore/ResourceManagement/ModelManager.h
+++ b/Sources/Overload/OvCore/include/OvCore/ResourceManagement/ModelManager.h
@@ -29,5 +29,12 @@ namespace OvCore::ResourceManagement
 		* @param p_resource
 		*/
 		virtual void DestroyResource(OvRendering::Resources::Model* p_resource) override;
+
+		/**
+		* Reload the given resource
+		* @param p_resource
+		* @param p_path
+		*/
+		virtual void ReloadResource(OvRendering::Resources::Model* p_resource, const std::string& p_path) override;
 	};
 }

--- a/Sources/Overload/OvCore/include/OvCore/ResourceManagement/ShaderManager.h
+++ b/Sources/Overload/OvCore/include/OvCore/ResourceManagement/ShaderManager.h
@@ -29,5 +29,12 @@ namespace OvCore::ResourceManagement
 		* @param p_resource
 		*/
 		virtual void DestroyResource(OvRendering::Resources::Shader* p_resource) override;
+
+		/**
+		* Reload the given resource
+		* @param p_resource
+		* @param p_path
+		*/
+		virtual void ReloadResource(OvRendering::Resources::Shader* p_resource, const std::string& p_path) override;
 	};
 }

--- a/Sources/Overload/OvCore/include/OvCore/ResourceManagement/SoundManager.h
+++ b/Sources/Overload/OvCore/include/OvCore/ResourceManagement/SoundManager.h
@@ -29,5 +29,12 @@ namespace OvCore::ResourceManagement
 		* @param p_resource
 		*/
 		virtual void DestroyResource(OvAudio::Resources::Sound* p_resource) override;
+
+		/**
+		* Reload the given resource
+		* @param p_resource
+		* @param p_path
+		*/
+		virtual void ReloadResource(OvAudio::Resources::Sound* p_resource, const std::string& p_path) override;
 	};
 }

--- a/Sources/Overload/OvCore/include/OvCore/ResourceManagement/TextureManager.h
+++ b/Sources/Overload/OvCore/include/OvCore/ResourceManagement/TextureManager.h
@@ -29,5 +29,12 @@ namespace OvCore::ResourceManagement
 		* @param p_resource
 		*/
 		virtual void DestroyResource(OvRendering::Resources::Texture* p_resource) override;
+
+		/**
+		* Reload the given resource
+		* @param p_resource
+		* @param p_path
+		*/
+		virtual void ReloadResource(OvRendering::Resources::Texture* p_resource, const std::string& p_path) override;
 	};
 }

--- a/Sources/Overload/OvCore/src/OvCore/ResourceManagement/MaterialManager.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ResourceManagement/MaterialManager.cpp
@@ -23,3 +23,8 @@ void OvCore::ResourceManagement::MaterialManager::DestroyResource(OvCore::Resour
 {
 	OvCore::Resources::Loaders::MaterialLoader::Destroy(p_resource);
 }
+
+void OvCore::ResourceManagement::MaterialManager::ReloadResource(OvCore::Resources::Material* p_resource, const std::string& p_path)
+{
+	OvCore::Resources::Loaders::MaterialLoader::Reload(*p_resource, p_path);
+}

--- a/Sources/Overload/OvCore/src/OvCore/ResourceManagement/ModelManager.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ResourceManagement/ModelManager.cpp
@@ -6,25 +6,48 @@
 
 #include "OvCore/ResourceManagement/ModelManager.h"
 
-OvRendering::Resources::Model* OvCore::ResourceManagement::ModelManager::CreateResource(const std::string& p_path)
+#include <OvTools/Filesystem/IniFile.h>
+
+OvRendering::Resources::Parsers::EModelParserFlags GetAssetMetadata(const std::string& p_path)
 {
+	auto metaFile = OvTools::Filesystem::IniFile(p_path + ".meta");
+
 	OvRendering::Resources::Parsers::EModelParserFlags flags = OvRendering::Resources::Parsers::EModelParserFlags::NONE;
 
-	flags |= OvRendering::Resources::Parsers::EModelParserFlags::TRIANGULATE;
-	flags |= OvRendering::Resources::Parsers::EModelParserFlags::GEN_SMOOTH_NORMALS;
-	flags |= OvRendering::Resources::Parsers::EModelParserFlags::OPTIMIZE_MESHES;
-	flags |= OvRendering::Resources::Parsers::EModelParserFlags::OPTIMIZE_GRAPH;
-	flags |= OvRendering::Resources::Parsers::EModelParserFlags::FIND_INSTANCES;
-	flags |= OvRendering::Resources::Parsers::EModelParserFlags::CALC_TANGENT_SPACE;
-	flags |= OvRendering::Resources::Parsers::EModelParserFlags::JOIN_IDENTICAL_VERTICES;
-	flags |= OvRendering::Resources::Parsers::EModelParserFlags::DEBONE;
-	flags |= OvRendering::Resources::Parsers::EModelParserFlags::FIND_INVALID_DATA;
-	flags |= OvRendering::Resources::Parsers::EModelParserFlags::IMPROVE_CACHE_LOCALITY;
-	flags |= OvRendering::Resources::Parsers::EModelParserFlags::GEN_UV_COORDS;
-	flags |= OvRendering::Resources::Parsers::EModelParserFlags::PRE_TRANSFORM_VERTICES;
+	if (metaFile.GetOrDefault("CALC_TANGENT_SPACE",			true))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::CALC_TANGENT_SPACE;
+	if (metaFile.GetOrDefault("JOIN_IDENTICAL_VERTICES",	true))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::JOIN_IDENTICAL_VERTICES;
+	if (metaFile.GetOrDefault("MAKE_LEFT_HANDED",			false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::MAKE_LEFT_HANDED;
+	if (metaFile.GetOrDefault("TRIANGULATE",				true))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::TRIANGULATE;
+	if (metaFile.GetOrDefault("REMOVE_COMPONENT",			false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::REMOVE_COMPONENT;
+	if (metaFile.GetOrDefault("GEN_NORMALS",				false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::GEN_NORMALS;
+	if (metaFile.GetOrDefault("GEN_SMOOTH_NORMALS",			true))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::GEN_SMOOTH_NORMALS;
+	if (metaFile.GetOrDefault("SPLIT_LARGE_MESHES",			false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::SPLIT_LARGE_MESHES;
+	if (metaFile.GetOrDefault("PRE_TRANSFORM_VERTICES",		true))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::PRE_TRANSFORM_VERTICES;
+	if (metaFile.GetOrDefault("LIMIT_BONE_WEIGHTS",			false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::LIMIT_BONE_WEIGHTS;
+	if (metaFile.GetOrDefault("VALIDATE_DATA_STRUCTURE",	false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::VALIDATE_DATA_STRUCTURE;
+	if (metaFile.GetOrDefault("IMPROVE_CACHE_LOCALITY",		true))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::IMPROVE_CACHE_LOCALITY;
+	if (metaFile.GetOrDefault("REMOVE_REDUNDANT_MATERIALS", false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::REMOVE_REDUNDANT_MATERIALS;
+	if (metaFile.GetOrDefault("FIX_INFACING_NORMALS",		false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::FIX_INFACING_NORMALS;
+	if (metaFile.GetOrDefault("SORT_BY_PTYPE",				false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::SORT_BY_PTYPE;
+	if (metaFile.GetOrDefault("FIND_DEGENERATES",			false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::FIND_DEGENERATES;
+	if (metaFile.GetOrDefault("FIND_INVALID_DATA",			true))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::FIND_INVALID_DATA;
+	if (metaFile.GetOrDefault("GEN_UV_COORDS",				true))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::GEN_UV_COORDS;
+	if (metaFile.GetOrDefault("TRANSFORM_UV_COORDS",		false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::TRANSFORM_UV_COORDS;
+	if (metaFile.GetOrDefault("FIND_INSTANCES",				true))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::FIND_INSTANCES;
+	if (metaFile.GetOrDefault("OPTIMIZE_MESHES",			true))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::OPTIMIZE_MESHES;
+	if (metaFile.GetOrDefault("OPTIMIZE_GRAPH",				true))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::OPTIMIZE_GRAPH;
+	if (metaFile.GetOrDefault("FLIP_UVS",					false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::FLIP_UVS;
+	if (metaFile.GetOrDefault("FLIP_WINDING_ORDER",			false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::FLIP_WINDING_ORDER;
+	if (metaFile.GetOrDefault("SPLIT_BY_BONE_COUNT",		false))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::SPLIT_BY_BONE_COUNT;
+	if (metaFile.GetOrDefault("DEBONE",						true))	flags |= OvRendering::Resources::Parsers::EModelParserFlags::DEBONE;
 
+	return { flags };
+}
+
+OvRendering::Resources::Model* OvCore::ResourceManagement::ModelManager::CreateResource(const std::string& p_path)
+{
 	std::string realPath = GetRealPath(p_path);
-	auto model = OvRendering::Resources::Loaders::ModelLoader::Create(realPath, flags);
+	auto model = OvRendering::Resources::Loaders::ModelLoader::Create(realPath, GetAssetMetadata(realPath));
 	if (model)
 		*reinterpret_cast<std::string*>(reinterpret_cast<char*>(model) + offsetof(OvRendering::Resources::Model, path)) = p_path; // Force the resource path to fit the given path
 
@@ -34,4 +57,10 @@ OvRendering::Resources::Model* OvCore::ResourceManagement::ModelManager::CreateR
 void OvCore::ResourceManagement::ModelManager::DestroyResource(OvRendering::Resources::Model* p_resource)
 {
 	OvRendering::Resources::Loaders::ModelLoader::Destroy(p_resource);
+}
+
+void OvCore::ResourceManagement::ModelManager::ReloadResource(OvRendering::Resources::Model* p_resource, const std::string& p_path)
+{
+	std::string realPath = GetRealPath(p_path);
+	OvRendering::Resources::Loaders::ModelLoader::Reload(*p_resource, realPath, GetAssetMetadata(realPath));
 }

--- a/Sources/Overload/OvCore/src/OvCore/ResourceManagement/ShaderManager.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ResourceManagement/ShaderManager.cpp
@@ -20,3 +20,8 @@ void OvCore::ResourceManagement::ShaderManager::DestroyResource(OvRendering::Res
 {
 	OvRendering::Resources::Loaders::ShaderLoader::Destroy(p_resource);
 }
+
+void OvCore::ResourceManagement::ShaderManager::ReloadResource(OvRendering::Resources::Shader* p_resource, const std::string& p_path)
+{
+	OvRendering::Resources::Loaders::ShaderLoader::Recompile(*p_resource, p_path);
+}

--- a/Sources/Overload/OvCore/src/OvCore/ResourceManagement/SoundManager.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ResourceManagement/SoundManager.cpp
@@ -20,3 +20,7 @@ void OvCore::ResourceManagement::SoundManager::DestroyResource(OvAudio::Resource
 {
 	OvAudio::Resources::Loaders::SoundLoader::Destroy(p_resource);
 }
+
+void OvCore::ResourceManagement::SoundManager::ReloadResource(OvAudio::Resources::Sound* p_resource, const std::string& p_path)
+{
+}

--- a/Sources/Overload/OvCore/src/OvCore/ResourceManagement/TextureManager.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ResourceManagement/TextureManager.cpp
@@ -7,13 +7,26 @@
 #include "OvCore/ResourceManagement/TextureManager.h"
 #include "OvRendering/Settings/DriverSettings.h"
 
+#include <OvTools/Filesystem/IniFile.h>
+
+std::tuple<OvRendering::Settings::ETextureFilteringMode, OvRendering::Settings::ETextureFilteringMode, bool> GetAssetMetadata(const std::string& p_path)
+{
+	auto metaFile = OvTools::Filesystem::IniFile(p_path + ".meta");
+
+	auto min = metaFile.GetOrDefault("MIN_FILTER", static_cast<int>(OvRendering::Settings::ETextureFilteringMode::LINEAR_MIPMAP_LINEAR));
+	auto mag = metaFile.GetOrDefault("MAG_FILTER", static_cast<int>(OvRendering::Settings::ETextureFilteringMode::LINEAR));
+	auto mipmap = metaFile.GetOrDefault("ENABLE_MIPMAPPING", true);
+
+	return { static_cast<OvRendering::Settings::ETextureFilteringMode>(min), static_cast<OvRendering::Settings::ETextureFilteringMode>(mag), mipmap };
+}
+
 OvRendering::Resources::Texture* OvCore::ResourceManagement::TextureManager::CreateResource(const std::string & p_path)
 {
-	OvRendering::Settings::ETextureFilteringMode firstFilter = OvRendering::Settings::ETextureFilteringMode::LINEAR_MIPMAP_LINEAR;
-	OvRendering::Settings::ETextureFilteringMode secondFilter = OvRendering::Settings::ETextureFilteringMode::LINEAR;
-
 	std::string realPath = GetRealPath(p_path);
-	OvRendering::Resources::Texture* texture = OvRendering::Resources::Loaders::TextureLoader::Create(realPath, firstFilter, secondFilter, true);
+
+	auto [min, mag, mipmap] = GetAssetMetadata(realPath);
+
+	OvRendering::Resources::Texture* texture = OvRendering::Resources::Loaders::TextureLoader::Create(realPath, min, mag, mipmap);
 	if (texture)
 		*reinterpret_cast<std::string*>(reinterpret_cast<char*>(texture) + offsetof(OvRendering::Resources::Texture, path)) = p_path; // Force the resource path to fit the given path
 
@@ -23,4 +36,13 @@ OvRendering::Resources::Texture* OvCore::ResourceManagement::TextureManager::Cre
 void OvCore::ResourceManagement::TextureManager::DestroyResource(OvRendering::Resources::Texture* p_resource)
 {
 	OvRendering::Resources::Loaders::TextureLoader::Destroy(p_resource);
+}
+
+void OvCore::ResourceManagement::TextureManager::ReloadResource(OvRendering::Resources::Texture* p_resource, const std::string& p_path)
+{
+	std::string realPath = GetRealPath(p_path);
+
+	auto [min, mag, mipmap] = GetAssetMetadata(realPath);
+
+	OvRendering::Resources::Loaders::TextureLoader::Reload(*p_resource, realPath, min, mag, mipmap);
 }

--- a/Sources/Overload/OvEditor/OvEditor.vcxproj
+++ b/Sources/Overload/OvEditor/OvEditor.vcxproj
@@ -146,6 +146,7 @@ xcopy "$(ProjectDir)Layout.ini" "$(SolutionDir)..\..\Build\$(ProjectName)\$(Conf
     <ClCompile Include="src\OvEditor\Core\PanelsManager.cpp" />
     <ClCompile Include="src\OvEditor\Core\ProjectHub.cpp" />
     <ClCompile Include="src\OvEditor\Panels\AssetBrowser.cpp" />
+    <ClCompile Include="src\OvEditor\Panels\AssetMetadataEditor.cpp" />
     <ClCompile Include="src\OvEditor\Panels\AssetView.cpp" />
     <ClCompile Include="src\OvEditor\Panels\AView.cpp" />
     <ClCompile Include="src\OvEditor\Panels\AViewControllable.cpp" />
@@ -176,6 +177,7 @@ xcopy "$(ProjectDir)Layout.ini" "$(SolutionDir)..\..\Build\$(ProjectName)\$(Conf
     <ClInclude Include="include\OvEditor\Core\GizmoBehaviour.h" />
     <ClInclude Include="include\OvEditor\Core\PanelsManager.h" />
     <ClInclude Include="include\OvEditor\Core\ProjectHub.h" />
+    <ClInclude Include="include\OvEditor\Panels\AssetMetadataEditor.h" />
     <ClInclude Include="include\OvEditor\Resources\RawShaders.h" />
     <ClInclude Include="include\OvEditor\Resources\RawTextures.h" />
     <ClInclude Include="include\OvEditor\Panels\AssetBrowser.h" />

--- a/Sources/Overload/OvEditor/OvEditor.vcxproj.filters
+++ b/Sources/Overload/OvEditor/OvEditor.vcxproj.filters
@@ -102,6 +102,9 @@
     <ClCompile Include="src\OvEditor\Settings\EditorSettings.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\OvEditor\Panels\AssetMetadataEditor.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\OvEditor\Panels\AssetBrowser.h">
@@ -192,6 +195,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\OvEditor\Settings\EditorSettings.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\OvEditor\Panels\AssetMetadataEditor.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/AssetMetadataEditor.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/AssetMetadataEditor.h
@@ -1,0 +1,65 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <variant>
+
+#include <OvTools/Filesystem/IniFile.h>
+
+#include <OvUI/Widgets/Texts/Text.h>
+#include <OvUI/Panels/PanelWindow.h>
+#include <OvUI/Widgets/Layout/Group.h>
+#include <OvUI/Widgets/Layout/Columns.h>
+
+#include <OvRendering/Resources/Model.h>
+#include <OvRendering/Resources/Texture.h>
+
+namespace OvEditor::Panels
+{
+	class AssetMetadataEditor : public OvUI::Panels::PanelWindow
+	{
+	public:
+		using EditableAssets = std::variant<OvRendering::Resources::Model*, OvRendering::Resources::Texture*>;
+
+		/**
+		* Constructor
+		* @param p_title
+		* @param p_opened
+		* @param p_windowSettings
+		*/
+		AssetMetadataEditor
+		(
+			const std::string& p_title,
+			bool p_opened,
+			const OvUI::Settings::PanelWindowSettings& p_windowSettings
+		);
+
+		/**
+		* Defines the target of the asset settings editor
+		* @param p_path
+		*/
+		void SetTarget(const std::string& p_path);
+
+		/**
+		* Launch the preview of the target asset
+		*/
+		void Preview();
+
+	private:
+		void CreateHeaderButtons();
+		void CreateSettings();
+		void CreateModelSettings();
+		void CreateTextureSettings();
+		void Apply();
+
+	private:
+		std::string m_resource;
+
+		OvUI::Widgets::Layout::Columns<2>* m_settings = nullptr;
+		std::unique_ptr<OvTools::Filesystem::IniFile> m_metadata;
+	};
+}

--- a/Sources/Overload/OvEditor/layout.ini
+++ b/Sources/Overload/OvEditor/layout.ini
@@ -67,8 +67,8 @@ Collapsed=0
 DockId=0x3F20F338,1
 
 [Window][Asset Browser##2]
-Pos=0,331
-Size=311,696
+Pos=0,24
+Size=311,1003
 Collapsed=0
 DockId=0x00000014,0
 
@@ -233,6 +233,12 @@ Size=429,497
 Collapsed=0
 DockId=0x0000000D,1
 
+[Window][Asset Metadata Editor##15]
+Pos=1491,24
+Size=429,497
+Collapsed=0
+DockId=0x0000000D,1
+
 [Docking][Data]
 DockSpace                       ID=0x3F20F338 Pos=0,24 Size=1920,1003 Split=X SelectedTab=0x110CC311
   DockNode                      ID=0x00000023 Parent=0x3F20F338 SizeRef=1429,1363 Split=X
@@ -264,8 +270,8 @@ DockSpace                       ID=0x3F20F338 Pos=0,24 Size=1920,1003 Split=X Se
             DockNode            ID=0x00000007 Parent=0x00000004 SizeRef=360,409 SelectedTab=0x1ACA2EC4
             DockNode            ID=0x00000008 Parent=0x00000004 SizeRef=360,453 SelectedTab=0x0B0A0F09
       DockNode                  ID=0x00000016 Parent=0x0000001A SizeRef=572,1363 Split=Y SelectedTab=0x92035EB3
-        DockNode                ID=0x0000000D Parent=0x00000016 SizeRef=215,676 SelectedTab=0x2DC8073C
-        DockNode                ID=0x00000012 Parent=0x00000016 SizeRef=215,685 SelectedTab=0xF3932F03
+        DockNode                ID=0x0000000D Parent=0x00000016 SizeRef=215,676 SelectedTab=0xF242A481
+        DockNode                ID=0x00000012 Parent=0x00000016 SizeRef=215,685 SelectedTab=0x92035EB3
   DockNode                      ID=0x00000024 Parent=0x3F20F338 SizeRef=489,1363 Split=Y SelectedTab=0xFD7203C3
     DockNode                    ID=0x0000001D Parent=0x00000024 SizeRef=489,598 Split=Y SelectedTab=0xB3AC929F
       DockNode                  ID=0x00000025 Parent=0x0000001D SizeRef=489,301 SelectedTab=0xFD7203C3

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -22,6 +22,7 @@
 #include "OvEditor/Panels/Toolbar.h"
 #include "OvEditor/Panels/MaterialEditor.h"
 #include "OvEditor/Panels/ProjectSettings.h"
+#include "OvEditor/Panels/AssetMetadataEditor.h"
 
 using namespace OvCore::ResourceManagement;
 using namespace OvEditor::Panels;
@@ -65,6 +66,7 @@ void OvEditor::Core::Editor::SetupUI()
 	m_panelsManager.CreatePanel<OvEditor::Panels::Toolbar>("Toolbar", true, settings);
 	m_panelsManager.CreatePanel<OvEditor::Panels::MaterialEditor>("Material Editor", false, settings);
 	m_panelsManager.CreatePanel<OvEditor::Panels::ProjectSettings>("Project Settings", false, settings);
+	m_panelsManager.CreatePanel<OvEditor::Panels::AssetMetadataEditor>("Asset Metadata Editor", false, settings);
 
 	m_canvas.MakeDockspace(true);
 	m_context.uiManager->SetCanvas(m_canvas);

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetMetadataEditor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetMetadataEditor.cpp
@@ -1,0 +1,233 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <OvTools/Utils/PathParser.h>
+
+#include <OvCore/Helpers/GUIDrawer.h>
+#include <OvCore/Global/ServiceLocator.h>
+#include <OvCore/ResourceManagement/ModelManager.h>
+#include <OvCore/ResourceManagement/TextureManager.h>
+
+#include <OvUI/Widgets/Visual/Separator.h>
+#include <OvUI/Widgets/Layout/Group.h>
+#include <OvUI/Widgets/Buttons/Button.h>
+#include <OvUI/Widgets/Selection/ComboBox.h>
+
+#include "OvEditor/Panels/AssetMetadataEditor.h"
+#include "OvEditor/Panels/AssetView.h"
+#include "OvEditor/Core/EditorActions.h"
+
+OvEditor::Panels::AssetMetadataEditor::AssetMetadataEditor
+(
+	const std::string& p_title,
+	bool p_opened,
+	const OvUI::Settings::PanelWindowSettings& p_windowSettings
+) :
+	PanelWindow(p_title, p_opened, p_windowSettings)
+{
+	CreateHeaderButtons();
+	CreateWidget<OvUI::Widgets::Visual::Separator>();
+	m_settings = &CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
+	m_settings->widths[0] = 150;
+}
+
+void OvEditor::Panels::AssetMetadataEditor::SetTarget(const std::string& p_path)
+{
+	m_resource = p_path;
+	m_metadata.reset(new OvTools::Filesystem::IniFile(m_resource + ".meta"));
+	CreateSettings();
+}
+
+void OvEditor::Panels::AssetMetadataEditor::Preview()
+{
+	auto& assetView = EDITOR_PANEL(OvEditor::Panels::AssetView, "Asset View");
+
+	auto resourcePath = EDITOR_EXEC(GetResourcePath(m_resource));
+	auto fileType = OvTools::Utils::PathParser::GetFileType(m_resource);
+
+	if (fileType == OvTools::Utils::PathParser::EFileType::MODEL)
+	{
+		if (auto resource = OVSERVICE(OvCore::ResourceManagement::ModelManager).GetResource(resourcePath))
+		{
+			assetView.SetResource(resource);
+		}
+	}
+	else if (fileType == OvTools::Utils::PathParser::EFileType::TEXTURE)
+	{
+		if (auto resource = OVSERVICE(OvCore::ResourceManagement::TextureManager).GetResource(resourcePath))
+		{
+			assetView.SetResource(resource);
+		}
+	}
+
+	assetView.Open();
+}
+
+void OvEditor::Panels::AssetMetadataEditor::CreateHeaderButtons()
+{
+	auto& applyButton = CreateWidget<OvUI::Widgets::Buttons::Button>("Apply");
+	applyButton.idleBackgroundColor = { 0.0f, 0.5f, 0.0f };
+	applyButton.ClickedEvent += [this]
+	{
+		Apply();
+	};
+
+	applyButton.lineBreak = false;
+
+	auto& reloadButton = CreateWidget<OvUI::Widgets::Buttons::Button>("Revert");
+	reloadButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
+	reloadButton.ClickedEvent += [this]
+	{
+		SetTarget(m_resource);
+	};
+
+	reloadButton.lineBreak = false;
+
+	auto& previewButton = CreateWidget<OvUI::Widgets::Buttons::Button>("Preview");
+	previewButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
+	previewButton.ClickedEvent += std::bind(&AssetMetadataEditor::Preview, this);
+	previewButton.lineBreak = false;
+
+	auto& defaultButton = CreateWidget<OvUI::Widgets::Buttons::Button>("Reset to default");
+	defaultButton.idleBackgroundColor = { 0.5f, 0.0f, 0.0f };
+	defaultButton.ClickedEvent += [this]
+	{
+		m_metadata->RemoveAll();
+		CreateSettings();
+	};
+}
+
+void OvEditor::Panels::AssetMetadataEditor::CreateSettings()
+{
+	m_settings->RemoveAllWidgets();
+
+	auto fileType = OvTools::Utils::PathParser::GetFileType(m_resource);
+	if (fileType == OvTools::Utils::PathParser::EFileType::MODEL)
+	{
+		CreateModelSettings();
+	}
+	else if (fileType == OvTools::Utils::PathParser::EFileType::TEXTURE)
+	{
+		CreateTextureSettings();
+	}
+}
+
+#define MODEL_FLAG_ENTRY(setting) OvCore::Helpers::GUIDrawer::DrawBoolean(*m_settings, setting, [&]() { return m_metadata->Get<bool>(setting); }, [&](bool value) { m_metadata->Set<bool>(setting, value); })
+
+void OvEditor::Panels::AssetMetadataEditor::CreateModelSettings()
+{
+	m_metadata->Add("CALC_TANGENT_SPACE", true);
+	m_metadata->Add("JOIN_IDENTICAL_VERTICES", true);
+	m_metadata->Add("MAKE_LEFT_HANDED", false);
+	m_metadata->Add("TRIANGULATE", true);
+	m_metadata->Add("REMOVE_COMPONENT", false);
+	m_metadata->Add("GEN_NORMALS", false);
+	m_metadata->Add("GEN_SMOOTH_NORMALS", true);
+	m_metadata->Add("SPLIT_LARGE_MESHES", false);
+	m_metadata->Add("PRE_TRANSFORM_VERTICES", true);
+	m_metadata->Add("LIMIT_BONE_WEIGHTS", false);
+	m_metadata->Add("VALIDATE_DATA_STRUCTURE", false);
+	m_metadata->Add("IMPROVE_CACHE_LOCALITY", true);
+	m_metadata->Add("REMOVE_REDUNDANT_MATERIALS", false);
+	m_metadata->Add("FIX_INFACING_NORMALS", false);
+	m_metadata->Add("SORT_BY_PTYPE", false);
+	m_metadata->Add("FIND_DEGENERATES", false);
+	m_metadata->Add("FIND_INVALID_DATA", true);
+	m_metadata->Add("GEN_UV_COORDS", true);
+	m_metadata->Add("TRANSFORM_UV_COORDS", false);
+	m_metadata->Add("FIND_INSTANCES", true);
+	m_metadata->Add("OPTIMIZE_MESHES", true);
+	m_metadata->Add("OPTIMIZE_GRAPH", true);
+	m_metadata->Add("FLIP_UVS", false);
+	m_metadata->Add("FLIP_WINDING_ORDER", false);
+	m_metadata->Add("SPLIT_BY_BONE_COUNT", false);
+	m_metadata->Add("DEBONE", true);
+
+	MODEL_FLAG_ENTRY("CALC_TANGENT_SPACE");
+	MODEL_FLAG_ENTRY("JOIN_IDENTICAL_VERTICES");
+	MODEL_FLAG_ENTRY("MAKE_LEFT_HANDED");
+	MODEL_FLAG_ENTRY("TRIANGULATE");
+	MODEL_FLAG_ENTRY("REMOVE_COMPONENT");
+	MODEL_FLAG_ENTRY("GEN_NORMALS");
+	MODEL_FLAG_ENTRY("GEN_SMOOTH_NORMALS");
+	MODEL_FLAG_ENTRY("SPLIT_LARGE_MESHES");
+	MODEL_FLAG_ENTRY("PRE_TRANSFORM_VERTICES");
+	MODEL_FLAG_ENTRY("LIMIT_BONE_WEIGHTS");
+	MODEL_FLAG_ENTRY("VALIDATE_DATA_STRUCTURE");
+	MODEL_FLAG_ENTRY("IMPROVE_CACHE_LOCALITY");
+	MODEL_FLAG_ENTRY("REMOVE_REDUNDANT_MATERIALS");
+	MODEL_FLAG_ENTRY("FIX_INFACING_NORMALS");
+	MODEL_FLAG_ENTRY("SORT_BY_PTYPE");
+	MODEL_FLAG_ENTRY("FIND_DEGENERATES");
+	MODEL_FLAG_ENTRY("FIND_INVALID_DATA");
+	MODEL_FLAG_ENTRY("GEN_UV_COORDS");
+	MODEL_FLAG_ENTRY("TRANSFORM_UV_COORDS");
+	MODEL_FLAG_ENTRY("FIND_INSTANCES");
+	MODEL_FLAG_ENTRY("OPTIMIZE_MESHES");
+	MODEL_FLAG_ENTRY("OPTIMIZE_GRAPH");
+	MODEL_FLAG_ENTRY("FLIP_UVS");
+	MODEL_FLAG_ENTRY("FLIP_WINDING_ORDER");
+	MODEL_FLAG_ENTRY("SPLIT_BY_BONE_COUNT");
+	MODEL_FLAG_ENTRY("DEBONE");
+};
+
+void OvEditor::Panels::AssetMetadataEditor::CreateTextureSettings()
+{
+	m_metadata->Add("MIN_FILTER", static_cast<int>(OvRendering::Settings::ETextureFilteringMode::LINEAR_MIPMAP_LINEAR));
+	m_metadata->Add("MAG_FILTER", static_cast<int>(OvRendering::Settings::ETextureFilteringMode::LINEAR));
+	m_metadata->Add("ENABLE_MIPMAPPING", true);
+
+	std::map<int, std::string> filteringModes;
+	filteringModes.emplace(0x2600, "NEAREST");
+	filteringModes.emplace(0x2601, "LINEAR");
+	filteringModes.emplace(0x2700, "NEAREST_MIPMAP_NEAREST");
+	filteringModes.emplace(0x2703, "LINEAR_MIPMAP_LINEAR");
+	filteringModes.emplace(0x2701, "LINEAR_MIPMAP_NEAREST");
+	filteringModes.emplace(0x2702, "NEAREST_MIPMAP_LINEAR");
+
+	OvCore::Helpers::GUIDrawer::CreateTitle(*m_settings, "MIN_FILTER");
+	auto& minFilter = m_settings->CreateWidget<OvUI::Widgets::Selection::ComboBox>(m_metadata->Get<int>("MIN_FILTER"));
+	minFilter.choices = filteringModes;
+	minFilter.ValueChangedEvent += [this](int p_choice)
+	{
+		m_metadata->Set("MIN_FILTER", p_choice);
+	};
+
+	OvCore::Helpers::GUIDrawer::CreateTitle(*m_settings, "MAG_FILTER");
+	auto& magFilter = m_settings->CreateWidget<OvUI::Widgets::Selection::ComboBox>(m_metadata->Get<int>("MAG_FILTER"));
+	magFilter.choices = filteringModes;
+	magFilter.ValueChangedEvent += [this](int p_choice)
+	{
+		m_metadata->Set("MAG_FILTER", p_choice);
+	};
+
+	OvCore::Helpers::GUIDrawer::DrawBoolean(*m_settings, "ENABLE_MIPMAPPING", [&]() { return m_metadata->Get<bool>("ENABLE_MIPMAPPING"); }, [&](bool value) { m_metadata->Set<bool>("ENABLE_MIPMAPPING", value); });
+}
+
+void OvEditor::Panels::AssetMetadataEditor::Apply()
+{
+	m_metadata->Rewrite();
+
+	auto resourcePath = EDITOR_EXEC(GetResourcePath(m_resource));
+	auto fileType = OvTools::Utils::PathParser::GetFileType(m_resource);
+
+	if (fileType == OvTools::Utils::PathParser::EFileType::MODEL)
+	{
+		auto& modelManager = OVSERVICE(OvCore::ResourceManagement::ModelManager);
+		if (modelManager.IsResourceRegistered(resourcePath))
+		{
+			modelManager.AResourceManager::ReloadResource(resourcePath);
+		}
+	}
+	else if (fileType == OvTools::Utils::PathParser::EFileType::TEXTURE)
+	{
+		auto& textureManager = OVSERVICE(OvCore::ResourceManagement::TextureManager);
+		if (textureManager.IsResourceRegistered(resourcePath))
+		{
+			textureManager.AResourceManager::ReloadResource(resourcePath);
+		}
+	}
+}

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/ModelLoader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/ModelLoader.h
@@ -32,6 +32,14 @@ namespace OvRendering::Resources::Loaders
 		static Model* Create(const std::string& p_filepath, Parsers::EModelParserFlags p_parserFlags = Parsers::EModelParserFlags::NONE);
 
 		/**
+		* Reload a model from file
+		* @param p_model
+		* @param p_filePath
+		* @param p_parserFlags
+		*/
+		static void Reload(Model& p_model, const std::string& p_filePath, Parsers::EModelParserFlags p_parserFlags = Parsers::EModelParserFlags::NONE);
+
+		/**
 		* Disabled constructor
 		* @param p_modelInstance
 		*/

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/TextureLoader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/TextureLoader.h
@@ -58,8 +58,11 @@ namespace OvRendering::Resources::Loaders
 		* Reload a texture from file
 		* @param p_texture
 		* @param p_filePath
+		* @param p_firstFilter
+		* @param p_secondFilter
+		* @param p_generateMipmap
 		*/
-		static void Reload(Texture& p_texture, const std::string& p_filePath);
+		static void Reload(Texture& p_texture, const std::string& p_filePath, OvRendering::Settings::ETextureFilteringMode p_firstFilter, OvRendering::Settings::ETextureFilteringMode p_secondFilter, bool p_generateMipmap);
 
 		/**
 		* Destroy a texture

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ModelLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ModelLoader.cpp
@@ -23,6 +23,19 @@ OvRendering::Resources::Model* OvRendering::Resources::Loaders::ModelLoader::Cre
 	return nullptr;
 }
 
+void OvRendering::Resources::Loaders::ModelLoader::Reload(Model& p_model, const std::string& p_filePath, Parsers::EModelParserFlags p_parserFlags)
+{
+	Model* newModel = Create(p_filePath, p_parserFlags);
+
+	if (newModel)
+	{
+		p_model.m_meshes = newModel->m_meshes;
+		p_model.m_materialNames = newModel->m_materialNames;
+		newModel->m_meshes.clear();
+		delete newModel;
+	}
+}
+
 bool OvRendering::Resources::Loaders::ModelLoader::Destroy(Model*& p_modelInstance)
 {
 	if (p_modelInstance)

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/TextureLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/TextureLoader.cpp
@@ -97,9 +97,9 @@ OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader:
 	return new Texture("", textureID, 1, 1, 32, p_firstFilter, p_secondFilter, p_generateMipmap);
 }
 
-void OvRendering::Resources::Loaders::TextureLoader::Reload(Texture & p_texture, const std::string & p_filePath)
+void OvRendering::Resources::Loaders::TextureLoader::Reload(Texture& p_texture, const std::string& p_filePath, OvRendering::Settings::ETextureFilteringMode p_firstFilter, OvRendering::Settings::ETextureFilteringMode p_secondFilter, bool p_generateMipmap)
 {
-	Texture* newTexture = Create(p_filePath, p_texture.firstFilter, p_texture.secondFilter, p_texture.isMimapped);
+	Texture* newTexture = Create(p_filePath, p_firstFilter, p_secondFilter, p_generateMipmap);
 
 	if (newTexture)
 	{

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
@@ -72,8 +72,8 @@ void OvRendering::Resources::Parsers::AssimpParser::ProcessMesh(void* p_transfor
 		aiVector3D position		= meshTransformation * p_mesh->mVertices[i];
 		aiVector3D normal		= meshTransformation * (p_mesh->mNormals ? p_mesh->mNormals[i] : aiVector3D(0.0f, 0.0f, 0.0f));
 		aiVector3D texCoords	= p_mesh->mTextureCoords[0] ? p_mesh->mTextureCoords[0][i] : aiVector3D(0.0f, 0.0f, 0.0f);
-		aiVector3D tangent		= p_mesh->mTextureCoords[0] ? meshTransformation * p_mesh->mTangents[i] : aiVector3D(0.0f, 0.0f, 0.0f);
-		aiVector3D bitangent	= p_mesh->mTextureCoords[0] ? meshTransformation * p_mesh->mBitangents[i] : aiVector3D(0.0f, 0.0f, 0.0f);
+		aiVector3D tangent		= p_mesh->mTangents ? meshTransformation * p_mesh->mTangents[i] : aiVector3D(0.0f, 0.0f, 0.0f);
+		aiVector3D bitangent	= p_mesh->mBitangents ? meshTransformation * p_mesh->mBitangents[i] : aiVector3D(0.0f, 0.0f, 0.0f);
 
 		p_outVertices.push_back
 		(

--- a/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.h
+++ b/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.h
@@ -48,6 +48,15 @@ namespace OvTools::Filesystem
 		T Get(const std::string& p_key);
 
 		/**
+		* Return the value attached to the given key
+		* If the key doesn't exist, the specified value is returned
+		* @param p_key
+		* @param p_default
+		*/
+		template<typename T>
+		T GetOrDefault(const std::string& p_key, T p_default);
+
+		/**
 		* Set a new value to the given key (Not applied to the real file untill Rewrite() or Save() is called)
 		* @param p_key
 		* @param p_value

--- a/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.inl
+++ b/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.inl
@@ -51,6 +51,12 @@ namespace OvTools::Filesystem
 	}
 
 	template<typename T>
+	inline T IniFile::GetOrDefault(const std::string& p_key, T p_default)
+	{
+		return IsKeyExisting(p_key) ? Get<T>(p_key) : p_default;
+	}
+
+	template<typename T>
 	inline bool IniFile::Set(const std::string& p_key, const T& p_value)
 	{
 		if (IsKeyExisting(p_key))


### PR DESCRIPTION
When an asset is loaded into Overload using a resource manager (Ex:
TextureManager, ModelManager), a set of default settings were used.

These settings are likely to get customized by the user.

In order to specify loading data for any texture/model, a .meta file
support has been added. Depending on the file type, the .meta file will
indicate how to load the asset.

The editor has been expanded to support .meta file generation and
modification,  (Asset, right click, Edit metadata).

Model can now be dynamically reloaded at runtime.

## Editing a texture metadata
![MetadataEdition](https://user-images.githubusercontent.com/33324216/75513042-74b80a80-59c1-11ea-954a-f7635e6f3344.gif)

## Editing a model metadata
![MetadataEditionForModels](https://user-images.githubusercontent.com/33324216/75513097-acbf4d80-59c1-11ea-9a44-2b37213d1157.gif)

**TODO:**
- [x] Support asset move/rename/delete (Metadata should be affected too)
- [x] Prevent crashing when setting an incompatible model parser flag combination
