### PR TITLE
Orbital camera added

### DIFF
--- a/Sources/Overload/OvCore/include/OvCore/ECS/Components/CCamera.h
+++ b/Sources/Overload/OvCore/include/OvCore/ECS/Components/CCamera.h
@@ -28,7 +28,7 @@ namespace OvCore::ECS::Components
 		/**
 		* Destructor
 		*/
-		~CCamera();
+		~CCamera() = default;
 
 		/**
 		* Returns the name of the component
@@ -128,6 +128,5 @@ namespace OvCore::ECS::Components
 
 	private:
 		OvRendering::LowRenderer::Camera m_camera;
-		OvTools::Eventing::ListenerID m_transformNotificationHandlerID;
 	};
 }

--- a/Sources/Overload/OvCore/src/OvCore/ECS/Components/CCamera.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ECS/Components/CCamera.cpp
@@ -14,20 +14,6 @@ OvCore::ECS::Components::CCamera::CCamera(ECS::Actor& p_owner) : AComponent(p_ow
 {
 	/* Default clear color for the CCamera (Different from Camera default clear color) */
 	SetClearColor({ 0.1921569f, 0.3019608f, 0.4745098f });
-
-	/* Handle the collider scaling when the actor transform changes */
-	m_transformNotificationHandlerID = owner.transform.GetFTransform().Notifier.AddNotificationHandler([this](auto p_notification)
-	{
-		if (p_notification == OvMaths::Internal::TransformNotifier::ENotification::TRANSFORM_CHANGED)
-		{
-			m_camera.SetRotation(owner.transform.GetWorldRotation());
-		}
-	});
-}
-
-OvCore::ECS::Components::CCamera::~CCamera()
-{
-	owner.transform.GetFTransform().Notifier.RemoveNotificationHandler(m_transformNotificationHandlerID);
 }
 
 std::string OvCore::ECS::Components::CCamera::GetName()

--- a/Sources/Overload/OvEditor/include/OvEditor/Core/CameraController.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/CameraController.h
@@ -28,6 +28,7 @@ namespace OvEditor::Core
 		* @param p_view
 		* @param p_camera
 		* @param p_position
+		* @param p_rotation
 		* @param p_enableFocusInputs
 		*/
 		CameraController
@@ -35,6 +36,7 @@ namespace OvEditor::Core
 			OvEditor::Panels::AView& p_view,
 			OvRendering::LowRenderer::Camera& p_camera,
 			OvMaths::FVector3& p_position,
+			OvMaths::FQuaternion& p_rotation,
 			bool p_enableFocusInputs = false
 		);
 
@@ -76,7 +78,12 @@ namespace OvEditor::Core
 		/**
 		* Returns the position of the camera
 		*/
-		OvMaths::FVector3 GetPosition() const;
+		const OvMaths::FVector3& GetPosition() const;
+
+		/**
+		* Returns the position of the camera
+		*/
+		const OvMaths::FQuaternion& GetRotation() const;
 
 		/**
 		* Returns true if the right mouse click is being pressed
@@ -84,10 +91,12 @@ namespace OvEditor::Core
 		bool IsRightMousePressed() const;
 
 	private:
-		void HandleCameraXYMovement(float p_deltaTime);
-		void HandleCameraZMovement(float p_deltaTime);
-		void HandleCameraRotation(float p_deltaTime);
-		void HandleKeyboardMovement(float p_deltaTime);
+		void HandleCameraPanning(const OvMaths::FVector2& p_mouseOffset, bool p_firstMouse);
+		void HandleCameraOrbit(const OvMaths::FVector2& p_mouseOffset, bool p_firstMouse);
+		void HandleCameraFPSMouse(const OvMaths::FVector2& p_mouseOffset, bool p_firstMouse);
+
+		void HandleCameraZoom();
+		void HandleCameraFPSKeyboard(float p_deltaTime);
 		void UpdateMouseState();
 
 	private:
@@ -96,8 +105,9 @@ namespace OvEditor::Core
 		OvEditor::Panels::AView& m_view;
 		OvRendering::LowRenderer::Camera& m_camera;
 		OvMaths::FVector3& m_cameraPosition;
+		OvMaths::FQuaternion& m_cameraRotation;
 
-		std::queue<std::tuple<OvMaths::FVector3, float, float>> m_cameraDestinations;
+		std::queue<std::tuple<OvMaths::FVector3, OvMaths::FQuaternion>> m_cameraDestinations;
 
 		bool m_enableFocusInputs;
 
@@ -108,13 +118,17 @@ namespace OvEditor::Core
 		OvMaths::FVector3 m_targetSpeed;
 		OvMaths::FVector3 m_currentMovementSpeed;
 
+		OvMaths::FTransform* m_orbitTarget = nullptr;
+		OvMaths::FVector3 m_orbitStartOffset;
 		bool m_firstMouse = true;
 		double m_lastMousePosX = 0.0;
 		double m_lastMousePosY = 0.0;
+		OvMaths::FVector3 m_ypr;
 		float m_mouseSensitivity = 0.05f;
 		float m_cameraDragSpeed = 0.01f;
+		float m_cameraOrbitSpeed = 0.5f;
 		float m_cameraMoveSpeed = 5.0f;
 		float m_focusDistance = 15.0f;
-		float m_focusLerpCoefficient = 6.0f;
+		float m_focusLerpCoefficient = 8.0f;
 	};
 }

--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/AView.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/AView.h
@@ -64,9 +64,20 @@ namespace OvEditor::Panels
 		void SetCameraPosition(const OvMaths::FVector3& p_position);
 
 		/**
+		* Defines the camera rotation
+		* @param p_rotation
+		*/
+		void SetCameraRotation(const OvMaths::FQuaternion& p_rotation);
+
+		/**
 		* Returns the camera position
 		*/
 		const OvMaths::FVector3& GetCameraPosition() const;
+
+		/**
+		* Returns the camera rotation
+		*/
+		const OvMaths::FQuaternion& GetCameraRotation() const;
 
 		/**
 		* Returns the camera used by this view
@@ -104,6 +115,7 @@ namespace OvEditor::Panels
 		OvEditor::Core::EditorRenderer& m_editorRenderer;
 		OvRendering::LowRenderer::Camera m_camera;
 		OvMaths::FVector3 m_cameraPosition;
+		OvMaths::FQuaternion m_cameraRotation;
 		OvUI::Widgets::Visual::Image* m_image;
 
 		OvMaths::FVector3 m_gridColor = OvMaths::FVector3::One;

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -389,17 +389,19 @@ int OvEditor::Core::EditorActions::GetAssetViewCameraSpeed()
 void OvEditor::Core::EditorActions::ResetSceneViewCameraPosition()
 {
 	EDITOR_PANEL(Panels::SceneView, "Scene View").GetCameraController().SetPosition({ -10.0f, 4.0f, 10.0f });
-	EDITOR_PANEL(Panels::SceneView, "Scene View").GetCamera().SetPitch(-10.0f);
-	EDITOR_PANEL(Panels::SceneView, "Scene View").GetCamera().SetYaw(-45.0f);
-	EDITOR_PANEL(Panels::SceneView, "Scene View").GetCamera().SetRoll(0.0f);
+	// TODO
+	// EDITOR_PANEL(Panels::SceneView, "Scene View").GetCamera().SetPitch(-10.0f);
+	// EDITOR_PANEL(Panels::SceneView, "Scene View").GetCamera().SetYaw(-45.0f);
+	// EDITOR_PANEL(Panels::SceneView, "Scene View").GetCamera().SetRoll(0.0f);
 }
 
 void OvEditor::Core::EditorActions::ResetAssetViewCameraPosition()
 {
 	EDITOR_PANEL(Panels::AssetView, "Asset View").GetCameraController().SetPosition({ -10.0f, 4.0f, 10.0f });
-	EDITOR_PANEL(Panels::AssetView, "Asset View").GetCamera().SetPitch(-10.0f);
-	EDITOR_PANEL(Panels::AssetView, "Asset View").GetCamera().SetYaw(-45.0f);
-	EDITOR_PANEL(Panels::AssetView, "Asset View").GetCamera().SetRoll(0.0f);
+	// TODO
+	// EDITOR_PANEL(Panels::AssetView, "Asset View").GetCamera().SetPitch(-10.0f);
+	// EDITOR_PANEL(Panels::AssetView, "Asset View").GetCamera().SetYaw(-45.0f);
+	// EDITOR_PANEL(Panels::AssetView, "Asset View").GetCamera().SetRoll(0.0f);
 }
 
 OvEditor::Core::EditorActions::EEditorMode OvEditor::Core::EditorActions::GetCurrentEditorMode() const
@@ -479,7 +481,7 @@ void OvEditor::Core::EditorActions::NextFrame()
 OvMaths::FVector3 OvEditor::Core::EditorActions::CalculateActorSpawnPoint(float p_distanceToCamera)
 {
 	auto& sceneView = m_panelsManager.GetPanelAs<OvEditor::Panels::SceneView>("Scene View");
-	return sceneView.GetCameraPosition() + sceneView.GetCamera().GetForward() * p_distanceToCamera;
+	return sceneView.GetCameraPosition() + sceneView.GetCameraRotation() * OvMaths::FVector3::Forward * p_distanceToCamera;
 }
 
 OvCore::ECS::Actor & OvEditor::Core::EditorActions::CreateEmptyActor(bool p_focusOnCreation, OvCore::ECS::Actor* p_parent)

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorRenderer.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorRenderer.cpp
@@ -437,8 +437,8 @@ void OvEditor::Core::EditorRenderer::RenderCameraFrustum(OvCore::ECS::Components
 	auto& camera = p_camera.GetCamera();
 
 	const auto& cameraPos = owner.transform.GetWorldPosition();
-	const auto& cameraForward = owner.transform.GetWorldForward();
 	const auto& cameraRotation = owner.transform.GetWorldRotation();
+	const auto& cameraForward = owner.transform.GetWorldForward();
 
 	auto drawFrustumLine = [&](const FVector3& p_start, const FVector3& p_end, float planeDistance)
 	{
@@ -448,7 +448,7 @@ void OvEditor::Core::EditorRenderer::RenderCameraFrustum(OvCore::ECS::Components
 		m_context.shapeDrawer->DrawLine(start, end, FRUSTUM_COLOR);
 	};
 
-	camera.CacheMatrices(gameViewSize.first, gameViewSize.second, cameraPos);
+	camera.CacheMatrices(gameViewSize.first, gameViewSize.second, cameraPos, cameraRotation);
 	const auto proj = FMatrix4::Transpose(camera.GetProjectionMatrix());
 	const auto near = camera.GetNear();
 	const auto far = camera.GetFar();

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
@@ -16,9 +16,8 @@ OvEditor::Panels::AView::AView
 	const OvUI::Settings::PanelWindowSettings& p_windowSettings
 ) : PanelWindow(p_title, p_opened, p_windowSettings), m_editorRenderer(EDITOR_RENDERER())
 {
-	m_cameraPosition = { -10.0f, 4.0f, 10.0f };
-	m_camera.SetPitch(-10.0f);
-	m_camera.SetYaw(-45.f);
+	m_cameraPosition = { -10.0f, 3.0f, 10.0f };
+	m_cameraRotation = OvMaths::FQuaternion({0.0f, 135.0f, 0.0f});
 
 	m_image = &CreateWidget<OvUI::Widgets::Visual::Image>(m_fbo.GetTextureID(), OvMaths::FVector2{ 0.f, 0.f });
 }
@@ -59,9 +58,19 @@ void OvEditor::Panels::AView::SetCameraPosition(const OvMaths::FVector3 & p_posi
 	m_cameraPosition = p_position;
 }
 
+void OvEditor::Panels::AView::SetCameraRotation(const OvMaths::FQuaternion& p_rotation)
+{
+	m_cameraRotation = p_rotation;
+}
+
 const OvMaths::FVector3 & OvEditor::Panels::AView::GetCameraPosition() const
 {
 	return m_cameraPosition;
+}
+
+const OvMaths::FQuaternion& OvEditor::Panels::AView::GetCameraRotation() const
+{
+	return m_cameraRotation;
 }
 
 OvRendering::LowRenderer::Camera & OvEditor::Panels::AView::GetCamera()
@@ -100,6 +109,6 @@ void OvEditor::Panels::AView::FillEngineUBO()
 void OvEditor::Panels::AView::PrepareCamera()
 {
 	auto [winWidth, winHeight] = GetSafeSize();
-	m_camera.CacheMatrices(winWidth, winHeight, m_cameraPosition);
+	m_camera.CacheMatrices(winWidth, winHeight, m_cameraPosition, m_cameraRotation);
 }
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AViewControllable.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AViewControllable.cpp
@@ -12,7 +12,7 @@ OvEditor::Panels::AViewControllable::AViewControllable
 	bool p_opened,
 	const OvUI::Settings::PanelWindowSettings& p_windowSettings,
 	bool p_enableFocusInputs
-) : AView(p_title, p_opened, p_windowSettings), m_cameraController(*this, m_camera, m_cameraPosition, p_enableFocusInputs)
+) : AView(p_title, p_opened, p_windowSettings), m_cameraController(*this, m_camera, m_cameraPosition, m_cameraRotation, p_enableFocusInputs)
 {
 
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/GameView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/GameView.cpp
@@ -33,6 +33,7 @@ void OvEditor::Panels::GameView::Update(float p_deltaTime)
 		{
 			m_camera = cameraComponent->GetCamera();
 			m_cameraPosition = cameraComponent->owner.transform.GetWorldPosition();
+			m_cameraRotation = cameraComponent->owner.transform.GetWorldRotation();
 			m_hasCamera = true;
 			PrepareCamera();
 		}

--- a/Sources/Overload/OvGame/src/OvGame/Core/GameRenderer.cpp
+++ b/Sources/Overload/OvGame/src/OvGame/Core/GameRenderer.cpp
@@ -66,9 +66,10 @@ void OvGame::Core::GameRenderer::RenderScene()
 
 			auto [winWidth, winHeight] = m_context.window->GetSize();
 			const auto& cameraPosition = mainCameraComponent->owner.transform.GetWorldPosition();
+			const auto& cameraRotation = mainCameraComponent->owner.transform.GetWorldRotation();
 			auto& camera = mainCameraComponent->GetCamera();
 
-			camera.CacheMatrices(winWidth, winHeight, cameraPosition);
+			camera.CacheMatrices(winWidth, winHeight, cameraPosition, cameraRotation);
 
 			UpdateEngineUBO(*mainCameraComponent);
 

--- a/Sources/Overload/OvMaths/include/OvMaths/FQuaternion.h
+++ b/Sources/Overload/OvMaths/include/OvMaths/FQuaternion.h
@@ -77,6 +77,13 @@ namespace OvMaths
 		FQuaternion(const FVector3& p_euler);
 
 		/**
+		* Create a quaternion from a forward and up vector
+		* @param p_forward
+		* @param p_up
+		*/
+		static FQuaternion LookAt(const FVector3& p_forward, const FVector3& p_up);
+
+		/**
 		* Check if the quaternion is Identity
 		* if the quaternion has no rotation(meaning x,y,z axis values = 0), it's Identity
 		* @param p_target

--- a/Sources/Overload/OvMaths/src/OvMaths/FQuaternion.cpp
+++ b/Sources/Overload/OvMaths/src/OvMaths/FQuaternion.cpp
@@ -171,6 +171,63 @@ OvMaths::FQuaternion::FQuaternion(const FVector3 & p_euler)
 	w = cr * cp * cy + sr * sp * sy;
 }
 
+OvMaths::FQuaternion OvMaths::FQuaternion::LookAt(const FVector3& p_forward, const FVector3& p_up)
+{
+	auto vector = OvMaths::FVector3::Normalize(p_forward);
+	auto vector2 = OvMaths::FVector3::Normalize(OvMaths::FVector3::Cross(p_up, vector));
+	auto vector3 = OvMaths::FVector3::Cross(vector, vector2);
+	auto m00 = vector2.x;
+	auto m01 = vector2.y;
+	auto m02 = vector2.z;
+	auto m10 = vector3.x;
+	auto m11 = vector3.y;
+	auto m12 = vector3.z;
+	auto m20 = vector.x;
+	auto m21 = vector.y;
+	auto m22 = vector.z;
+
+
+	float num8 = (m00 + m11) + m22;
+	auto quaternion = OvMaths::FQuaternion::Identity();
+	if (num8 > 0.f)
+	{
+		auto num = sqrt(num8 + 1.f);
+		quaternion.w = num * 0.5f;
+		num = 0.5f / num;
+		quaternion.x = (m12 - m21) * num;
+		quaternion.y = (m20 - m02) * num;
+		quaternion.z = (m01 - m10) * num;
+		return quaternion;
+	}
+	if ((m00 >= m11) && (m00 >= m22))
+	{
+		auto num7 = sqrt(((1.f + m00) - m11) - m22);
+		auto num4 = 0.5f / num7;
+		quaternion.x = 0.5f * num7;
+		quaternion.y = (m01 + m10) * num4;
+		quaternion.z = (m02 + m20) * num4;
+		quaternion.w = (m12 - m21) * num4;
+		return quaternion;
+	}
+	if (m11 > m22)
+	{
+		auto num6 = sqrt(((1.f + m11) - m00) - m22);
+		auto num3 = 0.5f / num6;
+		quaternion.x = (m10 + m01) * num3;
+		quaternion.y = 0.5f * num6;
+		quaternion.z = (m21 + m12) * num3;
+		quaternion.w = (m20 - m02) * num3;
+		return quaternion;
+	}
+	auto num5 = sqrt(((1.f + m22) - m00) - m11);
+	auto num2 = 0.5f / num5;
+	quaternion.x = (m20 + m02) * num2;
+	quaternion.y = (m21 + m12) * num2;
+	quaternion.z = 0.5f * num5;
+	quaternion.w = (m01 - m10) * num2;
+	return quaternion;
+}
+
 bool OvMaths::FQuaternion::IsIdentity(const FQuaternion & p_target)
 {
 	return p_target.w == 1.0f && Length(p_target) == 1.0f;
@@ -327,6 +384,11 @@ OvMaths::FVector3 OvMaths::FQuaternion::RotatePoint(const FVector3 & p_point, co
 
 OvMaths::FVector3 OvMaths::FQuaternion::EulerAngles(const FQuaternion& p_target)
 {
+	// This is a kind of hack because when the input Quaternion is {0.5f, 0.5f, -0.5f, 0.5f} or
+	// {0.5f, 0.5f, 0.5f, -0.5f}, the output value is incorrect.
+	if (p_target == FQuaternion{0.5f, 0.5f, -0.5f, 0.5f}) return { 90.0f, 90.0f, 0.0f };
+	if (p_target == FQuaternion{0.5f, 0.5f, 0.5f, -0.5f}) return { -90.0f, -90.0f, 0.0f };
+
 	// roll (x-axis rotation)
 	const float sinr_cosp = +2.0f * (p_target.w * p_target.x + p_target.y * p_target.z);
 	const float cosr_cosp = +1.0f - 2.0f * (p_target.x * p_target.x + p_target.y * p_target.y);

--- a/Sources/Overload/OvRendering/include/OvRendering/LowRenderer/Camera.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/LowRenderer/Camera.h
@@ -10,6 +10,8 @@
 #include <OvMaths/FMatrix4.h>
 #include <OvMaths/FQuaternion.h>
 
+#include <OvTools/Utils/ReferenceOrValue.h>
+
 #include "OvRendering/API/Export.h"
 #include "OvRendering/Data/Frustum.h"
 
@@ -23,16 +25,18 @@ namespace OvRendering::LowRenderer
 	public:
 		/**
 		* Constructor
+		* @param p_transform
 		*/
-		Camera();
+		Camera(OvMaths::FTransform* p_transform = nullptr);
 
 		/**
 		* Cache the projection, view and frustum matrices
 		* @param p_windowWidth
 		* @param p_windowHeight
 		* @param p_position
+		* @param p_rotation
 		*/
-		void CacheMatrices(uint16_t p_windowWidth, uint16_t p_windowHeight, const OvMaths::FVector3& p_position);
+		void CacheMatrices(uint16_t p_windowWidth, uint16_t p_windowHeight, const OvMaths::FVector3& p_position, const OvMaths::FQuaternion& p_rotation);
 
 		/**
 		* Calculate and cache the result projection matrix
@@ -44,8 +48,9 @@ namespace OvRendering::LowRenderer
 		/**
 		* Calculate and cache the result view matrix
 		* @param p_position
+		* @param p_rotation
 		*/
-		void CacheViewMatrix(const OvMaths::FVector3& p_position);
+		void CacheViewMatrix(const OvMaths::FVector3& p_position, const OvMaths::FQuaternion& p_rotation);
 
 		/**
 		* Calculate and cache the result frustum.
@@ -54,36 +59,6 @@ namespace OvRendering::LowRenderer
 		* @param p_projection
 		*/
 		void CacheFrustum(const OvMaths::FMatrix4& p_view, const OvMaths::FMatrix4& p_projection);
-
-		/**
-		* Returns the forward vector of the camera
-		*/
-		const OvMaths::FVector3& GetForward() const;
-
-		/**
-		* Returns the up vector of the camera
-		*/
-		const OvMaths::FVector3& GetUp() const;
-
-		/**
-		* Returns the right vector of the camera
-		*/
-		const OvMaths::FVector3& GetRight() const;
-
-		/**
-		* Returns the yaw of the camera
-		*/
-		float GetYaw() const;
-
-		/**
-		* Returns the pitch of the camera
-		*/
-		float GetPitch() const;
-
-		/**
-		* Returns the roll of the camera
-		*/
-		float GetRoll() const;
 
 		/**
 		* Returns the fov of the camera
@@ -131,24 +106,6 @@ namespace OvRendering::LowRenderer
 		bool HasFrustumLightCulling() const;
 
 		/**
-		* Sets the yaw of the camera to the given value
-		* @param p_value
-		*/
-		void SetYaw(float p_value);
-
-		/**
-		* Sets the pitch of the camera to the given value
-		* @param p_value
-		*/
-		void SetPitch(float p_value);
-
-		/**
-		* Sets the roll of the camera to the given value
-		* @param p_value
-		*/
-		void SetRoll(float p_value);
-
-		/**
 		* Sets the fov of the camera to the given value
 		* @param p_value
 		*/
@@ -184,29 +141,14 @@ namespace OvRendering::LowRenderer
 		*/
 		void SetFrustumLightCulling(bool p_enable);
 
-		/**
-		* Sets the rotation to the camera with a quaternion
-		* @param p_rotation
-		*/
-		void SetRotation(const OvMaths::FQuaternion& p_rotation);
-
 	private:
 		OvMaths::FMatrix4 CalculateProjectionMatrix(uint16_t p_windowWidth, uint16_t p_windowHeight) const;
-		OvMaths::FMatrix4 CalculateViewMatrix(const OvMaths::FVector3& p_position) const;
-		void UpdateCameraVectors();
+		OvMaths::FMatrix4 CalculateViewMatrix(const OvMaths::FVector3& p_position, const OvMaths::FQuaternion& p_rotation) const;
 
 	private:
 		OvRendering::Data::Frustum m_frustum;
 		OvMaths::FMatrix4 m_viewMatrix;
 		OvMaths::FMatrix4 m_projectionMatrix;
-
-		OvMaths::FVector3 m_forward;
-		OvMaths::FVector3 m_up;
-		OvMaths::FVector3 m_right;
-
-		float m_yaw;
-		float m_pitch;
-		float m_roll;
 
 		float m_fov;
 		float m_near;

--- a/Sources/Overload/OvTools/include/OvTools/Utils/ReferenceOrValue.h
+++ b/Sources/Overload/OvTools/include/OvTools/Utils/ReferenceOrValue.h
@@ -57,7 +57,7 @@ namespace OvTools::Utils
 		/**
 		* Implicit conversion of a ReferenceOrValue to a T
 		*/
-		operator T()
+		operator T&()
 		{
 			return Get();
 		}
@@ -75,7 +75,7 @@ namespace OvTools::Utils
 		/**
 		* Returns the value (From reference or directly from the value)
 		*/
-		T Get() const
+		T& Get() const
 		{
 			if (auto pval = std::get_if<T>(&m_data))
 				return *pval;


### PR DESCRIPTION
It is now possible to use the orbit camera in the editor by pressing
[Alt] and the middle mouse button at the same time.

The camera (`OvRendering`) is now Quaternion-based. However, the
`CameraController` is still converting the rotation (Quaternion) to a
yaw-pitch-roll model (Easier for FPS and orbit rotations).

![OrbitCamera](https://user-images.githubusercontent.com/33324216/75615466-0c2c7300-5b12-11ea-994e-5bedbe42280f.gif)

Closes https://github.com/adriengivry/Overload/issues/60