### PR TITLE
Adding FileWatcher and shader auto-reload

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include <OvCore/Global/ServiceLocator.h>
 #include <OvTools/Filesystem/IniFile.h>
 #include <OvTools/Utils/PathParser.h>
@@ -414,6 +416,7 @@ namespace OvEditor::Core
 		EActorSpawnMode m_actorSpawnMode = EActorSpawnMode::ORIGIN;
 		EEditorMode m_editorMode = EEditorMode::EDIT;
 
+		std::mutex m_delayedActionMutex;
 		std::vector<std::pair<uint32_t, std::function<void()>>> m_delayedActions;
 
 		tinyxml2::XMLDocument m_sceneBackup;

--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/AssetBrowser.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/AssetBrowser.h
@@ -13,6 +13,7 @@
 #include <OvUI/Panels/PanelWindow.h>
 #include <OvUI/Widgets/Layout/TreeNode.h>
 #include <OvRendering/Resources/Loaders/TextureLoader.h>
+#include <OvTools/Filesystem/FileWatcher.h>
 
 namespace OvEditor::Panels
 {
@@ -67,6 +68,7 @@ namespace OvEditor::Panels
 		std::string m_engineAssetFolder;
 		std::string m_projectAssetFolder;
 		std::string m_projectScriptFolder;
+		OvTools::Filesystem::FileWatcher m_projectAssetWatcher;
 		OvUI::Widgets::Layout::Group* m_assetList;
 		std::unordered_map<OvUI::Widgets::Layout::TreeNode*, std::string> m_pathUpdate;
 	};

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -313,11 +313,14 @@ void OvEditor::Core::EditorActions::BuildAtLocation(const std::string & p_config
 
 void OvEditor::Core::EditorActions::DelayAction(std::function<void()> p_action, uint32_t p_frames)
 {
+	m_delayedActionMutex.lock();
 	m_delayedActions.emplace_back(p_frames + 1, p_action);
+	m_delayedActionMutex.unlock();
 }
 
 void OvEditor::Core::EditorActions::ExecuteDelayedActions()
 {
+	m_delayedActionMutex.lock();
 	std::for_each(m_delayedActions.begin(), m_delayedActions.end(), [](std::pair<uint32_t, std::function<void()>> & p_element)
 	{
 		--p_element.first;
@@ -330,6 +333,7 @@ void OvEditor::Core::EditorActions::ExecuteDelayedActions()
 	{
 		return p_element.first == 0;
 	}), m_delayedActions.end());
+	m_delayedActionMutex.unlock();
 }
 
 OvEditor::Core::Context& OvEditor::Core::EditorActions::GetContext()

--- a/Sources/Overload/OvTools/OvTools.vcxproj
+++ b/Sources/Overload/OvTools/OvTools.vcxproj
@@ -98,6 +98,7 @@ xcopy "$(OutDir)*.dll" "$(SolutionDir)..\..\Build\$(ProjectName)\bin\$(Configura
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="include\OvTools\API\Export.h" />
+    <ClInclude Include="include\OvTools\Filesystem\FileWatcher.h" />
     <ClInclude Include="include\OvTools\Filesystem\tinyxml2.h" />
     <ClInclude Include="include\OvTools\Time\Clock.h" />
     <ClInclude Include="include\OvTools\Time\Date.h" />
@@ -110,6 +111,7 @@ xcopy "$(OutDir)*.dll" "$(SolutionDir)..\..\Build\$(ProjectName)\bin\$(Configura
     <ClInclude Include="include\OvTools\Utils\Random.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\OvTools\Filesystem\FileWatcher.cpp" />
     <ClCompile Include="src\OvTools\Filesystem\tinyxml2.cpp" />
     <ClCompile Include="src\OvTools\Time\Clock.cpp" />
     <ClCompile Include="src\OvTools\Time\Date.cpp" />

--- a/Sources/Overload/OvTools/OvTools.vcxproj.filters
+++ b/Sources/Overload/OvTools/OvTools.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClInclude Include="include\OvTools\Utils\ReferenceOrValue.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\OvTools\Filesystem\FileWatcher.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\OvTools\Utils\Random.cpp">
@@ -72,6 +75,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\OvTools\Utils\String.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\OvTools\Filesystem\FileWatcher.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Sources/Overload/OvTools/include/OvTools/Filesystem/FileWatcher.h
+++ b/Sources/Overload/OvTools/include/OvTools/Filesystem/FileWatcher.h
@@ -1,0 +1,67 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <filesystem>
+#include <chrono>
+#include <thread>
+#include <unordered_map>
+#include <string>
+#include <functional>
+
+#include "OvTools/API/Export.h"
+#include "OvTools/Eventing/Event.h"
+
+namespace OvTools::Filesystem
+{
+	/**
+	* The FileWatcher class represents allow its user to track a given directory of any file event (Modification, rename, deletion...)
+	*/
+	class API_OVTOOLS FileWatcher
+	{
+	public:
+		/**
+		* Create a FileWatcher
+		* @param p_pathToWatch (The directory to watch for)
+		* @param p_frequency (The delay between checks. Stopping the FileWatcher won't skip the delay)
+		*/
+		FileWatcher(std::string p_pathToWatch, std::chrono::duration<int, std::milli> p_frequency);
+
+		/**
+		* Destructor of the FileWatcher.
+		* If the FileWatcher is running, Stop() will be called.
+		*/
+		~FileWatcher();
+
+		/**
+		* Start watching the directory
+		*/
+		void Start();
+
+		/**
+		* Stop watching the directory (Delay can occur if the FileWatcher thread is waiting the given delay)
+		*/
+		void Stop();
+
+	private:
+		void ConcurrentTask();
+		bool Contains(const std::string& p_path);
+
+	public:
+		OvTools::Eventing::Event<std::string> FileAddedEvent;
+		OvTools::Eventing::Event<std::string> FileChangedEvent;
+		OvTools::Eventing::Event<std::string> FileDeletedEvent;
+
+	private:
+		std::unique_ptr<std::thread> m_worker;
+		std::string m_pathToWatch;
+		std::chrono::duration<int, std::milli> m_frequency;
+
+		std::unordered_map<std::string, std::filesystem::file_time_type> m_paths;
+		bool m_running = false;
+	};
+}

--- a/Sources/Overload/OvTools/src/OvTools/Filesystem/FileWatcher.cpp
+++ b/Sources/Overload/OvTools/src/OvTools/Filesystem/FileWatcher.cpp
@@ -1,0 +1,92 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include "OvTools/FileSystem/FileWatcher.h"
+
+OvTools::Filesystem::FileWatcher::FileWatcher(std::string p_pathToWatch, std::chrono::duration<int, std::milli> p_frequency) : m_pathToWatch(p_pathToWatch), m_frequency(p_frequency)
+{
+	for (auto& file : std::filesystem::recursive_directory_iterator(p_pathToWatch))
+	{
+		m_paths[file.path().string()] = std::filesystem::last_write_time(file);
+	}
+}
+
+OvTools::Filesystem::FileWatcher::~FileWatcher()
+{
+	if (m_running)
+	{
+		Stop();
+	}
+}
+
+void OvTools::Filesystem::FileWatcher::Start()
+{
+	if (!m_running)
+	{
+		m_running = true;
+		m_worker = std::make_unique<std::thread>(std::bind(&FileWatcher::ConcurrentTask, this));
+	}
+}
+
+void OvTools::Filesystem::FileWatcher::Stop()
+{
+	m_running = false;
+
+	if (m_worker)
+	{
+		m_worker->join();
+	}
+}
+
+void OvTools::Filesystem::FileWatcher::ConcurrentTask()
+{
+	while (m_running)
+	{
+		std::this_thread::sleep_for(m_frequency);
+
+		for (auto it = m_paths.begin(); it != m_paths.end();)
+		{
+			const auto filePath = it->first;
+
+			if (!std::filesystem::exists(filePath))
+			{
+				FileDeletedEvent.Invoke(filePath);
+				it = m_paths.erase(it);
+			}
+			else
+			{
+				++it;
+			}
+		}
+
+		// Check if a file was created or modified
+		for (auto& file : std::filesystem::recursive_directory_iterator(m_pathToWatch))
+		{
+			const auto current_file_last_write_time = std::filesystem::last_write_time(file);
+			const auto filePath = file.path().string();
+
+			if (!Contains(filePath))
+			{
+				m_paths[filePath] = current_file_last_write_time;
+				FileAddedEvent.Invoke(filePath);
+			}
+			else
+			{
+				if (m_paths[filePath] != current_file_last_write_time)
+				{
+					m_paths[filePath] = current_file_last_write_time;
+					FileChangedEvent.Invoke(filePath);
+				}
+			}
+		}
+	}
+}
+
+bool OvTools::Filesystem::FileWatcher::Contains(const std::string& p_key)
+{
+	auto el = m_paths.find(p_key);
+	return el != m_paths.end();
+}


### PR DESCRIPTION
The `FileWatcher` class has been added to `OvTools`. This class allows
watching a directory and getting notified of any file
added/removed/modified.

This `FileWatcher` has been introduced into the `AssetBrowser` to track
shader file changes and trigger shader recompilation automatically.

![ShaderReload](https://user-images.githubusercontent.com/33324216/75618679-d7371500-5b3f-11ea-98fe-39fff9b6c05e.gif)
