### PR TITLE
Enable vsync in editor by default.

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Application.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Application.cpp
@@ -12,7 +12,7 @@ OvEditor::Core::Application::Application(const std::string& p_projectPath, const
 	m_context(p_projectPath, p_projectName),
 	m_editor(m_context)
 {
-
+	m_context.device->SetVsync(true);
 }
 
 OvEditor::Core::Application::~Application()

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Application.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Application.cpp
@@ -12,7 +12,6 @@ OvEditor::Core::Application::Application(const std::string& p_projectPath, const
 	m_context(p_projectPath, p_projectName),
 	m_editor(m_context)
 {
-	m_context.device->SetVsync(true);
 }
 
 OvEditor::Core::Application::~Application()

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
@@ -54,6 +54,8 @@ OvEditor::Core::Context::Context(const std::string& p_projectPath, const std::st
 	inputManager = std::make_unique<OvWindowing::Inputs::InputManager>(*window);
 	window->MakeCurrentContext();
 
+	device->SetVsync(true);
+
 	/* Graphics context creation */
 	driver = std::make_unique<OvRendering::Context::Driver>(OvRendering::Settings::DriverSettings{ true });
 	renderer = std::make_unique<OvCore::ECS::Renderer>(*driver);


### PR DESCRIPTION
Vertical sync isn't enabled in the editor on startup.