### PR TITLE
Remove camera yaw pitch roll log

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Core/CameraController.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/CameraController.cpp
@@ -322,7 +322,6 @@ void OvEditor::Core::CameraController::HandleCameraFPSMouse(const OvMaths::FVect
 	{
 		m_ypr = OvMaths::FQuaternion::EulerAngles(m_cameraRotation);
 		m_ypr = RemoveRoll(m_ypr);
-		OVLOG("X:" + std::to_string(m_ypr.x) + " Y:" + std::to_string(m_ypr.y) + " Z:" + std::to_string(m_ypr.z));
 	}
 
 	m_ypr.y -= mouseOffset.x;


### PR DESCRIPTION
While working on the orbit camera, I was using an OVLOG to debug my
code. However I forgot to remove it from my pull request... So here is a
very small fix addressing this problem.