### PR TITLE
Exposing frustum culling to Lua and fixing frustum debugging issue

### DIFF
--- a/Sources/Overload/OvCore/src/OvCore/Scripting/LuaComponentBinder.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Scripting/LuaComponentBinder.cpp
@@ -61,12 +61,22 @@ void OvCore::Scripting::LuaComponentBinder::BindComponent(sol::state & p_luaStat
 		"GetWorldUp", &CTransform::GetWorldUp,
 		"GetWorldRight", &CTransform::GetWorldRight
 		);
+    
+    p_luaState.new_enum<OvCore::ECS::Components::CModelRenderer::EFrustumBehaviour>("FrustumBehaviour",
+        {
+            {"DISABLED",		OvCore::ECS::Components::CModelRenderer::EFrustumBehaviour::DISABLED},
+            {"CULL_MODEL",		OvCore::ECS::Components::CModelRenderer::EFrustumBehaviour::CULL_MODEL},
+            {"CULL_MESHES",		OvCore::ECS::Components::CModelRenderer::EFrustumBehaviour::CULL_MESHES},
+            {"CULL_CUSTOM",		OvCore::ECS::Components::CModelRenderer::EFrustumBehaviour::CULL_CUSTOM}
+        });
 
 	p_luaState.new_usertype<CModelRenderer>("ModelRenderer",
 		sol::base_classes, sol::bases<AComponent>(),
 		"GetModel", &CModelRenderer::GetModel,
-		"SetModel", &CModelRenderer::SetModel
-		);
+		"SetModel", &CModelRenderer::SetModel,
+		"GetFrustumBehaviour", &CModelRenderer::GetFrustumBehaviour,
+		"SetFrustumBehaviour", &CModelRenderer::SetFrustumBehaviour
+	);
 
 	p_luaState.new_usertype<CMaterialRenderer>("MaterialRenderer",
 		sol::base_classes, sol::bases<AComponent>(),
@@ -124,7 +134,7 @@ void OvCore::Scripting::LuaComponentBinder::BindComponent(sol::state & p_luaStat
 		"GetRadius", &CPhysicalCapsule::GetRadius,
 		"SetRadius", &CPhysicalCapsule::SetRadius,
 		"GetHeight", &CPhysicalCapsule::GetHeight,
-		"GetHeight", &CPhysicalCapsule::SetHeight
+		"SetHeight", &CPhysicalCapsule::SetHeight
 		);
 
 	p_luaState.new_usertype<CCamera>("Camera",
@@ -136,7 +146,11 @@ void OvCore::Scripting::LuaComponentBinder::BindComponent(sol::state & p_luaStat
 		"SetFov", &CCamera::SetFov,
 		"SetNear", &CCamera::SetNear,
 		"SetFar", &CCamera::SetFar,
-		"SetClearColor", &CCamera::SetClearColor
+		"SetClearColor", &CCamera::SetClearColor,
+        "HasFrustumGeometryCulling", &CCamera::HasFrustumGeometryCulling,
+        "HasFrustumLightCulling", &CCamera::HasFrustumLightCulling,
+        "SetFrustumGeometryCulling", &CCamera::SetFrustumGeometryCulling,
+        "SetFrustumLightCulling", &CCamera::SetFrustumLightCulling
 		);
 
 	p_luaState.new_usertype<CLight>("Light",

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
@@ -100,7 +100,7 @@ void OvEditor::Panels::SceneView::RenderScene(uint8_t p_defaultRenderState)
 	m_editorRenderer.RenderCameras();
 
 	// If the game is playing, and ShowGeometryFrustumCullingInSceneView is true, apply the game view frustum culling to the scene view (For debugging purposes)
-	if (auto gameViewFrustum = gameView.GetActiveFrustum(); gameViewFrustum.has_value() && gameView.GetCamera().HasFrustumLightCulling() && Settings::EditorSettings::ShowGeometryFrustumCullingInSceneView)
+	if (auto gameViewFrustum = gameView.GetActiveFrustum(); gameViewFrustum.has_value() && gameView.GetCamera().HasFrustumGeometryCulling() && Settings::EditorSettings::ShowGeometryFrustumCullingInSceneView)
 	{
 		m_camera.SetFrustumGeometryCulling(gameView.HasCamera() ? gameView.GetCamera().HasFrustumGeometryCulling() : false);
 		m_editorRenderer.RenderScene(m_cameraPosition, m_camera, &gameViewFrustum.value());


### PR DESCRIPTION
The frustum culling settings (Onto `Camera` and `ModelRenderer`) are now
exposed to Lua.

Two major bugs has also been fixed:
- `PhysicalCapsule.GetHeight()` lua binding was wrong (Typo)
- The frustum culling debugging tool (In editor) was considering the light
visualization to show/hide geometries outside of the frustum.

Fixes https://github.com/adriengivry/Overload/issues/39

> Frustum culling for models controlled via a lua script
![LuaFrustumCullingControl](https://user-images.githubusercontent.com/33324216/81230935-60dfe480-8fc0-11ea-9c2e-07e10c6c761d.gif)