### PR TITLE
Fix bug: unintialized varaible; change reinterpret_cast to static_cast

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Core/GizmoBehaviour.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/GizmoBehaviour.h
@@ -121,7 +121,7 @@ namespace OvEditor::Core
 	private:
 		bool m_firstMouse = true;
 		float m_distanceToActor = 0.0f;
-		OvCore::ECS::Actor* m_target;
+		OvCore::ECS::Actor* m_target = nullptr;
 		EGizmoOperation m_currentOperation;
 		EDirection m_direction;
 		OvMaths::FTransform m_originalTransform;

--- a/Sources/Overload/OvEditor/include/OvEditor/Core/PanelsManager.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/PanelsManager.h
@@ -38,7 +38,7 @@ namespace OvEditor::Core
 			if constexpr (std::is_base_of<OvUI::Panels::PanelWindow, T>::value)
 			{
 				m_panels.emplace(p_id, std::make_unique<T>(p_id, std::forward<Args>(p_args)...));
-				T& instance = *reinterpret_cast<T*>(m_panels.at(p_id).get());
+				T& instance = *static_cast<T*>(m_panels.at(p_id).get());
 				GetPanelAs<OvEditor::Panels::MenuBar>("Menu Bar").RegisterPanel(instance.name, instance);
 			}
 			else
@@ -56,7 +56,7 @@ namespace OvEditor::Core
 		template<typename T>
 		T& GetPanelAs(const std::string& p_id)
 		{
-			return *reinterpret_cast<T*>(m_panels[p_id].get());
+			return *static_cast<T*>(m_panels[p_id].get());
 		}
 
 	private:


### PR DESCRIPTION
1. As I said in #72, fix an bug: `uninitialized varaible`

2. For instances with same base class, `static_cast` is safer than `reinterpret_cast`, since compilers would perform perform typecheck for the latter one.