### PR TITLE
Force using dedicated GPU

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
@@ -8,16 +8,15 @@
 
 #include <OvTools/Utils/String.h>
 
+#include <OvRendering/Utils/Defines.h>
+
 #include "OvEditor/Core/ProjectHub.h"
 #include "OvEditor/Core/Application.h"
 
 #undef APIENTRY
 #include "Windows.h"
 
-extern "C"
-{
-	__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
-}
+FORCE_DEDICATED_GPU
 
 /**
 * When Overload is launched from a project file, we should consider the executable path as

--- a/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
@@ -14,6 +14,11 @@
 #undef APIENTRY
 #include "Windows.h"
 
+extern "C"
+{
+	__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+}
+
 /**
 * When Overload is launched from a project file, we should consider the executable path as
 * the current working directory

--- a/Sources/Overload/OvGame/src/OvGame/Main.cpp
+++ b/Sources/Overload/OvGame/src/OvGame/Main.cpp
@@ -4,12 +4,11 @@
 * @licence: MIT
 */
 
+#include <OvRendering/Utils/Defines.h>
+
 #include "OvGame/Core/Application.h"
 
-extern "C"
-{
-	__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
-}
+FORCE_DEDICATED_GPU
 
 #ifdef _DEBUG
 int main()

--- a/Sources/Overload/OvGame/src/OvGame/Main.cpp
+++ b/Sources/Overload/OvGame/src/OvGame/Main.cpp
@@ -6,6 +6,11 @@
 
 #include "OvGame/Core/Application.h"
 
+extern "C"
+{
+	__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+}
+
 #ifdef _DEBUG
 int main()
 #else

--- a/Sources/Overload/OvRendering/OvRendering.vcxproj
+++ b/Sources/Overload/OvRendering/OvRendering.vcxproj
@@ -165,6 +165,7 @@ xcopy "$(SolutionDir)..\..\Dependencies\assimp\bin\*.dll" "$(SolutionDir)..\..\B
     <ClInclude Include="include\OvRendering\Settings\ERenderingCapability.h" />
     <ClInclude Include="include\OvRendering\Settings\EComparaisonAlgorithm.h" />
     <ClInclude Include="include\OvRendering\Settings\ETextureFilteringMode.h" />
+    <ClInclude Include="include\OvRendering\Utils\Defines.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\OvRendering\Buffers\Framebuffer.cpp" />

--- a/Sources/Overload/OvRendering/OvRendering.vcxproj.filters
+++ b/Sources/Overload/OvRendering/OvRendering.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClInclude Include="include\OvRendering\Settings\ECullingOptions.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\OvRendering\Utils\Defines.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\OvRendering\Context\Driver.cpp">

--- a/Sources/Overload/OvRendering/include/OvRendering/Utils/Defines.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Utils/Defines.h
@@ -1,0 +1,15 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include "OvRendering/API/Export.h"
+
+#define FORCE_DEDICATED_GPU \
+extern "C"\
+{\
+	__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;\
+}


### PR DESCRIPTION
Fixing Overload failure at context creation by forcing to use the dedicated graphics card for the Editor and the Game.

Fixes #40 

Reference: https://docs.nvidia.com/gameworks/content/technologies/desktop/optimus.htm