### PR TITLE
Reversing the order of entries in profiler reports

### DIFF
--- a/Sources/Overload/OvAnalytics/src/OvAnalytics/Profiling/Profiler.cpp
+++ b/Sources/Overload/OvAnalytics/src/OvAnalytics/Profiling/Profiler.cpp
@@ -38,7 +38,7 @@ OvAnalytics::Profiling::ProfilerReport OvAnalytics::Profiling::Profiler::Generat
 	report.elapsedFrames = __ELAPSED_FRAMES;
 	report.elaspedTime = elapsed.count();
 
-	std::multimap<double, std::string> sortedHistory;
+	std::multimap<double, std::string, std::greater<double>> sortedHistory;
 
 	/* Fill the sorted history with the current history (Auto sort) */
 	for (auto& data : __ELPASED_HISTORY)


### PR DESCRIPTION
The ProfilerReport is containing a vector of `Action`. These actions
were sorted by duration (From lowest to highest duration). However, when
profiling, the longest action is generally the one we care more about,
thus, actions are now stored from the highest duration to the lowest
one. As a result, the profiler results are now shown in the editor in
the correct order (Longest actions on top, shortest actions on bottom).

## Before
![image](https://user-images.githubusercontent.com/33324216/83822364-cd710080-a69e-11ea-8eae-d28cc8496592.png)

## After
![image](https://user-images.githubusercontent.com/33324216/83822305-a9152400-a69e-11ea-9c7d-a8452b5a0d20.png)
