### PR TITLE
Editor crashes when deleting an already deleted file/folder

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -509,9 +509,12 @@ public:
 
 		if (message.GetUserAction() == MessageBox::EUserAction::YES)
 		{
-			EDITOR_EXEC(PropagateFolderDestruction(filePath));
-			std::filesystem::remove_all(filePath);
-			DestroyedEvent.Invoke(filePath);
+			if (std::filesystem::exists(filePath) == true)
+			{
+				EDITOR_EXEC(PropagateFolderDestruction(filePath));
+				std::filesystem::remove_all(filePath);
+				DestroyedEvent.Invoke(filePath);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixing file/folder suppression from `AssetBrowser` when this same file/folder has already been deleted using an external tool (Ex: Windows Explorer)