### PR TITLE
Window scroll control and console log order

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Console.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Console.cpp
@@ -84,6 +84,7 @@ OvEditor::Panels::Console::Console
 	CreateWidget<Visual::Separator>();
 
 	m_logGroup = &CreateWidget<Layout::Group>();
+    m_logGroup->ReverseDrawOrder();
 
 	EDITOR_EVENT(PlayEvent) += std::bind(&Console::ClearOnPlay, this);
 

--- a/Sources/Overload/OvUI/include/OvUI/Internal/WidgetContainer.h
+++ b/Sources/Overload/OvUI/include/OvUI/Internal/WidgetContainer.h
@@ -52,6 +52,11 @@ namespace OvUI::Internal
 		*/
 		void DrawWidgets();
 
+        /**
+        * Allow the user to reverse the draw order of this widget container
+        */
+        void ReverseDrawOrder(bool reversed = true);
+
 		/**
 		* Create a widget
 		* @param p_args
@@ -72,5 +77,6 @@ namespace OvUI::Internal
 
 	protected:
 		std::vector<std::pair<OvUI::Widgets::AWidget*, Internal::EMemoryMode>> m_widgets;
+        bool m_reversedDrawOrder = false;
 	};
 }

--- a/Sources/Overload/OvUI/include/OvUI/Panels/PanelWindow.h
+++ b/Sources/Overload/OvUI/include/OvUI/Panels/PanelWindow.h
@@ -75,6 +75,26 @@ namespace OvUI::Panels
 		*/
 		bool IsAppearing() const;
 
+        /**
+        * Scrolls to the bottom of the window
+        */
+        void ScrollToBottom();
+
+        /**
+        * Scrolls to the top of the window
+        */
+        void ScrollToTop();
+
+        /**
+        * Returns true if the window is scrolled to the bottom
+        */
+        bool IsScrolledToBottom() const;
+
+        /**
+        * Returns true if the window is scrolled to the bottom
+        */
+        bool IsScrolledToTop() const;
+
 	protected:
 		void _Draw_Impl() override;
 
@@ -105,5 +125,9 @@ namespace OvUI::Panels
 		bool m_opened;
 		bool m_hovered;
 		bool m_focused;
+        bool m_mustScrollToBottom = false;
+        bool m_mustScrollToTop = false;
+        bool m_scrolledToBottom = false;
+        bool m_scrolledToTop = false;
 	};
 }

--- a/Sources/Overload/OvUI/src/OvUI/Internal/WidgetContainer.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Internal/WidgetContainer.cpp
@@ -72,8 +72,21 @@ void OvUI::Internal::WidgetContainer::DrawWidgets()
 {
 	CollectGarbages();
 
-	for (auto& widget : m_widgets)
-		widget.first->Draw();
+    if (m_reversedDrawOrder)
+    {
+        for (auto it = m_widgets.crbegin(); it != m_widgets.crend(); ++it)
+            it->first->Draw();
+    }
+    else
+    {
+        for (const auto& widget : m_widgets)
+            widget.first->Draw();
+    }
+}
+
+void OvUI::Internal::WidgetContainer::ReverseDrawOrder(const bool reversed)
+{
+    m_reversedDrawOrder = reversed;
 }
 
 std::vector<std::pair<OvUI::Widgets::AWidget*, OvUI::Internal::EMemoryMode>>& OvUI::Internal::WidgetContainer::GetWidgets()

--- a/Sources/Overload/OvUI/src/OvUI/Panels/PanelWindow.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Panels/PanelWindow.cpp
@@ -87,6 +87,26 @@ bool OvUI::Panels::PanelWindow::IsAppearing() const
 		return false;
 }
 
+void OvUI::Panels::PanelWindow::ScrollToBottom()
+{
+    m_mustScrollToBottom = true;
+}
+
+void OvUI::Panels::PanelWindow::ScrollToTop()
+{
+    m_mustScrollToTop = true;
+}
+
+bool OvUI::Panels::PanelWindow::IsScrolledToBottom() const
+{
+    return m_scrolledToBottom;
+}
+
+bool OvUI::Panels::PanelWindow::IsScrolledToTop() const
+{
+    return m_scrolledToTop;
+}
+
 void OvUI::Panels::PanelWindow::_Draw_Impl()
 {
 	if (m_opened)
@@ -123,10 +143,27 @@ void OvUI::Panels::PanelWindow::_Draw_Impl()
 			m_hovered = ImGui::IsWindowHovered();
 			m_focused = ImGui::IsWindowFocused();
 
+            auto scrollY = ImGui::GetScrollY();
+
+            m_scrolledToBottom = scrollY == ImGui::GetScrollMaxY();
+            m_scrolledToTop = scrollY == 0.0f;
+
 			if (!m_opened)
 				CloseEvent.Invoke();
 
 			Update();
+
+            if (m_mustScrollToBottom)
+            {
+                ImGui::SetScrollY(ImGui::GetScrollMaxY());
+                m_mustScrollToBottom = false;
+            }
+
+            if (m_mustScrollToTop)
+            {
+                ImGui::SetScrollY(0.0f);
+                m_mustScrollToTop = false;
+            }
 
 			DrawWidgets();
 		}


### PR DESCRIPTION
Adding some new methods to `PanelWindow` to control the window scrolling
(`IsScrolledToBottom`, `IsScrolledToTop`, `ScrollToTop`, `ScrollToBottom`).

There is no use case for these new methods, however it has been added in
order to test console auto-scroll to bottom when new logs arrives.

`WidgetContainer` now supports reversed draw order, meaning that all of
our classes inheriting from it (Ex: `Group`), can be setup to draw its
internal widgets in reversed order. This new feature (Reversed order)
has been used with the console to draw recents log first.