### PR TITLE
Making `OvMaths::FQuaternion::Identity` a constant instead of a static method

### DIFF
--- a/Sources/Overload/OvCore/include/OvCore/ECS/Components/CTransform.h
+++ b/Sources/Overload/OvCore/include/OvCore/ECS/Components/CTransform.h
@@ -30,7 +30,7 @@ namespace OvCore::ECS::Components
 		* @param p_localRotation
 		* @param p_localScale
 		*/
-		CTransform(ECS::Actor& p_owner, struct OvMaths::FVector3 p_localPosition = OvMaths::FVector3(0.0f, 0.0f, 0.0f), OvMaths::FQuaternion p_localRotation = OvMaths::FQuaternion::Identity(), struct OvMaths::FVector3 p_localScale = OvMaths::FVector3(1.0f, 1.0f, 1.0f));
+		CTransform(ECS::Actor& p_owner, struct OvMaths::FVector3 p_localPosition = OvMaths::FVector3(0.0f, 0.0f, 0.0f), OvMaths::FQuaternion p_localRotation = OvMaths::FQuaternion::Identity, struct OvMaths::FVector3 p_localScale = OvMaths::FVector3(1.0f, 1.0f, 1.0f));
 
 		/**
 		* Returns the name of the component

--- a/Sources/Overload/OvMaths/include/OvMaths/FQuaternion.h
+++ b/Sources/Overload/OvMaths/include/OvMaths/FQuaternion.h
@@ -29,7 +29,7 @@ namespace OvMaths
 		/**
 		* Return an identity quaternion
 		*/
-		static FQuaternion Identity();
+		static const FQuaternion Identity;
 
 		/**
 		* Default Quaternion constructor (Create an identity quaternion with 1 as w)

--- a/Sources/Overload/OvMaths/include/OvMaths/FTransform.h
+++ b/Sources/Overload/OvMaths/include/OvMaths/FTransform.h
@@ -26,7 +26,7 @@ namespace OvMaths
 		* @param p_localRotation
 		* @param p_localScale
 		*/
-		FTransform(FVector3 p_localPosition = FVector3(0.0f, 0.0f, 0.0f), FQuaternion p_localRotation = FQuaternion::Identity(), FVector3 p_localScale = FVector3(1.0f, 1.0f, 1.0f));
+		FTransform(FVector3 p_localPosition = FVector3(0.0f, 0.0f, 0.0f), FQuaternion p_localRotation = FQuaternion::Identity, FVector3 p_localScale = FVector3(1.0f, 1.0f, 1.0f));
 
 		/**
 		* Destructor of the transform.

--- a/Sources/Overload/OvMaths/src/OvMaths/FQuaternion.cpp
+++ b/Sources/Overload/OvMaths/src/OvMaths/FQuaternion.cpp
@@ -16,10 +16,7 @@
 #define TO_RADIANS(value) value * PI / 180.f
 #define TO_DEGREES(value) value * 180.f / PI
 
-OvMaths::FQuaternion OvMaths::FQuaternion::Identity()
-{
-	return FQuaternion{ 0.0f, 0.0f, 0.0f, 1.0f };
-}
+const OvMaths::FQuaternion OvMaths::FQuaternion::Identity = OvMaths::FQuaternion(0.0f, 0.0f, 0.0f, 1.0f);
 
 OvMaths::FQuaternion::FQuaternion() :
 	x(0.0f), y(0.0f), z(0.0f), w(1.0f)
@@ -188,7 +185,7 @@ OvMaths::FQuaternion OvMaths::FQuaternion::LookAt(const FVector3& p_forward, con
 
 
 	float num8 = (m00 + m11) + m22;
-	auto quaternion = OvMaths::FQuaternion::Identity();
+	auto quaternion = OvMaths::FQuaternion::Identity;
 	if (num8 > 0.f)
 	{
 		auto num = sqrt(num8 + 1.f);


### PR DESCRIPTION
Fixes https://github.com/adriengivry/Overload/issues/86