### PR TITLE
Improving the actor duplication naming system

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -566,6 +566,62 @@ bool OvEditor::Core::EditorActions::DestroyActor(OvCore::ECS::Actor & p_actor)
 	return true;
 }
 
+std::string FindDuplicatedActorUniqueName(OvCore::ECS::Actor& p_duplicated, OvCore::ECS::Actor& p_newActor, OvCore::SceneSystem::Scene& p_scene)
+{
+    const auto sourceName = p_duplicated.GetName();
+    auto sourceNameWithoutSuffix = sourceName;
+
+    auto suffixOpeningParenthesisPos = std::string::npos;
+    auto suffixClosingParenthesisPos = std::string::npos;
+
+    // Keep track of the current character position when iterating onto `sourceName`
+    auto currentPos = decltype(std::string::npos){sourceName.length() - 1};
+
+    // Here we search for `(` and `)` positions. (Needed to extract the number between those parenthesis)
+    for (auto it = sourceName.rbegin(); it < sourceName.rend(); ++it, --currentPos)
+    {
+        auto c = *it;
+
+        if (suffixClosingParenthesisPos == std::string::npos && c == ')') suffixClosingParenthesisPos = currentPos;
+        if (suffixClosingParenthesisPos != std::string::npos && c == '(') suffixOpeningParenthesisPos = currentPos;
+    }
+
+    // We need to declare our `duplicationCounter` here to store the number between found parenthesis OR 1 (In the case no parenthesis, AKA, suffix, has been found)
+    auto duplicationCounter = uint32_t{ 1 };
+
+    // If the two parenthis have been found AND the closing parenthesis is the last character AND there is a space before the opening parenthesis
+    if (suffixOpeningParenthesisPos != std::string::npos && suffixClosingParenthesisPos == sourceName.length() - 1 && suffixOpeningParenthesisPos > 0 && sourceName[suffixOpeningParenthesisPos - 1] == ' ')
+    {
+        // Extract the string between those parenthesis
+        const auto between = sourceName.substr(suffixOpeningParenthesisPos + 1, suffixClosingParenthesisPos - suffixOpeningParenthesisPos - 1);
+
+        // If the `between` string is composed of digits (AKA, `between` is a number)
+        if (!between.empty() && std::find_if(between.begin(), between.end(), [](unsigned char c) { return !std::isdigit(c); }) == between.end())
+        {
+            duplicationCounter = static_cast<uint32_t>(std::atoi(between.c_str()));
+            sourceNameWithoutSuffix = sourceName.substr(0, suffixOpeningParenthesisPos - 1);
+        }
+    }
+
+    const auto parent = p_newActor.GetParent();
+    const auto adjacentActors = parent ? parent->GetChildren() : p_scene.GetActors();
+
+    auto foundName = sourceNameWithoutSuffix;
+
+    // Lambda that checks if the current `foundName` is used by the actor given in parameter (Also ensure that the given actor is adjacent to our new actor)
+    // We call "adjacent" two actors that shares the same hierarchical level. (Ex: If [A] and [B] are both direction children of [C], then, they are adjacents)
+    const auto isActorNameTaken = [&foundName, parent](auto actor) { return (parent || !actor->GetParent()) && actor->GetName() == foundName; };
+
+    // While there is an adjacent actor with the current `foundName`, we keep generating new names
+    while (std::find_if(adjacentActors.begin(), adjacentActors.end(), isActorNameTaken) != adjacentActors.end())
+    {
+        // New names are composed of the `sourceNameWithoutSuffix` (Ex: "Cube (1)" name without suffix is "Cube")
+        foundName = sourceNameWithoutSuffix + " (" + std::to_string(duplicationCounter++) + ")";
+    }
+
+    return foundName;
+}
+
 void OvEditor::Core::EditorActions::DuplicateActor(OvCore::ECS::Actor & p_toDuplicate, OvCore::ECS::Actor* p_forcedParent, bool p_focus)
 {
 	tinyxml2::XMLDocument doc;
@@ -582,12 +638,18 @@ void OvEditor::Core::EditorActions::DuplicateActor(OvCore::ECS::Actor & p_toDupl
 		newActor.SetParent(*p_forcedParent);
 	else
 	{
-		newActor.SetName(p_toDuplicate.GetName() + " (Copy)"); // Dont overload the name if it has a forced parent
-		if (newActor.GetParentID() > 0)
-		{
-			if (auto found = m_context.sceneManager.GetCurrentScene()->FindActorByID(newActor.GetParentID()); found)
-				newActor.SetParent(*found);
-		}
+        auto currentScene = m_context.sceneManager.GetCurrentScene();
+
+        if (newActor.GetParentID() > 0)
+        {
+            if (auto found = currentScene->FindActorByID(newActor.GetParentID()); found)
+            {
+                newActor.SetParent(*found);
+            }
+        }
+
+        const auto uniqueName = FindDuplicatedActorUniqueName(p_toDuplicate, newActor, *currentScene);
+        newActor.SetName(uniqueName);
 	}
 
 	if (p_focus)


### PR DESCRIPTION
Previously, duplicating an actor name would add '(Copy)' after the name
of the duplicated actor. However, it resulted into sometimes having
multiple `(Copy) (Copy) (Copy)`.

To prevent that, the behaviour of Unity has been mimicked (Incremental
ID generated after name : `(1)`, `(2)`...).

![image](https://user-images.githubusercontent.com/33324216/84452433-cceae380-ac23-11ea-9693-65a17a9b68df.png)

Fixes https://github.com/adriengivry/Overload/issues/98
