### PR TITLE
Removing useless transform parameter from Camera constructor

### DIFF
--- a/Sources/Overload/OvRendering/include/OvRendering/LowRenderer/Camera.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/LowRenderer/Camera.h
@@ -25,9 +25,8 @@ namespace OvRendering::LowRenderer
 	public:
 		/**
 		* Constructor
-		* @param p_transform
 		*/
-		Camera(OvMaths::FTransform* p_transform = nullptr);
+		Camera();
 
 		/**
 		* Cache the projection, view and frustum matrices

--- a/Sources/Overload/OvRendering/src/OvRendering/LowRenderer/Camera.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/LowRenderer/Camera.cpp
@@ -9,7 +9,7 @@
 #include "OvRendering/LowRenderer/Camera.h"
 #include "OvMaths/FMatrix4.h"
 
-OvRendering::LowRenderer::Camera::Camera(OvMaths::FTransform* p_transform) :
+OvRendering::LowRenderer::Camera::Camera() :
 	m_fov(45.0f),
 	m_near(0.1f),
 	m_far(100.f),


### PR DESCRIPTION
Fixes https://github.com/adriengivry/Overload/issues/85