### PR TITLE
Adding orthographic camera mode

### DIFF
--- a/Sources/Overload/OvCore/include/OvCore/ECS/Components/CCamera.h
+++ b/Sources/Overload/OvCore/include/OvCore/ECS/Components/CCamera.h
@@ -41,6 +41,12 @@ namespace OvCore::ECS::Components
 		*/
 		void SetFov(float p_value);
 
+        /**
+        * Sets the size of the camera to the given value
+        * @param p_value
+        */
+        void SetSize(float p_value);
+
 		/**
 		* Sets the near of the camera to the given value
 		* @param p_value
@@ -71,10 +77,21 @@ namespace OvCore::ECS::Components
 		*/
 		void SetFrustumLightCulling(bool p_enable);
 
+        /**
+        * Defines the projection mode the camera should adopt
+        * @param p_projectionMode
+        */
+        void SetProjectionMode(OvRendering::Settings::EProjectionMode p_projectionMode);
+
 		/**
 		* Returns the fov of the camera
 		*/
 		float GetFov() const;
+
+        /**
+        * Returns the size of the camera
+        */
+        float GetSize() const;
 
 		/**
 		* Returns the near of the camera
@@ -100,6 +117,11 @@ namespace OvCore::ECS::Components
 		* Returns true if the frustum light culling is enabled
 		*/
 		bool HasFrustumLightCulling() const;
+
+        /**
+        * Returns the current projection mode
+        */
+        OvRendering::Settings::EProjectionMode GetProjectionMode() const;
 
 		/**
 		* Returns the OvRendering camera instance attached to this component

--- a/Sources/Overload/OvCore/src/OvCore/ECS/Components/CCamera.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ECS/Components/CCamera.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <OvUI/Widgets/Drags/DragFloat.h>
+#include <OvUI/Widgets/Selection/ComboBox.h>
 #include <OvUI/Plugins/DataDispatcher.h>
 
 #include "OvCore/ECS/Components/CCamera.h"
@@ -24,6 +25,11 @@ std::string OvCore::ECS::Components::CCamera::GetName()
 void OvCore::ECS::Components::CCamera::SetFov(float p_value)
 {
 	m_camera.SetFov(p_value);
+}
+
+void OvCore::ECS::Components::CCamera::SetSize(float p_value)
+{
+    m_camera.SetSize(p_value);
 }
 
 void OvCore::ECS::Components::CCamera::SetNear(float p_value)
@@ -46,9 +52,19 @@ void OvCore::ECS::Components::CCamera::SetFrustumLightCulling(bool p_enable)
 	m_camera.SetFrustumLightCulling(p_enable);
 }
 
+void OvCore::ECS::Components::CCamera::SetProjectionMode(OvRendering::Settings::EProjectionMode p_projectionMode)
+{
+    m_camera.SetProjectionMode(p_projectionMode);
+}
+
 float OvCore::ECS::Components::CCamera::GetFov() const
 {
 	return m_camera.GetFov();
+}
+
+float OvCore::ECS::Components::CCamera::GetSize() const
+{
+    return m_camera.GetSize();
 }
 
 float OvCore::ECS::Components::CCamera::GetNear() const
@@ -81,6 +97,11 @@ bool OvCore::ECS::Components::CCamera::HasFrustumLightCulling() const
 	return m_camera.HasFrustumLightCulling();
 }
 
+OvRendering::Settings::EProjectionMode OvCore::ECS::Components::CCamera::GetProjectionMode() const
+{
+    return m_camera.GetProjectionMode();
+}
+
 OvRendering::LowRenderer::Camera & OvCore::ECS::Components::CCamera::GetCamera()
 {
 	return m_camera;
@@ -89,29 +110,63 @@ OvRendering::LowRenderer::Camera & OvCore::ECS::Components::CCamera::GetCamera()
 void OvCore::ECS::Components::CCamera::OnSerialize(tinyxml2::XMLDocument & p_doc, tinyxml2::XMLNode * p_node)
 {
 	OvCore::Helpers::Serializer::SerializeFloat(p_doc, p_node, "fov", m_camera.GetFov());
+	OvCore::Helpers::Serializer::SerializeFloat(p_doc, p_node, "size", m_camera.GetSize());
 	OvCore::Helpers::Serializer::SerializeFloat(p_doc, p_node, "near", m_camera.GetNear());
 	OvCore::Helpers::Serializer::SerializeFloat(p_doc, p_node, "far", m_camera.GetFar());
 	OvCore::Helpers::Serializer::SerializeVec3(p_doc, p_node, "clear_color", m_camera.GetClearColor());
 	OvCore::Helpers::Serializer::SerializeBoolean(p_doc, p_node, "frustum_geometry_culling", m_camera.HasFrustumGeometryCulling());
 	OvCore::Helpers::Serializer::SerializeBoolean(p_doc, p_node, "frustum_light_culling", m_camera.HasFrustumLightCulling());
+	OvCore::Helpers::Serializer::SerializeInt(p_doc, p_node, "projection_mode", static_cast<int>(m_camera.GetProjectionMode()));
 }
 
 void OvCore::ECS::Components::CCamera::OnDeserialize(tinyxml2::XMLDocument & p_doc, tinyxml2::XMLNode * p_node)
 {
 	m_camera.SetFov(OvCore::Helpers::Serializer::DeserializeFloat(p_doc, p_node, "fov"));
+	m_camera.SetSize(OvCore::Helpers::Serializer::DeserializeFloat(p_doc, p_node, "size"));
 	m_camera.SetNear(OvCore::Helpers::Serializer::DeserializeFloat(p_doc, p_node, "near"));
 	m_camera.SetFar(OvCore::Helpers::Serializer::DeserializeFloat(p_doc, p_node, "far"));
 	m_camera.SetClearColor(OvCore::Helpers::Serializer::DeserializeVec3(p_doc, p_node, "clear_color"));
 	m_camera.SetFrustumGeometryCulling(OvCore::Helpers::Serializer::DeserializeBoolean(p_doc, p_node, "frustum_geometry_culling"));
 	m_camera.SetFrustumLightCulling(OvCore::Helpers::Serializer::DeserializeBoolean(p_doc, p_node, "frustum_light_culling"));
+
+    // We have to make sure the "projection_mode" exists in the serialized component, otherwise we do not want to modify the default setting (Perspective).
+    // This is a bad practice to have each components calling setters in `OnDeserialize` even if no XML node hasn't been found for a given property.
+    // We should rework this system later. As it is out of the scope of the orthographic projection scope, this will be left as is for now.
+    if (p_node->FirstChildElement("projection_mode"))
+    {
+        m_camera.SetProjectionMode(static_cast<OvRendering::Settings::EProjectionMode>(OvCore::Helpers::Serializer::DeserializeInt(p_doc, p_node, "projection_mode")));
+    }
 }
 
 void OvCore::ECS::Components::CCamera::OnInspector(OvUI::Internal::WidgetContainer& p_root)
 {
+    auto currentProjectionMode = GetProjectionMode();
+
 	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Field of view", std::bind(&CCamera::GetFov, this), std::bind(&CCamera::SetFov, this, std::placeholders::_1));
+    auto& fovWidget = *p_root.GetWidgets()[p_root.GetWidgets().size() - 1].first;
+    auto& fovWidgetLabel = *p_root.GetWidgets()[p_root.GetWidgets().size() - 2].first;
+    fovWidget.enabled = fovWidgetLabel.enabled = currentProjectionMode == OvRendering::Settings::EProjectionMode::PERSPECTIVE;
+
+	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Size", std::bind(&CCamera::GetSize, this), std::bind(&CCamera::SetSize, this, std::placeholders::_1));
+    auto& sizeWidget = *p_root.GetWidgets()[p_root.GetWidgets().size() - 1].first;
+    auto& sizeWidgetLabel = *p_root.GetWidgets()[p_root.GetWidgets().size() - 2].first;
+    sizeWidget.enabled = sizeWidgetLabel.enabled = currentProjectionMode == OvRendering::Settings::EProjectionMode::ORTHOGRAPHIC;
+
 	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Near", std::bind(&CCamera::GetNear, this), std::bind(&CCamera::SetNear, this, std::placeholders::_1));
 	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Far", std::bind(&CCamera::GetFar, this), std::bind(&CCamera::SetFar, this, std::placeholders::_1));
 	OvCore::Helpers::GUIDrawer::DrawColor(p_root, "Clear color", [this]() {return reinterpret_cast<const OvUI::Types::Color&>(GetClearColor()); }, [this](OvUI::Types::Color p_color) { SetClearColor({ p_color.r, p_color.g, p_color.b }); }, false);
 	OvCore::Helpers::GUIDrawer::DrawBoolean(p_root, "Frustum Geometry Culling", std::bind(&CCamera::HasFrustumGeometryCulling, this), std::bind(&CCamera::SetFrustumGeometryCulling, this, std::placeholders::_1));
 	OvCore::Helpers::GUIDrawer::DrawBoolean(p_root, "Frustum Light Culling", std::bind(&CCamera::HasFrustumLightCulling, this), std::bind(&CCamera::SetFrustumLightCulling, this, std::placeholders::_1));
+
+    Helpers::GUIDrawer::CreateTitle(p_root, "Projection Mode");
+    auto& projectionMode = p_root.CreateWidget<OvUI::Widgets::Selection::ComboBox>(static_cast<int>(GetProjectionMode()));
+    projectionMode.choices.emplace(0, "Orthographic");
+    projectionMode.choices.emplace(1, "Perspective");
+    projectionMode.ValueChangedEvent += [this, &fovWidget, &fovWidgetLabel, &sizeWidget, &sizeWidgetLabel](int p_choice)
+    {
+        const auto newProjectionMode = static_cast<OvRendering::Settings::EProjectionMode>(p_choice);
+        SetProjectionMode(newProjectionMode);
+        fovWidget.enabled = fovWidgetLabel.enabled = newProjectionMode == OvRendering::Settings::EProjectionMode::PERSPECTIVE;
+        sizeWidget.enabled = sizeWidgetLabel.enabled = newProjectionMode == OvRendering::Settings::EProjectionMode::ORTHOGRAPHIC;
+    };
 }

--- a/Sources/Overload/OvCore/src/OvCore/Scripting/LuaComponentBinder.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Scripting/LuaComponentBinder.cpp
@@ -137,20 +137,30 @@ void OvCore::Scripting::LuaComponentBinder::BindComponent(sol::state & p_luaStat
 		"SetHeight", &CPhysicalCapsule::SetHeight
 		);
 
+    p_luaState.new_enum<OvRendering::Settings::EProjectionMode>("ProjectionMode",
+    {
+        {"ORTHOGRAPHIC",	OvRendering::Settings::EProjectionMode::ORTHOGRAPHIC},
+        {"PERSPECTIVE",		OvRendering::Settings::EProjectionMode::PERSPECTIVE}
+    });
+
 	p_luaState.new_usertype<CCamera>("Camera",
 		sol::base_classes, sol::bases<AComponent>(),
 		"GetFov", &CCamera::GetFov,
+		"GetSize", &CCamera::GetSize,
 		"GetNear", &CCamera::GetNear,
 		"GetFar", &CCamera::GetFar,
 		"GetClearColor", &CCamera::GetClearColor,
 		"SetFov", &CCamera::SetFov,
+		"SetSize", &CCamera::SetSize,
 		"SetNear", &CCamera::SetNear,
 		"SetFar", &CCamera::SetFar,
 		"SetClearColor", &CCamera::SetClearColor,
         "HasFrustumGeometryCulling", &CCamera::HasFrustumGeometryCulling,
         "HasFrustumLightCulling", &CCamera::HasFrustumLightCulling,
+        "GetProjectionMode", &CCamera::GetProjectionMode,
         "SetFrustumGeometryCulling", &CCamera::SetFrustumGeometryCulling,
-        "SetFrustumLightCulling", &CCamera::SetFrustumLightCulling
+        "SetFrustumLightCulling", &CCamera::SetFrustumLightCulling,
+        "SetProjectionMode", &CCamera::SetProjectionMode
 		);
 
 	p_luaState.new_usertype<CLight>("Light",

--- a/Sources/Overload/OvEditor/include/OvEditor/Core/EditorRenderer.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/EditorRenderer.h
@@ -110,6 +110,20 @@ namespace OvEditor::Core
 		*/
 		void RenderActorOutlinePass(OvCore::ECS::Actor& p_actor, bool p_toStencil, bool p_isSelected = false);
 
+        /**
+        * Render the camera perspective frustum
+        * @param p_size
+        * @param p_camera
+        */
+        void RenderCameraPerspectiveFrustum(std::pair<uint16_t, uint16_t>& p_size, OvCore::ECS::Components::CCamera& p_camera);
+
+        /**
+        * Render the camera orthographic frustum
+        * @param p_size
+        * @param p_camera
+        */
+        void RenderCameraOrthographicFrustum(std::pair<uint16_t, uint16_t>& p_size, OvCore::ECS::Components::CCamera& p_camera);
+
 		/**
 		* Render the camera frustum
 		*/

--- a/Sources/Overload/OvMaths/include/OvMaths/FMatrix4.h
+++ b/Sources/Overload/OvMaths/include/OvMaths/FMatrix4.h
@@ -350,6 +350,15 @@ namespace OvMaths
 		*/
 		static FMatrix4 CreatePerspective(const float p_fov, const float p_aspectRatio, const float p_zNear, const float p_zFar);
 
+        /**
+        * Returns an orthographic matrix
+        * @param p_size
+        * @param p_aspectRatio
+        * @param p_zNear
+        * @param p_zFar
+        */
+        static FMatrix4 CreateOrthographic(const float p_size, const float p_aspectRatio, const float p_zNear, const float p_zFar);
+
 		/**
 		* Return view matrix
 		* @param p_eyeX

--- a/Sources/Overload/OvMaths/src/OvMaths/FMatrix4.cpp
+++ b/Sources/Overload/OvMaths/src/OvMaths/FMatrix4.cpp
@@ -449,18 +449,27 @@ OvMaths::FMatrix4 OvMaths::FMatrix4::CreatePerspective(const float p_fov, const 
 	const float width = height * p_aspectRatio;
 
 	return CreateFrustum(-width, width, -height, height, p_zNear, p_zFar);
+}
 
-	/*float const rad = p_fov;
-	float const tanHalfFovy = tan(rad / 2);
+OvMaths::FMatrix4 OvMaths::FMatrix4::CreateOrthographic(const float p_size, const float p_aspectRatio, const float p_zNear, const float p_zFar)
+{
+    auto ortho = OvMaths::FMatrix4::Identity;
 
-	OvMaths::FMatrix4 frustum;
-	frustum.data[0] = 1.0f / (p_aspectRatio * tanHalfFovy);
-	frustum.data[5] = 1.0f / (tanHalfFovy);
-	frustum.data[10] = -(p_zFar + p_zNear) / (p_zFar - p_zNear);
-	frustum.data[11] = -1.0f;
-	frustum.data[14] = -(2.0f * p_zFar * p_zNear) / (p_zFar - p_zNear);
-	return frustum;*/
+    const auto right = p_size * p_aspectRatio;
+    const auto left = -right;
 
+    const auto top = p_size;
+    const auto bottom = -top;
+
+    ortho(0, 0) = 2.0f / (right - left);
+    ortho(1, 1) = 2.0f / (top - bottom);
+    ortho(2, 2) = -2.0f / (p_zFar - p_zNear);
+    ortho(0, 3) = -(right + left) / (right - left);
+    ortho(1, 3) = -(top + bottom) / (top - bottom);
+    ortho(2, 3) = -(p_zFar + p_zNear) / (p_zFar - p_zNear);
+    ortho(3, 3) = 1.0f;
+
+    return ortho;
 }
 
 OvMaths::FMatrix4 OvMaths::FMatrix4::CreateView(const float p_eyeX, const float p_eyeY, const float p_eyeZ, const float p_lookX, const float p_lookY, const float p_lookZ, const float p_upX, const float p_upY, const float p_upZ)

--- a/Sources/Overload/OvRendering/OvRendering.vcxproj
+++ b/Sources/Overload/OvRendering/OvRendering.vcxproj
@@ -161,6 +161,7 @@ xcopy "$(SolutionDir)..\..\Dependencies\assimp\bin\*.dll" "$(SolutionDir)..\..\B
     <ClInclude Include="include\OvRendering\Settings\ECullingOptions.h" />
     <ClInclude Include="include\OvRendering\Settings\EOperation.h" />
     <ClInclude Include="include\OvRendering\Settings\EPrimitiveMode.h" />
+    <ClInclude Include="include\OvRendering\Settings\EProjectionMode.h" />
     <ClInclude Include="include\OvRendering\Settings\ERasterizationMode.h" />
     <ClInclude Include="include\OvRendering\Settings\ERenderingCapability.h" />
     <ClInclude Include="include\OvRendering\Settings\EComparaisonAlgorithm.h" />

--- a/Sources/Overload/OvRendering/OvRendering.vcxproj.filters
+++ b/Sources/Overload/OvRendering/OvRendering.vcxproj.filters
@@ -132,6 +132,9 @@
     <ClInclude Include="include\OvRendering\Utils\Defines.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\OvRendering\Settings\EProjectionMode.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\OvRendering\Context\Driver.cpp">

--- a/Sources/Overload/OvRendering/include/OvRendering/LowRenderer/Camera.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/LowRenderer/Camera.h
@@ -14,6 +14,7 @@
 
 #include "OvRendering/API/Export.h"
 #include "OvRendering/Data/Frustum.h"
+#include "OvRendering/Settings/EProjectionMode.h"
 
 namespace OvRendering::LowRenderer
 {
@@ -64,6 +65,11 @@ namespace OvRendering::LowRenderer
 		*/
 		float GetFov() const;
 
+        /**
+        * Returns the size of the camera
+        */
+        float GetSize() const;
+
 		/**
 		* Returns the near of the camera
 		*/
@@ -104,11 +110,22 @@ namespace OvRendering::LowRenderer
 		*/
 		bool HasFrustumLightCulling() const;
 
+        /**
+        * Returns the current projection mode
+        */
+        OvRendering::Settings::EProjectionMode GetProjectionMode() const;
+
 		/**
 		* Sets the fov of the camera to the given value
 		* @param p_value
 		*/
 		void SetFov(float p_value);
+
+        /**
+        * Sets the size of the camera to the given value
+        * @param p_value
+        */
+        void SetSize(float p_value);
 
 		/**
 		* Sets the near of the camera to the given value
@@ -140,6 +157,12 @@ namespace OvRendering::LowRenderer
 		*/
 		void SetFrustumLightCulling(bool p_enable);
 
+        /**
+        * Defines the projection mode the camera should adopt
+        * @param p_projectionMode
+        */
+        void SetProjectionMode(OvRendering::Settings::EProjectionMode p_projectionMode);
+
 	private:
 		OvMaths::FMatrix4 CalculateProjectionMatrix(uint16_t p_windowWidth, uint16_t p_windowHeight) const;
 		OvMaths::FMatrix4 CalculateViewMatrix(const OvMaths::FVector3& p_position, const OvMaths::FQuaternion& p_rotation) const;
@@ -148,8 +171,10 @@ namespace OvRendering::LowRenderer
 		OvRendering::Data::Frustum m_frustum;
 		OvMaths::FMatrix4 m_viewMatrix;
 		OvMaths::FMatrix4 m_projectionMatrix;
+        OvRendering::Settings::EProjectionMode m_projectionMode;
 
 		float m_fov;
+        float m_size;
 		float m_near;
 		float m_far;
 

--- a/Sources/Overload/OvRendering/include/OvRendering/Settings/EProjectionMode.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Settings/EProjectionMode.h
@@ -1,0 +1,21 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include "OvRendering/API/Export.h"
+
+namespace OvRendering::Settings
+{
+    /**
+    * Projection modes, mostly used for cameras
+    */
+    enum class EProjectionMode
+    {
+        ORTHOGRAPHIC,
+        PERSPECTIVE
+    };
+}

--- a/Sources/Overload/OvRendering/src/OvRendering/LowRenderer/Camera.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/LowRenderer/Camera.cpp
@@ -10,7 +10,9 @@
 #include "OvMaths/FMatrix4.h"
 
 OvRendering::LowRenderer::Camera::Camera() :
+    m_projectionMode(Settings::EProjectionMode::PERSPECTIVE),
 	m_fov(45.0f),
+    m_size(5.0f),
 	m_near(0.1f),
 	m_far(100.f),
 	m_clearColor(0.f, 0.f, 0.f),
@@ -44,6 +46,11 @@ void OvRendering::LowRenderer::Camera::CacheFrustum(const OvMaths::FMatrix4& p_v
 float OvRendering::LowRenderer::Camera::GetFov() const
 {
 	return m_fov;
+}
+
+float OvRendering::LowRenderer::Camera::GetSize() const
+{
+    return m_size;
 }
 
 float OvRendering::LowRenderer::Camera::GetNear() const
@@ -86,9 +93,19 @@ bool OvRendering::LowRenderer::Camera::HasFrustumLightCulling() const
 	return m_frustumLightCulling;
 }
 
+OvRendering::Settings::EProjectionMode OvRendering::LowRenderer::Camera::GetProjectionMode() const
+{
+    return m_projectionMode;
+}
+
 void OvRendering::LowRenderer::Camera::SetFov(float p_value)
 {
 	m_fov = p_value;
+}
+
+void OvRendering::LowRenderer::Camera::SetSize(float p_value)
+{
+    m_size = p_value;
 }
 
 void OvRendering::LowRenderer::Camera::SetNear(float p_value)
@@ -116,9 +133,29 @@ void OvRendering::LowRenderer::Camera::SetFrustumLightCulling(bool p_enable)
 	m_frustumLightCulling = p_enable;
 }
 
+void OvRendering::LowRenderer::Camera::SetProjectionMode(OvRendering::Settings::EProjectionMode p_projectionMode)
+{
+    m_projectionMode = p_projectionMode;
+}
+
 OvMaths::FMatrix4 OvRendering::LowRenderer::Camera::CalculateProjectionMatrix(uint16_t p_windowWidth, uint16_t p_windowHeight) const
 {
-	return OvMaths::FMatrix4::CreatePerspective(m_fov, static_cast<float>(p_windowWidth) / static_cast<float>(p_windowHeight), m_near, m_far);
+    using namespace OvMaths;
+    using namespace OvRendering::Settings;
+
+    const auto ratio = p_windowWidth / static_cast<float>(p_windowHeight);
+
+    switch (m_projectionMode)
+    {
+    case EProjectionMode::ORTHOGRAPHIC:
+        return FMatrix4::CreateOrthographic(m_size, ratio, m_near, m_far);
+
+    case EProjectionMode::PERSPECTIVE: 
+        return FMatrix4::CreatePerspective(m_fov, ratio, m_near, m_far);
+
+    default:
+        return FMatrix4::Identity;
+    }
 }
 
 OvMaths::FMatrix4 OvRendering::LowRenderer::Camera::CalculateViewMatrix(const OvMaths::FVector3& p_position, const OvMaths::FQuaternion& p_rotation) const


### PR DESCRIPTION
Previously, our camera was only supporting perspective projection.
However, it is sometimes convenient to use orthographic projection
(Shadow mapping, 2D graphics, isometric games...).

- A new method has been added to `OvMaths::FMatrix4` to create an
orthographic projection matrix.

- The rendering side camera has a new `m_projectionMode` setting and
is now considering this setting for the projection calculation.
An extra `m_size` setting has been added for orthographic camera.

- The camera component has been updated to expose and serialize these new settings.

- Lua binding has been updated to support these new methods.

- Frustum drawing (Editor) has been updated to support orthographic
projection.

_Note: Adding a new serialized member to an Overload component is
currently a problem. When deserializing, we are not considering
the case when the XML file doesn't contain a certain entry, and thus, some
garbage values are sometimes loaded. A dirty check has been done in
order to prevent the camera projection setting to be a garbage value on
our old scenes (Retro-compatibility), but we should replace this by a
new safer deserialization solution._

|Orthographic|Perspective|
|-|-|
|![OrthographicProjection](https://user-images.githubusercontent.com/33324216/84551501-d9cb0e00-acdb-11ea-82f2-5a190ee165be.gif)| ![PerspectiveProjection](https://user-images.githubusercontent.com/33324216/84551503-dc2d6800-acdb-11ea-92e4-e4e598359c10.gif)|

Fixes https://github.com/adriengivry/Overload/issues/69