### PR TITLE
Unique string generation system

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -568,58 +568,16 @@ bool OvEditor::Core::EditorActions::DestroyActor(OvCore::ECS::Actor & p_actor)
 
 std::string FindDuplicatedActorUniqueName(OvCore::ECS::Actor& p_duplicated, OvCore::ECS::Actor& p_newActor, OvCore::SceneSystem::Scene& p_scene)
 {
-    const auto sourceName = p_duplicated.GetName();
-    auto sourceNameWithoutSuffix = sourceName;
-
-    auto suffixOpeningParenthesisPos = std::string::npos;
-    auto suffixClosingParenthesisPos = std::string::npos;
-
-    // Keep track of the current character position when iterating onto `sourceName`
-    auto currentPos = decltype(std::string::npos){sourceName.length() - 1};
-
-    // Here we search for `(` and `)` positions. (Needed to extract the number between those parenthesis)
-    for (auto it = sourceName.rbegin(); it < sourceName.rend(); ++it, --currentPos)
-    {
-        auto c = *it;
-
-        if (suffixClosingParenthesisPos == std::string::npos && c == ')') suffixClosingParenthesisPos = currentPos;
-        if (suffixClosingParenthesisPos != std::string::npos && c == '(') suffixOpeningParenthesisPos = currentPos;
-    }
-
-    // We need to declare our `duplicationCounter` here to store the number between found parenthesis OR 1 (In the case no parenthesis, AKA, suffix, has been found)
-    auto duplicationCounter = uint32_t{ 1 };
-
-    // If the two parenthis have been found AND the closing parenthesis is the last character AND there is a space before the opening parenthesis
-    if (suffixOpeningParenthesisPos != std::string::npos && suffixClosingParenthesisPos == sourceName.length() - 1 && suffixOpeningParenthesisPos > 0 && sourceName[suffixOpeningParenthesisPos - 1] == ' ')
-    {
-        // Extract the string between those parenthesis
-        const auto between = sourceName.substr(suffixOpeningParenthesisPos + 1, suffixClosingParenthesisPos - suffixOpeningParenthesisPos - 1);
-
-        // If the `between` string is composed of digits (AKA, `between` is a number)
-        if (!between.empty() && std::find_if(between.begin(), between.end(), [](unsigned char c) { return !std::isdigit(c); }) == between.end())
-        {
-            duplicationCounter = static_cast<uint32_t>(std::atoi(between.c_str()));
-            sourceNameWithoutSuffix = sourceName.substr(0, suffixOpeningParenthesisPos - 1);
-        }
-    }
-
     const auto parent = p_newActor.GetParent();
     const auto adjacentActors = parent ? parent->GetChildren() : p_scene.GetActors();
 
-    auto foundName = sourceNameWithoutSuffix;
-
-    // Lambda that checks if the current `foundName` is used by the actor given in parameter (Also ensure that the given actor is adjacent to our new actor)
-    // We call "adjacent" two actors that shares the same hierarchical level. (Ex: If [A] and [B] are both direction children of [C], then, they are adjacents)
-    const auto isActorNameTaken = [&foundName, parent](auto actor) { return (parent || !actor->GetParent()) && actor->GetName() == foundName; };
-
-    // While there is an adjacent actor with the current `foundName`, we keep generating new names
-    while (std::find_if(adjacentActors.begin(), adjacentActors.end(), isActorNameTaken) != adjacentActors.end())
+    auto availabilityChecker = [&parent, &adjacentActors](std::string target) -> bool
     {
-        // New names are composed of the `sourceNameWithoutSuffix` (Ex: "Cube (1)" name without suffix is "Cube")
-        foundName = sourceNameWithoutSuffix + " (" + std::to_string(duplicationCounter++) + ")";
-    }
+        const auto isActorNameTaken = [&target, parent](auto actor) { return (parent || !actor->GetParent()) && actor->GetName() == target; };
+        return std::find_if(adjacentActors.begin(), adjacentActors.end(), isActorNameTaken) == adjacentActors.end();
+    };
 
-    return foundName;
+    return OvTools::Utils::String::GenerateUnique(p_duplicated.GetName(), availabilityChecker);
 }
 
 void OvEditor::Core::EditorActions::DuplicateActor(OvCore::ECS::Actor & p_toDuplicate, OvCore::ECS::Actor* p_forcedParent, bool p_focus)

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -21,6 +21,7 @@
 #include <OvWindowing/Dialogs/OpenFileDialog.h>
 #include <OvTools/Utils/SystemCalls.h>
 #include <OvTools/Utils/PathParser.h>
+#include <OvTools/Utils/String.h>
 
 #include <OvCore/Global/ServiceLocator.h>
 #include <OvCore/ResourceManagement/ModelManager.h>
@@ -593,12 +594,14 @@ public:
 				if (size_t pos = filePathWithoutExtension.rfind('.'); pos != std::string::npos)
 					filePathWithoutExtension = filePathWithoutExtension.substr(0, pos);
 
-				std::string newNameWithoutExtension = filePathWithoutExtension + " (Copy)";
 				std::string extension = "." + OvTools::Utils::PathParser::GetExtension(filePath);
-				while (std::filesystem::exists(newNameWithoutExtension + extension))
-				{
-					newNameWithoutExtension += " (Copy)";
-				}
+
+                auto filenameAvailable = [&extension](const std::string& target)
+                {
+                    return !std::filesystem::exists(target + extension);
+                };
+
+                const auto newNameWithoutExtension = OvTools::Utils::String::GenerateUnique(filePathWithoutExtension, filenameAvailable);
 
 				std::string finalPath = newNameWithoutExtension + extension;
 				std::filesystem::copy(filePath, finalPath);

--- a/Sources/Overload/OvTools/include/OvTools/Utils/String.h
+++ b/Sources/Overload/OvTools/include/OvTools/Utils/String.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <string>
+#include <functional>
 
 #include "OvTools/API/Export.h"
 
@@ -38,5 +39,12 @@ namespace OvTools::Utils
 		* @param p_to
 		*/
 		static void ReplaceAll(std::string& p_target, const std::string& p_from, const std::string& p_to);
+
+        /**
+        * Generate a unique string satisfying the availability predicate
+        * @param p_source
+        * @param p_isAvailable (A callback that must returning true if the input string is available)
+        */
+        static std::string GenerateUnique(const std::string& p_source, std::function<bool(std::string)> p_isAvailable);
 	};
 }

--- a/Sources/Overload/OvTools/src/OvTools/Utils/String.cpp
+++ b/Sources/Overload/OvTools/src/OvTools/Utils/String.cpp
@@ -30,3 +30,51 @@ void OvTools::Utils::String::ReplaceAll(std::string& p_target, const std::string
 		start_pos += p_to.length();
 	}
 }
+
+std::string OvTools::Utils::String::GenerateUnique(const std::string& p_source, std::function<bool(std::string)> p_isAvailable)
+{
+    auto suffixlessSource = p_source;
+
+    auto suffixOpeningParenthesisPos = std::string::npos;
+    auto suffixClosingParenthesisPos = std::string::npos;
+
+    // Keep track of the current character position when iterating onto `p_source`
+    auto currentPos = decltype(std::string::npos){p_source.length() - 1};
+
+    // Here we search for `(` and `)` positions. (Needed to extract the number between those parenthesis)
+    for (auto it = p_source.rbegin(); it < p_source.rend(); ++it, --currentPos)
+    {
+        const auto c = *it;
+
+        if (suffixClosingParenthesisPos == std::string::npos && c == ')') suffixClosingParenthesisPos = currentPos;
+        if (suffixClosingParenthesisPos != std::string::npos && c == '(') suffixOpeningParenthesisPos = currentPos;
+    }
+
+    // We need to declare our `counter` here to store the number between found parenthesis OR 1 (In the case no parenthesis, AKA, suffix, has been found)
+    auto counter = uint32_t{ 1 };
+
+    // If the two parenthis have been found AND the closing parenthesis is the last character AND there is a space before the opening parenthesis
+    if (suffixOpeningParenthesisPos != std::string::npos && suffixClosingParenthesisPos == p_source.length() - 1 && suffixOpeningParenthesisPos > 0 && p_source[suffixOpeningParenthesisPos - 1] == ' ')
+    {
+        // Extract the string between those parenthesis
+        const auto between = p_source.substr(suffixOpeningParenthesisPos + 1, suffixClosingParenthesisPos - suffixOpeningParenthesisPos - 1);
+
+        // If the `between` string is composed of digits (AKA, `between` is a number)
+        if (!between.empty() && std::find_if(between.begin(), between.end(), [](unsigned char c) { return !std::isdigit(c); }) == between.end())
+        {
+            counter = static_cast<uint32_t>(std::atoi(between.c_str()));
+            suffixlessSource = p_source.substr(0, suffixOpeningParenthesisPos - 1);
+        }
+    }
+
+    auto result = suffixlessSource;
+
+    // While `result` isn't available, we keep generating new strings
+    while (!p_isAvailable(result))
+    {
+        // New strings are composed of the `suffixlessSource` (Ex: "Foo (1)" without suffix is "Foo")
+        result = suffixlessSource + " (" + std::to_string(counter++) + ")";
+    }
+
+    return result;
+}


### PR DESCRIPTION
## Sumary
This PR adds a unique string generation system, applied to asset and actor duplication.

## Description
Previously, the asset duplication naming system was adding `(Copy)` after the name of each duplicated asset. However, like in our previous actor duplication naming system, this nomenclature was very heavy and caused relatively long asset names after multiple duplications.

In order to avoid code duplication, the actor duplication naming system has been generalized in `OvTools::Utils::String` as a function able to generate a unique string satisfying a predicate.

This new function (Responsible of adding integer suffixes between parentheses) is based on the previous actor duplication naming system.

It is now used by both the asset browser and the hierarchy to generate unique names for actors and assets.

## Screenshots
![GeneralizedDuplicationNamingSystem](https://user-images.githubusercontent.com/33324216/84853766-e928bf00-b02d-11ea-952e-3a8b8abdb5e5.gif)
_Both of these windows (`AssetBrowser` and `Hierarchy`) are using the new string generation system_

Related to https://github.com/adriengivry/Overload/pull/99
Fixes https://github.com/adriengivry/Overload/issues/109