### PR TITLE
Updating the help menu

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
@@ -228,25 +228,15 @@ void OvEditor::Panels::MenuBar::CreateLayoutMenu()
 
 void OvEditor::Panels::MenuBar::CreateHelpMenu()
 {
-	auto& helpMenu = CreateWidget<MenuList>("Help");
-	helpMenu.CreateWidget<MenuItem>("Overload Documentation").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("http://overloadengine.org/doc/1.1/annotated.html"); };
-	helpMenu.CreateWidget<MenuItem>("Scripting Documentation").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("http://overloadengine.org/api/1.1"); };
-	helpMenu.CreateWidget<MenuItem>("Overload Website").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("http://overloadengine.org"); };
-
-	helpMenu.CreateWidget<Visual::Separator>();
-	auto& creditsMenu = helpMenu.CreateWidget<MenuList>("Credits");
-	auto& max = creditsMenu.CreateWidget<MenuList>("Max BRUN");
-	auto& adrien = creditsMenu.CreateWidget<MenuList>("Adrien GIVRY");
-	auto& benji = creditsMenu.CreateWidget<MenuList>("Benjamin VIRANIN");
-
-	helpMenu.CreateWidget<Visual::Separator>();
-	helpMenu.CreateWidget<Texts::Text>("Current version: 1.1.1");
-
-	max.CreateWidget<MenuItem>("Website").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("https://maxbrun.wixsite.com/maxbrundevelopment"); };
-	max.CreateWidget<MenuItem>("GitHub").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("https://github.com/maxbrundev"); };
-	adrien.CreateWidget<MenuItem>("Website").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("http://adrien-givry.com/"); };
-	adrien.CreateWidget<MenuItem>("GitHub").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("https://github.com/adriengivry"); };
-	benji.CreateWidget<MenuItem>("GitHub").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("https://github.com/BenjaminViranin"); };
+    auto& helpMenu = CreateWidget<MenuList>("Help");
+    helpMenu.CreateWidget<MenuItem>("GitHub").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("https://github.com/adriengivry/Overload"); };
+    helpMenu.CreateWidget<MenuItem>("Tutorials").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("https://github.com/adriengivry/Overload/wiki/Tutorials"); };
+    helpMenu.CreateWidget<MenuItem>("Scripting API").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("https://github.com/adriengivry/Overload/wiki/Scripting-API"); };
+    helpMenu.CreateWidget<Visual::Separator>();
+    helpMenu.CreateWidget<MenuItem>("Bug Report").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("https://github.com/adriengivry/Overload/issues/new?assignees=&labels=Bug&template=bug_report.md&title="); };
+    helpMenu.CreateWidget<MenuItem>("Feature Request").ClickedEvent += [] {OvTools::Utils::SystemCalls::OpenURL("https://github.com/adriengivry/Overload/issues/new?assignees=&labels=Feature&template=feature_request.md&title="); };
+    helpMenu.CreateWidget<Visual::Separator>();
+    helpMenu.CreateWidget<Texts::Text>("Version: 1.3.0");
 }
 
 void OvEditor::Panels::MenuBar::RegisterPanel(const std::string& p_name, OvUI::Panels::PanelWindow& p_panel)


### PR DESCRIPTION
The help menu (Accessible from the menu bar), has been updated to:

![image](https://user-images.githubusercontent.com/33324216/85343982-633cc600-b4bc-11ea-9358-dc85be530c91.png)

`Credits` section has been removed because it is redundant from what you'll find on the GitHub page. Morehover, as Overload is now a collaborative project, it will be hard to keep track of our contributors and could affect negatively the code (Lots of change in the help menu everytime a new contributor joins us).

`Overload Website` link has been removed. Actually, our website unique goal is to bring users from search engines to our GitHub page. Our long term goal is to have all Overload documentation into our Wiki instead of dispatching it accross multiple websites, thus, the website is becoming pointless for our users.

`Overload documentation`, which was a link to our sources documentation, has been removed. As Overload is now public and sources are documented, we do not need to have this online documentation. Any method/class/struct documentation can be found directly in the source code, and we should avoid having multiple ways to do the same thing to reduce maintenance costs.

Fixes https://github.com/adriengivry/Overload/issues/111

_Note: This PR isn't exactly addressing points of issue #111. However, I feel like these changes reflect more the vision of Overload's future (Documentation centralization) than the original issue._