### PR TITLE
Disable client-side decorations for project hub window.

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Core/ProjectHub.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/ProjectHub.cpp
@@ -37,9 +37,8 @@ public:
 		m_projectName(p_projectName)
 	{
 		resizable = false;
-		closable = true;
-		collapsable = false;
 		movable = false;
+		titleBar = false;
 
 		std::filesystem::create_directories(std::string(getenv("APPDATA")) + "\\OverloadTech\\OvEditor\\");
 
@@ -285,7 +284,7 @@ void OvEditor::Core::ProjectHub::SetupContext()
 	windowSettings.height = 580;
 	windowSettings.maximized = false;
 	windowSettings.resizable = false;
-	windowSettings.decorated = false;
+	windowSettings.decorated = true;
 
 	/* Window creation */
 	m_device = std::make_unique<OvWindowing::Context::Device>(deviceSettings);

--- a/Sources/Overload/OvUI/include/OvUI/Panels/PanelWindow.h
+++ b/Sources/Overload/OvUI/include/OvUI/Panels/PanelWindow.h
@@ -96,6 +96,7 @@ namespace OvUI::Panels
 		bool bringToFrontOnFocus = true;
 		bool collapsable = false;
 		bool allowInputs = true;
+		bool titleBar = true;
 
 		OvTools::Eventing::Event<> OpenEvent;
 		OvTools::Eventing::Event<> CloseEvent;

--- a/Sources/Overload/OvUI/include/OvUI/Settings/PanelWindowSettings.h
+++ b/Sources/Overload/OvUI/include/OvUI/Settings/PanelWindowSettings.h
@@ -27,6 +27,7 @@ namespace OvUI::Settings
 		bool bringToFrontOnFocus		= true;
 		bool collapsable				= false;
 		bool allowInputs				= true;
+		bool titleBar					= true;
 		bool autoSize					= false;
 	};
 }

--- a/Sources/Overload/OvUI/src/OvUI/Panels/PanelWindow.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Panels/PanelWindow.cpp
@@ -104,6 +104,7 @@ void OvUI::Panels::PanelWindow::_Draw_Impl()
 		if (!collapsable)				windowFlags |= ImGuiWindowFlags_NoCollapse;
 		if (!allowInputs)				windowFlags |= ImGuiWindowFlags_NoInputs;
         if (!scrollable)                windowFlags |= ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoScrollbar;
+		if (!titleBar)					windowFlags |= ImGuiWindowFlags_NoTitleBar;
 
 		ImVec2 minSizeConstraint = Internal::Converter::ToImVec2(minSize);
 		ImVec2 maxSizeConstraint = Internal::Converter::ToImVec2(maxSize);


### PR DESCRIPTION
Currently in project hub window there is no system title bar, only the imgui one is present. Which cannot move the window. I don't think this is desirable because `OvEditor` window does have a system title bar and thus creates an inconsistency.
This PR adds `titleBar` option to `PanelWindow` and changes the related options in `ProjectHub.cpp`. 

The result of these changes:
![image](https://user-images.githubusercontent.com/38976370/88582154-8a079280-d04e-11ea-98b0-8680dbe7f0fa.png)

