### PR TITLE
Remove GL calls from anywhere else than OvRendering

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
@@ -50,9 +50,9 @@ void OvEditor::Panels::AView::Render()
 
 	EDITOR_CONTEXT(shapeDrawer)->SetViewProjection(m_camera.GetProjectionMatrix() * m_camera.GetViewMatrix());
 
-	auto renderer = EDITOR_CONTEXT(renderer).get();
+	auto& baseRenderer = *EDITOR_CONTEXT(renderer).get();
 
-	renderer->SetViewPort(0, 0, winWidth, winHeight);
+	baseRenderer.SetViewPort(0, 0, winWidth, winHeight);
 
 	_Render_Impl();
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
@@ -50,9 +50,7 @@ void OvEditor::Panels::AView::Render()
 
 	EDITOR_CONTEXT(shapeDrawer)->SetViewProjection(m_camera.GetProjectionMatrix() * m_camera.GetViewMatrix());
 
-	auto& baseRenderer = *EDITOR_CONTEXT(renderer).get();
-
-	baseRenderer.SetViewPort(0, 0, winWidth, winHeight);
+	EDITOR_CONTEXT(renderer)->SetViewPort(0, 0, winWidth, winHeight);
 
 	_Render_Impl();
 }
@@ -115,4 +113,3 @@ void OvEditor::Panels::AView::PrepareCamera()
 	auto [winWidth, winHeight] = GetSafeSize();
 	m_camera.CacheMatrices(winWidth, winHeight, m_cameraPosition, m_cameraRotation);
 }
-

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
@@ -50,7 +50,9 @@ void OvEditor::Panels::AView::Render()
 
 	EDITOR_CONTEXT(shapeDrawer)->SetViewProjection(m_camera.GetProjectionMatrix() * m_camera.GetViewMatrix());
 
-	glViewport(0, 0, winWidth, winHeight); // TODO: Move this OpenGL call to OvRendering
+	auto renderer = EDITOR_CONTEXT(renderer).get();
+
+	renderer->SetViewPort(0, 0, winWidth, winHeight);
 
 	_Render_Impl();
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
@@ -204,7 +204,8 @@ void OvEditor::Panels::SceneView::HandleActorPicking()
 
 		m_actorPickingFramebuffer.Bind();
 		uint8_t pixel[3];
-		glReadPixels(static_cast<int>(mouseX), static_cast<int>(mouseY), 1, 1, GL_RGB, GL_UNSIGNED_BYTE, pixel);
+		auto& baseRenderer = *EDITOR_CONTEXT(renderer).get();
+		baseRenderer.ReadPixels(static_cast<int>(mouseX), static_cast<int>(mouseY), 1, 1, OvRendering::Settings::EPixelDataFormat::RGB,OvRendering::Settings::EPixelDataType::UNSIGNED_BYTE,pixel);
 		m_actorPickingFramebuffer.Unbind();
 
 		uint32_t actorID = (0 << 24) | (pixel[2] << 16) | (pixel[1] << 8) | (pixel[0] << 0);

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
@@ -204,8 +204,7 @@ void OvEditor::Panels::SceneView::HandleActorPicking()
 
 		m_actorPickingFramebuffer.Bind();
 		uint8_t pixel[3];
-		auto& baseRenderer = *EDITOR_CONTEXT(renderer).get();
-		baseRenderer.ReadPixels(static_cast<int>(mouseX), static_cast<int>(mouseY), 1, 1, OvRendering::Settings::EPixelDataFormat::RGB,OvRendering::Settings::EPixelDataType::UNSIGNED_BYTE,pixel);
+		EDITOR_CONTEXT(renderer)->ReadPixels(static_cast<int>(mouseX), static_cast<int>(mouseY), 1, 1, OvRendering::Settings::EPixelDataFormat::RGB, OvRendering::Settings::EPixelDataType::UNSIGNED_BYTE, pixel);
 		m_actorPickingFramebuffer.Unbind();
 
 		uint32_t actorID = (0 << 24) | (pixel[2] << 16) | (pixel[1] << 8) | (pixel[0] << 0);

--- a/Sources/Overload/OvRendering/OvRendering.vcxproj
+++ b/Sources/Overload/OvRendering/OvRendering.vcxproj
@@ -160,6 +160,8 @@ xcopy "$(SolutionDir)..\..\Dependencies\assimp\bin\*.dll" "$(SolutionDir)..\..\B
     <ClInclude Include="include\OvRendering\Settings\ECullFace.h" />
     <ClInclude Include="include\OvRendering\Settings\ECullingOptions.h" />
     <ClInclude Include="include\OvRendering\Settings\EOperation.h" />
+    <ClInclude Include="include\OvRendering\Settings\EPixelDataFormat.h" />
+    <ClInclude Include="include\OvRendering\Settings\EPixelDataType.h" />
     <ClInclude Include="include\OvRendering\Settings\EPrimitiveMode.h" />
     <ClInclude Include="include\OvRendering\Settings\EProjectionMode.h" />
     <ClInclude Include="include\OvRendering\Settings\ERasterizationMode.h" />

--- a/Sources/Overload/OvRendering/OvRendering.vcxproj.filters
+++ b/Sources/Overload/OvRendering/OvRendering.vcxproj.filters
@@ -135,6 +135,12 @@
     <ClInclude Include="include\OvRendering\Settings\EProjectionMode.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\OvRendering\Settings\EPixelDataFormat.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\OvRendering\Settings\EPixelDataType.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\OvRendering\Context\Driver.cpp">

--- a/Sources/Overload/OvRendering/include/OvRendering/Core/Renderer.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Core/Renderer.h
@@ -19,6 +19,8 @@
 #include "OvRendering/Settings/EOperation.h"
 #include "OvRendering/Settings/ECullFace.h"
 #include "OvRendering/Settings/ECullingOptions.h"
+#include "OvRendering/Settings/EPixelDataFormat.h"
+#include "OvRendering/Settings/EPixelDataType.h"
 
 namespace OvRendering::Core
 {
@@ -165,7 +167,19 @@ namespace OvRendering::Core
 		 * @param width
 		 * @param height
 		 */
-		void SetViewPort(uint16_t x, uint16_t y, uint16_t width, uint16_t height);
+		void SetViewPort(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+
+		/**
+		 * Read a block of pixels from the frame buffer.
+		 * @param x
+		 * @param y
+		 * @param width
+		 * @param height
+		 * @param format
+		 * @param type
+		 * @param data
+		 */
+		void ReadPixels(uint32_t x, uint32_t y, uint32_t width, uint32_t height, Settings::EPixelDataFormat format,Settings::EPixelDataType type, void* data);
 
 		/**
 		* Return the value associated to the given GLenum

--- a/Sources/Overload/OvRendering/include/OvRendering/Core/Renderer.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Core/Renderer.h
@@ -157,6 +157,16 @@ namespace OvRendering::Core
 		*/
 		void SetColorWriting(bool p_enable);
 
+
+		/**
+		 * Set the viewport parameters.
+		 * @param x
+		 * @param y
+		 * @param width
+		 * @param height
+		 */
+		void SetViewPort(uint16_t x, uint16_t y, uint16_t width, uint16_t height);
+
 		/**
 		* Return the value associated to the given GLenum
 		* @param p_parameter

--- a/Sources/Overload/OvRendering/include/OvRendering/Settings/EPixelDataFormat.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Settings/EPixelDataFormat.h
@@ -11,7 +11,7 @@
 namespace OvRendering::Settings
 {
 	/**
-	* OpenGL rendering capability enum wrapper
+	* OpenGL pixel data format enum wrapper
 	*/
 	enum class EPixelDataFormat
 	{

--- a/Sources/Overload/OvRendering/include/OvRendering/Settings/EPixelDataFormat.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Settings/EPixelDataFormat.h
@@ -1,0 +1,32 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include "OvRendering/API/Export.h"
+
+namespace OvRendering::Settings
+{
+	/**
+	* OpenGL rendering capability enum wrapper
+	*/
+	enum class EPixelDataFormat
+	{
+		COLOR_INDEX					= 0x1900,
+		STENCIL_INDEX				= 0x1901,
+		DEPTH_COMPONENT				= 0x1902,
+		RED							= 0x1903,
+		GREEN						= 0x1904,
+		BLUE						= 0x1905,
+		ALPHA						= 0x1906,
+		RGB							= 0x1907,
+		BGR							= 0x80E0,
+		RGBA						= 0x1908,
+		BGRA						= 0x80E1,
+		LUMINANCE					= 0x1909,
+		LUMINANCE_ALPHA				= 0x190A,
+	};
+}

--- a/Sources/Overload/OvRendering/include/OvRendering/Settings/EPixelDataType.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Settings/EPixelDataType.h
@@ -1,0 +1,39 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include "OvRendering/API/Export.h"
+
+namespace OvRendering::Settings
+{
+	/**
+	* OpenGL rendering capability enum wrapper
+	*/
+	enum class EPixelDataType
+	{
+		BYTE						= 0x1400,
+		UNSIGNED_BYTE				= 0x1401,
+		BITMAP						= 0x1A00,
+		SHORT						= 0x1402,
+		UNSIGNED_SHORT				= 0x1403,
+		INT							= 0x1404,
+		UNSIGNED_INT				= 0x1405,
+		FLOAT						= 0x1406,
+		UNSIGNED_BYTE_3_3_2			= 0x8032,
+		UNSIGNED_BYTE_2_3_3_REV		= 0x8362,
+		UNSIGNED_SHORT_5_6_5		= 0x8363,
+		UNSIGNED_SHORT_5_6_5_REV	= 0x8364,
+		UNSIGNED_SHORT_4_4_4_4		= 0x8033,
+		UNSIGNED_SHORT_4_4_4_4_REV	= 0x8365,
+		UNSIGNED_SHORT_5_5_5_1		= 0x8034,
+		UNSIGNED_SHORT_1_5_5_5_REV	= 0x8366,
+		UNSIGNED_INT_8_8_8_8		= 0x8035,
+		UNSIGNED_INT_8_8_8_8_REV	= 0x8367,
+		UNSIGNED_INT_10_10_10_2		= 0x8036,
+		UNSIGNED_INT_2_10_10_10_REV	= 0x8368
+	};
+}

--- a/Sources/Overload/OvRendering/include/OvRendering/Settings/EPixelDataType.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Settings/EPixelDataType.h
@@ -11,7 +11,7 @@
 namespace OvRendering::Settings
 {
 	/**
-	* OpenGL rendering capability enum wrapper
+	* OpenGL pixel data type enum wrapper
 	*/
 	enum class EPixelDataType
 	{

--- a/Sources/Overload/OvRendering/src/OvRendering/Core/Renderer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Core/Renderer.cpp
@@ -102,9 +102,14 @@ void OvRendering::Core::Renderer::SetColorWriting(bool p_enable)
 	glColorMask(p_enable, p_enable, p_enable, p_enable);
 }
 
-void OvRendering::Core::Renderer::SetViewPort(uint16_t x, uint16_t y, uint16_t width, uint16_t height)
+void OvRendering::Core::Renderer::SetViewPort(uint32_t x, uint32_t y, uint32_t width, uint32_t height)
 {
 	glViewport(x, y, width, height);
+}
+
+void OvRendering::Core::Renderer::ReadPixels(uint32_t x, uint32_t y, uint32_t width, uint32_t height, Settings::EPixelDataFormat format, Settings::EPixelDataType type, void* data)
+{
+	glReadPixels(x, y, width, height, static_cast<GLenum>(format), static_cast<GLenum>(type), data);
 }
 
 bool OvRendering::Core::Renderer::GetBool(GLenum p_parameter)

--- a/Sources/Overload/OvRendering/src/OvRendering/Core/Renderer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Core/Renderer.cpp
@@ -102,6 +102,11 @@ void OvRendering::Core::Renderer::SetColorWriting(bool p_enable)
 	glColorMask(p_enable, p_enable, p_enable, p_enable);
 }
 
+void OvRendering::Core::Renderer::SetViewPort(uint16_t x, uint16_t y, uint16_t width, uint16_t height)
+{
+	glViewport(x, y, width, height);
+}
+
 bool OvRendering::Core::Renderer::GetBool(GLenum p_parameter)
 {
 	GLboolean result;


### PR DESCRIPTION
resolves #95 

glReadPixels and glViewport wrapps into Rendering methods.

glReadPixels function uses "Format" and "Type" so I add EPixelDataFormat and EPixelDataType.

I tried to see if other gl calls existed in other files else than OvRendering but as far as I know, i could not find it.

