### PR TITLE
Fixing VS2019 MSVC16.7 no_except bug with sol2

### DIFF
--- a/Dependencies/lua/include/sol.hpp
+++ b/Dependencies/lua/include/sol.hpp
@@ -17020,7 +17020,7 @@ namespace sol {
             typedef std::remove_pointer_t<std::decay_t<Function>> function_type;
             typedef meta::bind_traits<function_type> traits_type;
 
-            static int real_call(lua_State* L) noexcept(traits_type::is_noexcept) {
+            static int real_call(lua_State* L) /* noexcept(traits_type::is_noexcept) */ {
                 auto udata = stack::stack_detail::get_as_upvalues<function_type*>(L);
                 function_type* fx = udata.first;
                 return call_detail::call_wrapped<void, true, false>(L, fx);
@@ -17155,7 +17155,7 @@ namespace sol {
             typedef std::remove_pointer_t<std::decay_t<Function>> function_type;
             typedef lua_bind_traits<function_type> traits_type;
 
-            static int real_call(lua_State* L) noexcept(traits_type::is_noexcept) {
+            static int real_call(lua_State* L) /* noexcept(traits_type::is_noexcept) */ {
                 // Layout:
                 // idx 1...n: verbatim data of member variable pointer
                 function_type& memfx = stack::get<user<function_type>>(L, upvalue_index(2));


### PR DESCRIPTION
Related to sol2 issue: https://github.com/ThePhD/sol2/issues/1008

If Microsoft fixes this compiler issue, we should revert this commit.