### PR TITLE
Hierarchy actor focus on double click

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -389,4 +389,5 @@ void OvEditor::Panels::Hierarchy::AddActorByInstance(OvCore::ECS::Actor & p_acto
 	m_widgetActorLink[targetPtr] = &textSelectable;
 
 	textSelectable.ClickedEvent += EDITOR_BIND(SelectActor, std::ref(p_actor));
+	textSelectable.DoubleClickedEvent += EDITOR_BIND(MoveToTarget, std::ref(p_actor));
 }

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/TreeNode.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/TreeNode.h
@@ -52,6 +52,7 @@ namespace OvUI::Widgets::Layout
 		bool leaf = false;
 
 		OvTools::Eventing::Event<> ClickedEvent;
+		OvTools::Eventing::Event<> DoubleClickedEvent;
 		OvTools::Eventing::Event<> OpenedEvent;
 		OvTools::Eventing::Event<> ClosedEvent;
 

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Texts/TextClickable.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Texts/TextClickable.h
@@ -29,5 +29,6 @@ namespace OvUI::Widgets::Texts
 
 	public:
 		OvTools::Eventing::Event<> ClickedEvent;
+		OvTools::Eventing::Event<> DoubleClickedEvent;
 	};
 }

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/TreeNode.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/TreeNode.cpp
@@ -51,10 +51,19 @@ void OvUI::Widgets::Layout::TreeNode::_Draw_Impl()
 	if (selected)			flags |= ImGuiTreeNodeFlags_Selected;
 	if (leaf)				flags |= ImGuiTreeNodeFlags_Leaf;
 
+    flags |= ImGuiTreeNodeFlags_OpenOnDoubleClick;
+
 	bool opened = ImGui::TreeNodeEx((name + m_widgetID).c_str(), flags);
 
-	if (ImGui::IsItemClicked() && (ImGui::GetMousePos().x - ImGui::GetItemRectMin().x) > ImGui::GetTreeNodeToLabelSpacing())
-		ClickedEvent.Invoke();
+    if (ImGui::IsItemClicked() && (ImGui::GetMousePos().x - ImGui::GetItemRectMin().x) > ImGui::GetTreeNodeToLabelSpacing())
+    {
+        ClickedEvent.Invoke();
+
+        if (ImGui::IsMouseDoubleClicked(0))
+        {
+            DoubleClickedEvent.Invoke();
+        }
+    }
 
 	if (opened)
 	{

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/TextClickable.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/TextClickable.cpp
@@ -15,6 +15,15 @@ void OvUI::Widgets::Texts::TextClickable::_Draw_Impl()
 {
 	bool useless = false;
 
-	if (ImGui::Selectable((content + m_widgetID).c_str(), &useless))
-		ClickedEvent.Invoke();
+    if (ImGui::Selectable((content + m_widgetID).c_str(), &useless, ImGuiSelectableFlags_AllowDoubleClick))
+    {
+        if (ImGui::IsMouseDoubleClicked(0))
+        {
+            DoubleClickedEvent.Invoke();
+        }
+        else
+        {
+            ClickedEvent.Invoke();
+        }
+    }
 }


### PR DESCRIPTION
Adding `DoubleClickEvent` to `TreeNode` and `TextSelectable`.
This event is now being used by the hierarchy to focus an actor when
double-clicked.

![DoubleClickActorFocus](https://user-images.githubusercontent.com/33324216/95004531-42efcd80-05ba-11eb-9d6c-8ceda36ffe5a.gif)

Fixes https://github.com/adriengivry/Overload/issues/146