### PR TITLE
Added virtual destructor for OvUI::API:IDrawable

### DIFF
--- a/Sources/Overload/OvUI/include/OvUI/API/IDrawable.h
+++ b/Sources/Overload/OvUI/include/OvUI/API/IDrawable.h
@@ -15,5 +15,8 @@ namespace OvUI::API
 	{
 	public:
 		virtual void Draw() = 0;
+
+	protected:
+		virtual ~IDrawable() = default;
 	};
 }


### PR DESCRIPTION
That very small fix should guarantee a proper destruction of IDrawable derived-classes