### PR TITLE
Adding validation to the add script button

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/Inspector.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/Inspector.h
@@ -88,6 +88,7 @@ namespace OvEditor::Panels
 		OvUI::Widgets::Layout::Group* m_actorInfo;
 		OvUI::Widgets::Layout::Group* m_inspectorHeader;
 		OvUI::Widgets::Selection::ComboBox* m_componentSelectorWidget;
+        OvUI::Widgets::InputFields::InputText* m_scriptSelectorWidget;
 
 		uint64_t m_componentAddedListener	= 0;
 		uint64_t m_componentRemovedListener = 0;

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Inspector.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Inspector.cpp
@@ -147,21 +147,45 @@ OvEditor::Panels::Inspector::Inspector
 
 	/* Script selector + button */
 	{
-		auto& scriptSelectorWidget = m_inspectorHeader->CreateWidget<OvUI::Widgets::InputFields::InputText>("");
-		scriptSelectorWidget.lineBreak = false;
-		auto& ddTarget = scriptSelectorWidget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, Layout::Group*>>>("File");
-		ddTarget.DataReceivedEvent += [&scriptSelectorWidget](std::pair<std::string, Layout::Group*> p_data)
-		{
-			scriptSelectorWidget.content = EDITOR_EXEC(GetScriptPath(p_data.first));
-		};
+		m_scriptSelectorWidget = &m_inspectorHeader->CreateWidget<OvUI::Widgets::InputFields::InputText>("");
+        m_scriptSelectorWidget->lineBreak = false;
+		auto& ddTarget = m_scriptSelectorWidget->AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, Layout::Group*>>>("File");
 		
 		auto& addScriptButton = m_inspectorHeader->CreateWidget<OvUI::Widgets::Buttons::Button>("Add Script", OvMaths::FVector2{ 100.f, 0 });
 		addScriptButton.idleBackgroundColor = OvUI::Types::Color{ 0.7f, 0.5f, 0.f };
 		addScriptButton.textColor = OvUI::Types::Color::White;
-		addScriptButton.ClickedEvent += [&scriptSelectorWidget, this]
+
+        // Add script button state updater
+        const auto updateAddScriptButton = [&addScriptButton, this](const std::string& p_script)
+        {
+            const std::string realScriptPath = EDITOR_CONTEXT(projectScriptsPath) + p_script + ".lua";
+
+            const auto targetActor = GetTargetActor();
+            const bool isScriptValid = std::filesystem::exists(realScriptPath) && targetActor && !targetActor->GetBehaviour(p_script);
+
+            addScriptButton.disabled = !isScriptValid;
+            addScriptButton.idleBackgroundColor = isScriptValid ? OvUI::Types::Color{ 0.7f, 0.5f, 0.f } : OvUI::Types::Color{ 0.1f, 0.1f, 0.1f };
+        };
+
+        m_scriptSelectorWidget->ContentChangedEvent += updateAddScriptButton;
+
+		addScriptButton.ClickedEvent += [updateAddScriptButton, this]
 		{
-			GetTargetActor()->AddBehaviour(scriptSelectorWidget.content);
+            const std::string realScriptPath = EDITOR_CONTEXT(projectScriptsPath) + m_scriptSelectorWidget->content + ".lua";
+
+            // Ensure that the script is a valid one
+            if (std::filesystem::exists(realScriptPath))
+            {
+                GetTargetActor()->AddBehaviour(m_scriptSelectorWidget->content);
+                updateAddScriptButton(m_scriptSelectorWidget->content);
+            }
 		};
+
+        ddTarget.DataReceivedEvent += [updateAddScriptButton, this](std::pair<std::string, Layout::Group*> p_data)
+        {
+            m_scriptSelectorWidget->content = EDITOR_EXEC(GetScriptPath(p_data.first));
+            updateAddScriptButton(m_scriptSelectorWidget->content);
+        };
 	}
 
 	m_inspectorHeader->CreateWidget<OvUI::Widgets::Visual::Separator>();
@@ -198,7 +222,9 @@ void OvEditor::Panels::Inspector::FocusActor(OvCore::ECS::Actor& p_target)
 
 	CreateActorInspector(p_target);
 
+    // Force component and script selectors to trigger their ChangedEvent to update button states
 	m_componentSelectorWidget->ValueChangedEvent.Invoke(m_componentSelectorWidget->currentChoice);
+    m_scriptSelectorWidget->ContentChangedEvent.Invoke(m_scriptSelectorWidget->content);
 
 	EDITOR_EVENT(ActorSelectedEvent).Invoke(*m_targetActor);
 }


### PR DESCRIPTION
Previously, it was possible to add an invalid script to an actor by
typing an incorrect script name in the script text field.

This has been fixed by adding a validation function (lambda) that is
updating the `Add Script` button state (Enabled or disabled) depending
on the content entered in the text field.

![ConCrash](https://user-images.githubusercontent.com/33324216/95021253-eafaaa80-063d-11eb-94b6-36c2d16ee4d8.gif)


Fixes https://github.com/adriengivry/Overload/issues/143