### PR TITLE
Improved actor creation menu

### DIFF
--- a/Sources/Overload/OvEditor/OvEditor.vcxproj
+++ b/Sources/Overload/OvEditor/OvEditor.vcxproj
@@ -166,6 +166,7 @@ xcopy "$(ProjectDir)Layout.ini" "$(SolutionDir)..\..\Build\$(ProjectName)\$(Conf
     <ClCompile Include="src\OvEditor\Panels\Toolbar.cpp" />
     <ClCompile Include="src\OvEditor\Resources\RawShaders.cpp" />
     <ClCompile Include="src\OvEditor\Settings\EditorSettings.cpp" />
+    <ClCompile Include="src\OvEditor\Utils\ActorCreationMenu.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\OvEditor\Core\Application.h" />
@@ -197,6 +198,7 @@ xcopy "$(ProjectDir)Layout.ini" "$(SolutionDir)..\..\Build\$(ProjectName)\$(Conf
     <ClInclude Include="include\OvEditor\Panels\ProjectSettings.h" />
     <ClInclude Include="include\OvEditor\Panels\SceneView.h" />
     <ClInclude Include="include\OvEditor\Panels\Toolbar.h" />
+    <ClInclude Include="include\OvEditor\Utils\ActorCreationMenu.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="include\OvEditor\Settings\EditorSettings.h" />
   </ItemGroup>

--- a/Sources/Overload/OvEditor/OvEditor.vcxproj.filters
+++ b/Sources/Overload/OvEditor/OvEditor.vcxproj.filters
@@ -105,6 +105,9 @@
     <ClCompile Include="src\OvEditor\Panels\AssetProperties.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\OvEditor\Utils\ActorCreationMenu.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\OvEditor\Panels\AssetBrowser.h">
@@ -198,6 +201,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\OvEditor\Panels\AssetProperties.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\OvEditor\Utils\ActorCreationMenu.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -166,8 +166,9 @@ namespace OvEditor::Core
 		* Create an empty actor
 		* @param p_focusOnCreation
 		* @param p_parent
+        * @param p_name
 		*/
-		OvCore::ECS::Actor&	CreateEmptyActor(bool p_focusOnCreation = true, OvCore::ECS::Actor* p_parent = nullptr);
+		OvCore::ECS::Actor&	CreateEmptyActor(bool p_focusOnCreation = true, OvCore::ECS::Actor* p_parent = nullptr, const std::string& p_name = "");
 
 		/**
 		* Create an actor with a model renderer and a material renderer. The model renderer with use the model identified
@@ -175,29 +176,9 @@ namespace OvEditor::Core
 		* @param p_path
 		* @param p_focusOnCreation
 		* @param p_parent
+        * @param p_name
 		*/
-		OvCore::ECS::Actor&	CreateActorWithModel(const std::string& p_path, bool p_focusOnCreation = true, OvCore::ECS::Actor* p_parent = nullptr);
-
-		/**
-		* Create an actor whith a physical box
-		* @param p_focusOnCreation
-		* @param p_parent
-		*/
-		OvCore::ECS::Actor&	CreatePhysicalBox(bool p_focusOnCreation = true, OvCore::ECS::Actor* p_parent = nullptr);
-
-		/**
-		* Create an actor whith a physical sphere
-		* @param p_focusOnCreation
-		* @param p_parent
-		*/
-		OvCore::ECS::Actor&	CreatePhysicalSphere(bool p_focusOnCreation = true, OvCore::ECS::Actor* p_parent = nullptr);
-
-		/**
-		* Create an actor whith a physical capsule
-		* @param p_focusOnCreation
-		* @param p_parent
-		*/
-		OvCore::ECS::Actor& CreatePhysicalCapsule(bool p_focusOnCreation = true, OvCore::ECS::Actor* p_parent = nullptr);
+		OvCore::ECS::Actor&	CreateActorWithModel(const std::string& p_path, bool p_focusOnCreation = true, OvCore::ECS::Actor* p_parent = nullptr, const std::string& p_name = "");
 
 		/**
 		* Destroy an actor from his scene

--- a/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.inl
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.inl
@@ -15,7 +15,9 @@ namespace OvEditor::Core
 	{
 		auto& instance = CreateEmptyActor(false, p_parent);
 
-		instance.AddComponent<T>();
+		T& component = instance.AddComponent<T>();
+
+        instance.SetName(component.GetName());
 
 		if (p_focusOnCreation)
 			SelectActor(instance);

--- a/Sources/Overload/OvEditor/include/OvEditor/Utils/ActorCreationMenu.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Utils/ActorCreationMenu.h
@@ -1,0 +1,43 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <functional>
+
+namespace OvUI::Widgets::Menu
+{
+    class MenuList;
+}
+
+namespace OvCore::ECS
+{
+    class Actor;
+}
+
+namespace OvEditor::Utils
+{
+    /**
+    * Class exposing tools to generate an actor creation menu
+    */
+    class ActorCreationMenu
+    {
+    public:
+        /**
+        * Disabled constructor
+        */
+        ActorCreationMenu() = delete;
+
+        /**
+        * Generates an actor creation menu under the given MenuList item.
+        * Also handles custom additionnal OnClick callback
+        * @param p_menuList
+        * @param p_parent
+        * @param p_onItemClicked
+        */
+        static void GenerateActorCreationMenu(OvUI::Widgets::Menu::MenuList& p_menuList, OvCore::ECS::Actor* p_parent = nullptr, std::optional<std::function<void()>> p_onItemClicked = {});
+    };
+}

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -483,9 +483,10 @@ OvMaths::FVector3 OvEditor::Core::EditorActions::CalculateActorSpawnPoint(float 
 	return sceneView.GetCameraPosition() + sceneView.GetCameraRotation() * OvMaths::FVector3::Forward * p_distanceToCamera;
 }
 
-OvCore::ECS::Actor & OvEditor::Core::EditorActions::CreateEmptyActor(bool p_focusOnCreation, OvCore::ECS::Actor* p_parent)
+OvCore::ECS::Actor & OvEditor::Core::EditorActions::CreateEmptyActor(bool p_focusOnCreation, OvCore::ECS::Actor* p_parent, const std::string& p_name)
 {
-	auto& instance = m_context.sceneManager.GetCurrentScene()->CreateActor();
+    const auto currentScene = m_context.sceneManager.GetCurrentScene();
+	auto& instance = p_name.empty() ? currentScene->CreateActor() : currentScene->CreateActor(p_name);
 
 	if (p_parent)
 		instance.SetParent(*p_parent);
@@ -501,56 +502,20 @@ OvCore::ECS::Actor & OvEditor::Core::EditorActions::CreateEmptyActor(bool p_focu
 	return instance;
 }
 
-OvCore::ECS::Actor & OvEditor::Core::EditorActions::CreateActorWithModel(const std::string& p_path, bool p_focusOnCreation, OvCore::ECS::Actor* p_parent)
+OvCore::ECS::Actor & OvEditor::Core::EditorActions::CreateActorWithModel(const std::string& p_path, bool p_focusOnCreation, OvCore::ECS::Actor* p_parent, const std::string& p_name)
 {
-	auto& instance = CreateEmptyActor(false, p_parent);
+	auto& instance = CreateEmptyActor(false, p_parent, p_name);
 
 	auto& modelRenderer = instance.AddComponent<OvCore::ECS::Components::CModelRenderer>();
 
-	auto model = m_context.modelManager[p_path];
+	const auto model = m_context.modelManager[p_path];
 	if (model)
 		modelRenderer.SetModel(model);
 
 	auto& materialRenderer = instance.AddComponent<OvCore::ECS::Components::CMaterialRenderer>();
-	auto material = m_context.materialManager[":Materials\\Default.ovmat"];
+    const auto material = m_context.materialManager[":Materials\\Default.ovmat"];
 	if (material)
 		materialRenderer.FillWithMaterial(*material);
-
-	if (p_focusOnCreation)
-		SelectActor(instance);
-
-	return instance;
-}
-
-OvCore::ECS::Actor & OvEditor::Core::EditorActions::CreatePhysicalBox(bool p_focusOnCreation, OvCore::ECS::Actor* p_parent)
-{
-	auto& instance = CreateEmptyActor(false, p_parent);
-
-	instance.AddComponent<OvCore::ECS::Components::CPhysicalBox>();
-
-	if (p_focusOnCreation)
-		SelectActor(instance);
-
-	return instance;
-}
-
-OvCore::ECS::Actor & OvEditor::Core::EditorActions::CreatePhysicalSphere(bool p_focusOnCreation, OvCore::ECS::Actor* p_parent)
-{
-	auto& instance = CreateEmptyActor(false, p_parent);
-
-	instance.AddComponent<OvCore::ECS::Components::CPhysicalSphere>();
-
-	if (p_focusOnCreation)
-		SelectActor(instance);
-
-	return instance;
-}
-
-OvCore::ECS::Actor & OvEditor::Core::EditorActions::CreatePhysicalCapsule(bool p_focusOnCreation, OvCore::ECS::Actor* p_parent)
-{
-	auto& instance = CreateEmptyActor(false, p_parent);
-
-	instance.AddComponent<OvCore::ECS::Components::CPhysicalCapsule>();
 
 	if (p_focusOnCreation)
 		SelectActor(instance);

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -31,136 +31,43 @@
 
 #include <OvUI/Plugins/ContextualMenu.h>
 
-class HierarchyActorContextualMenu : public OvUI::Plugins::ContextualMenu
+#include "OvEditor/Utils/ActorCreationMenu.h"
+
+class HierarchyContextualMenu : public OvUI::Plugins::ContextualMenu
 {
 public:
-	HierarchyActorContextualMenu(OvCore::ECS::Actor& p_target, OvUI::Widgets::Layout::TreeNode& p_treeNode) :
-		m_target(p_target), m_treeNode(p_treeNode)
-	{
-		using namespace OvUI::Panels;
-		using namespace OvUI::Widgets;
-		using namespace OvUI::Widgets::Menu;
-		using namespace OvCore::ECS::Components;
+    HierarchyContextualMenu(OvCore::ECS::Actor* p_target, OvUI::Widgets::Layout::TreeNode& p_treeNode, bool p_panelMenu = false) :
+        m_target(p_target),
+        m_treeNode(p_treeNode)
+    {
+        using namespace OvUI::Panels;
+        using namespace OvUI::Widgets;
+        using namespace OvUI::Widgets::Menu;
+        using namespace OvCore::ECS::Components;
 
-		auto& focusButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Focus");
-		focusButton.ClickedEvent += [this]
-		{
-			EDITOR_EXEC(MoveToTarget(m_target));
-		};
+        if (m_target)
+        {
+            auto& focusButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Focus");
+            focusButton.ClickedEvent += [this]
+            {
+                EDITOR_EXEC(MoveToTarget(*m_target));
+            };
 
-		auto& duplicateButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Duplicate");
-		duplicateButton.ClickedEvent += [this]
-		{
-			EDITOR_EXEC(DelayAction(EDITOR_BIND(DuplicateActor, std::ref(m_target), nullptr, true), 0));
-		};
+            auto& duplicateButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Duplicate");
+            duplicateButton.ClickedEvent += [this]
+            {
+                EDITOR_EXEC(DelayAction(EDITOR_BIND(DuplicateActor, std::ref(*m_target), nullptr, true), 0));
+            };
 
-		auto& deleteButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Delete");
-		deleteButton.ClickedEvent += [this]
-		{
-			EDITOR_EXEC(DestroyActor(std::ref(m_target)));
-		};
+            auto& deleteButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Delete");
+            deleteButton.ClickedEvent += [this]
+            {
+                EDITOR_EXEC(DestroyActor(std::ref(*m_target)));
+            };
+        }
 
 		auto& createActor = CreateWidget<OvUI::Widgets::Menu::MenuList>("Create...");
-
-		auto openParent = [this] {m_treeNode.Open(); };
-
-		auto& createEmpty = createActor.CreateWidget<MenuItem>("Create Empty");
-		createEmpty.ClickedEvent += EDITOR_BIND(CreateEmptyActor, true, &m_target);
-		createEmpty.ClickedEvent += openParent;
-
-		auto& primitives = createActor.CreateWidget<MenuList>("Primitives");
-		std::string modelsPath = ":Models\\";
-		auto& createCube = primitives.CreateWidget<MenuItem>("Cube");
-		createCube.ClickedEvent += EDITOR_BIND(CreateActorWithModel, modelsPath + "Cube.fbx", true, &m_target);
-		createCube.ClickedEvent += openParent;
-
-		auto& createSphere = primitives.CreateWidget<MenuItem>("Sphere");
-		createSphere.ClickedEvent += EDITOR_BIND(CreateActorWithModel, modelsPath + "Sphere.fbx", true, &m_target);
-		createSphere.ClickedEvent += openParent;
-
-		auto& createCone = primitives.CreateWidget<MenuItem>("Cone");
-		createCone.ClickedEvent += EDITOR_BIND(CreateActorWithModel, modelsPath + "Cone.fbx", true, &m_target);
-		createCone.ClickedEvent += openParent;
-
-		auto& createCylinder = primitives.CreateWidget<MenuItem>("Cylinder");
-		createCylinder.ClickedEvent += EDITOR_BIND(CreateActorWithModel, modelsPath + "Cylinder.fbx", true, &m_target);
-		createCylinder.ClickedEvent += openParent;
-
-		auto& createPlane = primitives.CreateWidget<MenuItem>("Plane");
-		createPlane.ClickedEvent += EDITOR_BIND(CreateActorWithModel, modelsPath + "Plane.fbx", true, &m_target);
-		createPlane.ClickedEvent += openParent;
-
-		auto& createGear = primitives.CreateWidget<MenuItem>("Gear");
-		createGear.ClickedEvent += EDITOR_BIND(CreateActorWithModel, modelsPath + "Gear.fbx", true, &m_target);
-		createGear.ClickedEvent += openParent;
-
-		auto& createHelix = primitives.CreateWidget<MenuItem>("Helix");
-		createHelix.ClickedEvent += EDITOR_BIND(CreateActorWithModel, modelsPath + "Helix.fbx", true, &m_target);
-		createHelix.ClickedEvent += openParent;
-
-		auto& createPipe = primitives.CreateWidget<MenuItem>("Pipe");
-		createPipe.ClickedEvent += EDITOR_BIND(CreateActorWithModel, modelsPath + "Pipe.fbx", true, &m_target);
-		createPipe.ClickedEvent += openParent;
-
-		auto& createPyramid = primitives.CreateWidget<MenuItem>("Pyramid");
-		createPyramid.ClickedEvent += EDITOR_BIND(CreateActorWithModel, modelsPath + "Pyramid.fbx", true, &m_target);
-		createPyramid.ClickedEvent += openParent;
-
-		auto& createTorus = primitives.CreateWidget<MenuItem>("Torus");
-		createTorus.ClickedEvent += EDITOR_BIND(CreateActorWithModel, modelsPath + "Torus.fbx", true, &m_target);
-		createTorus.ClickedEvent += openParent;
-
-		auto& physicals = createActor.CreateWidget<MenuList>("Physicals");
-
-		auto& createPhysicalBox = physicals.CreateWidget<MenuItem>("Physical Box");
-		createPhysicalBox.ClickedEvent += EDITOR_BIND(CreatePhysicalBox, true, &m_target);
-		createPhysicalBox.ClickedEvent += openParent;
-
-		auto& createPhysicalSphere = physicals.CreateWidget<MenuItem>("Physical Sphere");
-		createPhysicalSphere.ClickedEvent += EDITOR_BIND(CreatePhysicalSphere, true, &m_target);
-		createPhysicalSphere.ClickedEvent += openParent;
-
-		auto& createPhysicalCapsule = physicals.CreateWidget<MenuItem>("Physical Capsule");
-		createPhysicalCapsule.ClickedEvent += EDITOR_BIND(CreatePhysicalCapsule, true, &m_target);
-		createPhysicalCapsule.ClickedEvent += openParent;
-
-		auto& lights = createActor.CreateWidget<MenuList>("Lights");
-
-		auto& createPoint = lights.CreateWidget<MenuItem>("Point");
-		createPoint.ClickedEvent += EDITOR_BIND(CreateMonoComponentActor<CPointLight>, true, &m_target);
-		createPoint.ClickedEvent += openParent;
-
-		auto& createDirectional = lights.CreateWidget<MenuItem>("Directional");
-		createDirectional.ClickedEvent += EDITOR_BIND(CreateMonoComponentActor<CDirectionalLight>, true, &m_target);
-		createDirectional.ClickedEvent += openParent;
-
-		auto& createSpot = lights.CreateWidget<MenuItem>("Spot");
-		createSpot.ClickedEvent += EDITOR_BIND(CreateMonoComponentActor<CSpotLight>, true, &m_target);
-		createSpot.ClickedEvent += openParent;
-
-		auto& createAmbientBox = lights.CreateWidget<MenuItem>("Ambient Box");
-		createAmbientBox.ClickedEvent += EDITOR_BIND(CreateMonoComponentActor<CAmbientBoxLight>, true, &m_target);
-		createAmbientBox.ClickedEvent += openParent;
-
-		auto& createAmbientSphere = lights.CreateWidget<MenuItem>("Ambient Sphere");
-		createAmbientSphere.ClickedEvent += EDITOR_BIND(CreateMonoComponentActor<CAmbientSphereLight>, true, &m_target);
-		createAmbientSphere.ClickedEvent += openParent;
-
-		auto& audio = createActor.CreateWidget<MenuList>("Audio");
-
-		auto& createAudioSource = audio.CreateWidget<MenuItem>("Audio Source");
-		createAudioSource.ClickedEvent += EDITOR_BIND(CreateMonoComponentActor<CAudioSource>, true, &m_target);
-		createAudioSource.ClickedEvent += openParent;
-
-		auto& createAudioListener = audio.CreateWidget<MenuItem>("Audio Listener");
-		createAudioListener.ClickedEvent += EDITOR_BIND(CreateMonoComponentActor<CAudioListener>, true, &m_target);
-		createAudioListener.ClickedEvent += openParent;
-
-		auto& others = createActor.CreateWidget<MenuList>("Others");
-
-		auto& createCamera = others.CreateWidget<MenuItem>("Camera");
-		createCamera.ClickedEvent += EDITOR_BIND(CreateMonoComponentActor<CCamera>, true, &m_target);
-		createCamera.ClickedEvent += openParent;
+        OvEditor::Utils::ActorCreationMenu::GenerateActorCreationMenu(createActor, m_target, std::bind(&OvUI::Widgets::Layout::TreeNode::Open, &m_treeNode));
 	}
 
 	virtual void Execute() override
@@ -170,7 +77,7 @@ public:
 	}
 
 private:
-	OvCore::ECS::Actor& m_target;
+	OvCore::ECS::Actor* m_target;
 	OvUI::Widgets::Layout::TreeNode& m_treeNode;
 };
 
@@ -269,6 +176,7 @@ OvEditor::Panels::Hierarchy::Hierarchy
 
 		p_element.first->DetachFromParent();
 	};
+    m_sceneRoot->AddPlugin<HierarchyContextualMenu>(nullptr, *m_sceneRoot);
 
 	EDITOR_EVENT(ActorUnselectedEvent) += std::bind(&Hierarchy::UnselectActorsWidgets, this);
 	EDITOR_CONTEXT(sceneManager).SceneUnloadEvent += std::bind(&Hierarchy::Clear, this);
@@ -370,7 +278,7 @@ void OvEditor::Panels::Hierarchy::AddActorByInstance(OvCore::ECS::Actor & p_acto
 {
 	auto& textSelectable = m_sceneRoot->CreateWidget<OvUI::Widgets::Layout::TreeNode>(p_actor.GetName(), true);
 	textSelectable.leaf = true;
-	textSelectable.AddPlugin<HierarchyActorContextualMenu>(p_actor, textSelectable);
+	textSelectable.AddPlugin<HierarchyContextualMenu>(&p_actor, textSelectable);
 	textSelectable.AddPlugin<OvUI::Plugins::DDSource<std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*>>>("Actor", "Attach to...", std::make_pair(&p_actor, &textSelectable));
 	textSelectable.AddPlugin<OvUI::Plugins::DDTarget<std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*>>>("Actor").DataReceivedEvent += [&p_actor, &textSelectable](std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*> p_element)
 	{

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
@@ -29,6 +29,7 @@
 #include "OvEditor/Panels/AssetView.h"
 #include "OvEditor/Core/EditorActions.h"
 #include "OvEditor/Settings/EditorSettings.h"
+#include "OvEditor/Utils/ActorCreationMenu.h"
 
 using namespace OvUI::Panels;
 using namespace OvUI::Widgets;
@@ -98,40 +99,7 @@ void OvEditor::Panels::MenuBar::CreateWindowMenu()
 void OvEditor::Panels::MenuBar::CreateActorsMenu()
 {
 	auto& actorsMenu = CreateWidget<MenuList>("Actors");
-
-	actorsMenu.CreateWidget<MenuItem>("Create Empty").ClickedEvent += EDITOR_BIND(CreateEmptyActor, true, nullptr);
-
-	auto& primitives = actorsMenu.CreateWidget<MenuList>("Primitives");
-	std::string modelsPath = ":Models\\";
-	primitives.CreateWidget<MenuItem>("Cube").ClickedEvent		+= EDITOR_BIND(CreateActorWithModel, modelsPath + "Cube.fbx", true, nullptr);
-	primitives.CreateWidget<MenuItem>("Sphere").ClickedEvent	+= EDITOR_BIND(CreateActorWithModel, modelsPath + "Sphere.fbx", true, nullptr);
-	primitives.CreateWidget<MenuItem>("Cone").ClickedEvent		+= EDITOR_BIND(CreateActorWithModel, modelsPath + "Cone.fbx", true, nullptr);
-	primitives.CreateWidget<MenuItem>("Cylinder").ClickedEvent	+= EDITOR_BIND(CreateActorWithModel, modelsPath + "Cylinder.fbx", true, nullptr);
-	primitives.CreateWidget<MenuItem>("Plane").ClickedEvent		+= EDITOR_BIND(CreateActorWithModel, modelsPath + "Plane.fbx", true, nullptr);
-	primitives.CreateWidget<MenuItem>("Gear").ClickedEvent		+= EDITOR_BIND(CreateActorWithModel, modelsPath + "Gear.fbx", true, nullptr);
-	primitives.CreateWidget<MenuItem>("Helix").ClickedEvent		+= EDITOR_BIND(CreateActorWithModel, modelsPath + "Helix.fbx", true, nullptr);
-	primitives.CreateWidget<MenuItem>("Pipe").ClickedEvent		+= EDITOR_BIND(CreateActorWithModel, modelsPath + "Pipe.fbx", true, nullptr);
-	primitives.CreateWidget<MenuItem>("Pyramid").ClickedEvent	+= EDITOR_BIND(CreateActorWithModel, modelsPath + "Pyramid.fbx", true, nullptr);
-	primitives.CreateWidget<MenuItem>("Torus").ClickedEvent		+= EDITOR_BIND(CreateActorWithModel, modelsPath + "Torus.fbx", true, nullptr);
-
-	auto& physicals = actorsMenu.CreateWidget<MenuList>("Physicals");
-	physicals.CreateWidget<MenuItem>("Physical Box").ClickedEvent		+= EDITOR_BIND(CreatePhysicalBox, true, nullptr);
-	physicals.CreateWidget<MenuItem>("Physical Sphere").ClickedEvent	+= EDITOR_BIND(CreatePhysicalSphere, true, nullptr);
-	physicals.CreateWidget<MenuItem>("Physical Capsule").ClickedEvent	+= EDITOR_BIND(CreatePhysicalCapsule, true, nullptr);
-
-	auto& lights = actorsMenu.CreateWidget<MenuList>("Lights");
-	lights.CreateWidget<MenuItem>("Point").ClickedEvent				+= EDITOR_BIND(CreateMonoComponentActor<CPointLight>, true, nullptr);
-	lights.CreateWidget<MenuItem>("Directional").ClickedEvent		+= EDITOR_BIND(CreateMonoComponentActor<CDirectionalLight>, true, nullptr);
-	lights.CreateWidget<MenuItem>("Spot").ClickedEvent				+= EDITOR_BIND(CreateMonoComponentActor<CSpotLight>, true, nullptr);
-	lights.CreateWidget<MenuItem>("Ambient Box").ClickedEvent		+= EDITOR_BIND(CreateMonoComponentActor<CAmbientBoxLight>, true, nullptr);
-	lights.CreateWidget<MenuItem>("Ambient Sphere").ClickedEvent	+= EDITOR_BIND(CreateMonoComponentActor<CAmbientSphereLight>, true, nullptr);
-
-	auto& audio = actorsMenu.CreateWidget<MenuList>("Audio");
-	audio.CreateWidget<MenuItem>("Audio Source").ClickedEvent	+= EDITOR_BIND(CreateMonoComponentActor<CAudioSource>, true, nullptr);
-	audio.CreateWidget<MenuItem>("Audio Listener").ClickedEvent += EDITOR_BIND(CreateMonoComponentActor<CAudioListener>, true, nullptr);
-
-	auto& others = actorsMenu.CreateWidget<MenuList>("Others");
-	others.CreateWidget<MenuItem>("Camera").ClickedEvent += EDITOR_BIND(CreateMonoComponentActor<CCamera>, true, nullptr);
+    Utils::ActorCreationMenu::GenerateActorCreationMenu(actorsMenu);
 }
 
 void OvEditor::Panels::MenuBar::CreateResourcesMenu()

--- a/Sources/Overload/OvEditor/src/OvEditor/Utils/ActorCreationMenu.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Utils/ActorCreationMenu.cpp
@@ -1,0 +1,83 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <OvUI/Widgets/Menu/MenuList.h>
+#include <OvUI/Widgets/Menu/MenuItem.h>
+
+#include <OvCore/ECS/Components/CPhysicalBox.h>
+#include <OvCore/ECS/Components/CPhysicalSphere.h>
+#include <OvCore/ECS/Components/CPhysicalCapsule.h>
+#include <OvCore/ECS/Components/CPointLight.h>
+#include <OvCore/ECS/Components/CDirectionalLight.h>
+#include <OvCore/ECS/Components/CSpotLight.h>
+#include <OvCore/ECS/Components/CAmbientSphereLight.h>
+#include <OvCore/ECS/Components/CAudioSource.h>
+#include <OvCore/ECS/Components/CAudioListener.h>
+#include <OvCore/ECS/Components/CCamera.h>
+
+#include "OvEditor/Core/EditorActions.h"
+#include "OvEditor/Utils/ActorCreationMenu.h"
+
+std::function<void()> Combine(std::function<void()> p_a, std::optional<std::function<void()>> p_b)
+{
+    if (p_b.has_value())
+    {
+        return [=]()
+        {
+            p_a();
+            p_b.value()();
+        };
+    }
+
+    return p_a;
+}
+
+template<class T>
+std::function<void()> ActorWithComponentCreationHandler(OvCore::ECS::Actor* p_parent, std::optional<std::function<void()>> p_onItemClicked)
+{
+    return Combine(EDITOR_BIND(CreateMonoComponentActor<T>, true, p_parent), p_onItemClicked);
+}
+
+std::function<void()> ActorWithModelComponentCreationHandler(OvCore::ECS::Actor* p_parent, const std::string& p_modelName, std::optional<std::function<void()>> p_onItemClicked)
+{
+    return Combine(EDITOR_BIND(CreateActorWithModel, ":Models\\" + p_modelName + ".fbx", true, p_parent, p_modelName), p_onItemClicked);
+}
+
+void OvEditor::Utils::ActorCreationMenu::GenerateActorCreationMenu(OvUI::Widgets::Menu::MenuList& p_menuList, OvCore::ECS::Actor* p_parent, std::optional<std::function<void()>> p_onItemClicked)
+{
+    using namespace OvUI::Widgets::Menu;
+    using namespace OvCore::ECS::Components;
+
+    p_menuList.CreateWidget<MenuItem>("Create Empty").ClickedEvent += Combine(EDITOR_BIND(CreateEmptyActor, true, p_parent, ""), p_onItemClicked);
+
+    auto& primitives = p_menuList.CreateWidget<MenuList>("Primitives");
+    auto& physicals = p_menuList.CreateWidget<MenuList>("Physicals");
+    auto& lights = p_menuList.CreateWidget<MenuList>("Lights");
+    auto& audio = p_menuList.CreateWidget<MenuList>("Audio");
+    auto& others = p_menuList.CreateWidget<MenuList>("Others");
+
+    primitives.CreateWidget<MenuItem>("Cube").ClickedEvent              += ActorWithModelComponentCreationHandler(p_parent, "Cube", p_onItemClicked);
+    primitives.CreateWidget<MenuItem>("Sphere").ClickedEvent            += ActorWithModelComponentCreationHandler(p_parent, "Sphere", p_onItemClicked);
+    primitives.CreateWidget<MenuItem>("Cone").ClickedEvent              += ActorWithModelComponentCreationHandler(p_parent, "Cone", p_onItemClicked);
+    primitives.CreateWidget<MenuItem>("Cylinder").ClickedEvent          += ActorWithModelComponentCreationHandler(p_parent, "Cylinder", p_onItemClicked);
+    primitives.CreateWidget<MenuItem>("Plane").ClickedEvent             += ActorWithModelComponentCreationHandler(p_parent, "Plane", p_onItemClicked);
+    primitives.CreateWidget<MenuItem>("Gear").ClickedEvent              += ActorWithModelComponentCreationHandler(p_parent, "Gear", p_onItemClicked);
+    primitives.CreateWidget<MenuItem>("Helix").ClickedEvent             += ActorWithModelComponentCreationHandler(p_parent, "Helix", p_onItemClicked);
+    primitives.CreateWidget<MenuItem>("Pipe").ClickedEvent              += ActorWithModelComponentCreationHandler(p_parent, "Pipe", p_onItemClicked);
+    primitives.CreateWidget<MenuItem>("Pyramid").ClickedEvent           += ActorWithModelComponentCreationHandler(p_parent, "Pyramid", p_onItemClicked);
+    primitives.CreateWidget<MenuItem>("Torus").ClickedEvent             += ActorWithModelComponentCreationHandler(p_parent, "Torus", p_onItemClicked);
+    physicals.CreateWidget<MenuItem>("Physical Box").ClickedEvent       += ActorWithComponentCreationHandler<CPhysicalBox>(p_parent, p_onItemClicked);
+    physicals.CreateWidget<MenuItem>("Physical Sphere").ClickedEvent    += ActorWithComponentCreationHandler<CPhysicalSphere>(p_parent, p_onItemClicked);
+    physicals.CreateWidget<MenuItem>("Physical Capsule").ClickedEvent   += ActorWithComponentCreationHandler<CPhysicalCapsule>(p_parent, p_onItemClicked);
+    lights.CreateWidget<MenuItem>("Point").ClickedEvent                 += ActorWithComponentCreationHandler<CPointLight>(p_parent, p_onItemClicked);
+    lights.CreateWidget<MenuItem>("Directional").ClickedEvent           += ActorWithComponentCreationHandler<CDirectionalLight>(p_parent, p_onItemClicked);
+    lights.CreateWidget<MenuItem>("Spot").ClickedEvent                  += ActorWithComponentCreationHandler<CSpotLight>(p_parent, p_onItemClicked);
+    lights.CreateWidget<MenuItem>("Ambient Box").ClickedEvent           += ActorWithComponentCreationHandler<CAmbientBoxLight>(p_parent, p_onItemClicked);
+    lights.CreateWidget<MenuItem>("Ambient Sphere").ClickedEvent        += ActorWithComponentCreationHandler<CAmbientSphereLight>(p_parent, p_onItemClicked);
+    audio.CreateWidget<MenuItem>("Audio Source").ClickedEvent           += ActorWithComponentCreationHandler<CAudioSource>(p_parent, p_onItemClicked);
+    audio.CreateWidget<MenuItem>("Audio Listener").ClickedEvent         += ActorWithComponentCreationHandler<CAudioListener>(p_parent, p_onItemClicked);
+    others.CreateWidget<MenuItem>("Camera").ClickedEvent                += ActorWithComponentCreationHandler<CCamera>(p_parent, p_onItemClicked);
+}


### PR DESCRIPTION
The actor creation menu had duplicated code. It actually was implemented twice (In `MenuBar` and `Hierarchy`). To avoid that, an `OvEditor/Utils/` folder has been added with an `ActorCreationMenu` class. This class exposes a function that generates an actor creation menu.

It is now also possible to create a new actor by right-clicking onto the `Root` node in the hierarchy.

This PR also changes the default name of created actors.
Previously, creating an actor resulted in an actor named "New Actor".
Now, the name of the created actor depends on its type (Camera, Cube, Sphere, Physical Box...)

![ActorCreationMenu](https://user-images.githubusercontent.com/33324216/95028866-9d983080-0671-11eb-8fe6-519a7757be6a.gif)

