### PR TITLE
Improved grid and view backgrounds

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/AView.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/AView.h
@@ -118,7 +118,7 @@ namespace OvEditor::Panels
 		OvMaths::FQuaternion m_cameraRotation;
 		OvUI::Widgets::Visual::Image* m_image;
 
-		OvMaths::FVector3 m_gridColor = OvMaths::FVector3::One;
+        OvMaths::FVector3 m_gridColor = OvMaths::FVector3 { 0.176f, 0.176f, 0.176f };
 
 		OvRendering::Buffers::Framebuffer m_fbo;
 	};

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorRenderer.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorRenderer.cpp
@@ -815,9 +815,15 @@ void OvEditor::Core::EditorRenderer::RenderMaterialAsset(OvCore::Resources::Mate
 
 void OvEditor::Core::EditorRenderer::RenderGrid(const OvMaths::FVector3& p_viewPos, const OvMaths::FVector3& p_color)
 {
-	FMatrix4 model = FMatrix4::Scaling({ 1000.f, 1.f, 1000.f });
+    constexpr float gridSize = 5000.0f;
+
+    FMatrix4 model = FMatrix4::Translation({ p_viewPos.x, 0.0f, p_viewPos.z }) * FMatrix4::Scaling({ gridSize * 2.0f, 1.f, gridSize * 2.0f });
 	m_gridMaterial.Set("u_Color", p_color);
 	m_context.renderer->DrawModelWithSingleMaterial(*m_context.editorResources->GetModel("Plane"), m_gridMaterial, &model);
+
+    m_context.shapeDrawer->DrawLine(OvMaths::FVector3(-gridSize + p_viewPos.x, 0.0f, 0.0f), OvMaths::FVector3(gridSize + p_viewPos.x, 0.0f, 0.0f), OvMaths::FVector3(1.0f, 0.0f, 0.0f), 1.0f);
+    m_context.shapeDrawer->DrawLine(OvMaths::FVector3(0.0f, -gridSize + p_viewPos.y, 0.0f), OvMaths::FVector3(0.0f, gridSize + p_viewPos.y, 0.0f), OvMaths::FVector3(0.0f, 1.0f, 0.0f), 1.0f);
+    m_context.shapeDrawer->DrawLine(OvMaths::FVector3(0.0f, 0.0f, -gridSize + p_viewPos.z), OvMaths::FVector3(0.0f, 0.0f, gridSize + p_viewPos.z), OvMaths::FVector3(0.0f, 0.0f, 1.0f), 1.0f);
 }
 
 void OvEditor::Core::EditorRenderer::UpdateLights(OvCore::SceneSystem::Scene& p_scene)

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetView.cpp
@@ -19,8 +19,8 @@ OvEditor::Panels::AssetView::AssetView
 	const OvUI::Settings::PanelWindowSettings& p_windowSettings
 ) : AViewControllable(p_title, p_opened, p_windowSettings)
 {
-	m_camera.SetClearColor({ 0.278f, 0.278f, 0.278f });
-	m_camera.SetFar(1000.0f);
+	m_camera.SetClearColor({ 0.098f, 0.098f, 0.098f });
+	m_camera.SetFar(5000.0f);
 
 	m_resource = static_cast<OvRendering::Resources::Model*>(nullptr);
 	m_image->AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent += [this](auto p_data)

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
@@ -155,51 +155,51 @@ void OvEditor::Panels::MenuBar::CreateSettingsMenu()
 
 	auto& viewColors = settingsMenu.CreateWidget<MenuList>("View Colors");
 	auto& sceneViewBackground = viewColors.CreateWidget<MenuList>("Scene View Background");
-	auto& sceneViewBackgroundPicker = sceneViewBackground.CreateWidget<Selection::ColorEdit>(false, OvUI::Types::Color{ 0.278f, 0.278f, 0.278f });
+	auto& sceneViewBackgroundPicker = sceneViewBackground.CreateWidget<Selection::ColorEdit>(false, OvUI::Types::Color{ 0.098f, 0.098f, 0.098f });
 	sceneViewBackgroundPicker.ColorChangedEvent += [this](const auto & color)
 	{
 		EDITOR_PANEL(Panels::SceneView, "Scene View").GetCamera().SetClearColor({ color.r, color.g, color.b });
 	};
 	sceneViewBackground.CreateWidget<MenuItem>("Reset").ClickedEvent += [this, &sceneViewBackgroundPicker]
 	{
-		EDITOR_PANEL(Panels::SceneView, "Scene View").GetCamera().SetClearColor({ 0.278f, 0.278f, 0.278f });
-		sceneViewBackgroundPicker.color = { 0.278f, 0.278f, 0.278f };
+		EDITOR_PANEL(Panels::SceneView, "Scene View").GetCamera().SetClearColor({ 0.098f, 0.098f, 0.098f });
+		sceneViewBackgroundPicker.color = { 0.098f, 0.098f, 0.098f };
 	};
 
 	auto& sceneViewGrid = viewColors.CreateWidget<MenuList>("Scene View Grid");
-	auto& sceneViewGridPicker = sceneViewGrid.CreateWidget<Selection::ColorEdit>(false, OvUI::Types::Color::White);
+    auto& sceneViewGridPicker = sceneViewGrid.CreateWidget<Selection::ColorEdit>(false, OvUI::Types::Color(0.176f, 0.176f, 0.176f));
 	sceneViewGridPicker.ColorChangedEvent += [this](const auto & color)
 	{
 		EDITOR_PANEL(Panels::SceneView, "Scene View").SetGridColor({ color.r, color.g, color.b });
 	};
 	sceneViewGrid.CreateWidget<MenuItem>("Reset").ClickedEvent += [this, &sceneViewGridPicker]
 	{
-		EDITOR_PANEL(Panels::SceneView, "Scene View").SetGridColor(OvMaths::FVector3::One);
-		sceneViewGridPicker.color = OvUI::Types::Color::White;
+		EDITOR_PANEL(Panels::SceneView, "Scene View").SetGridColor(OvMaths::FVector3(0.176f, 0.176f, 0.176f));
+		sceneViewGridPicker.color = OvUI::Types::Color(0.176f, 0.176f, 0.176f);
 	};
 
 	auto& assetViewBackground = viewColors.CreateWidget<MenuList>("Asset View Background");
-	auto& assetViewBackgroundPicker = assetViewBackground.CreateWidget<Selection::ColorEdit>(false, OvUI::Types::Color{ 0.278f, 0.278f, 0.278f });
+	auto& assetViewBackgroundPicker = assetViewBackground.CreateWidget<Selection::ColorEdit>(false, OvUI::Types::Color{ 0.098f, 0.098f, 0.098f });
 	assetViewBackgroundPicker.ColorChangedEvent += [this](const auto & color)
 	{
 		EDITOR_PANEL(Panels::AssetView, "Asset View").GetCamera().SetClearColor({ color.r, color.g, color.b });
 	};
 	assetViewBackground.CreateWidget<MenuItem>("Reset").ClickedEvent += [this, &assetViewBackgroundPicker]
 	{
-		EDITOR_PANEL(Panels::AssetView, "Asset View").GetCamera().SetClearColor({ 0.278f, 0.278f, 0.278f });
-		assetViewBackgroundPicker.color = { 0.278f, 0.278f, 0.278f };
+		EDITOR_PANEL(Panels::AssetView, "Asset View").GetCamera().SetClearColor({ 0.098f, 0.098f, 0.098f });
+		assetViewBackgroundPicker.color = { 0.098f, 0.098f, 0.098f };
 	};
 
 	auto& assetViewGrid = viewColors.CreateWidget<MenuList>("Asset View Grid");
-	auto& assetViewGridPicker = assetViewGrid.CreateWidget<Selection::ColorEdit>(false, OvUI::Types::Color::White);
+	auto& assetViewGridPicker = assetViewGrid.CreateWidget<Selection::ColorEdit>(false, OvUI::Types::Color(0.176f, 0.176f, 0.176f));
 	assetViewGridPicker.ColorChangedEvent += [this](const auto & color)
 	{
 		EDITOR_PANEL(Panels::AssetView, "Asset View").SetGridColor({ color.r, color.g, color.b });
 	};
 	assetViewGrid.CreateWidget<MenuItem>("Reset").ClickedEvent += [this, &assetViewGridPicker]
 	{
-		EDITOR_PANEL(Panels::AssetView, "Asset View").SetGridColor(OvMaths::FVector3::One);
-		assetViewGridPicker.color = OvUI::Types::Color::White;
+		EDITOR_PANEL(Panels::AssetView, "Asset View").SetGridColor(OvMaths::FVector3(0.176f, 0.176f, 0.176f));
+		assetViewGridPicker.color = OvUI::Types::Color(0.176f, 0.176f, 0.176f);
 	};
 
 	auto& sceneViewBillboardScaleMenu = settingsMenu.CreateWidget<MenuList>("3D Icons Scales");

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
@@ -20,8 +20,8 @@ OvEditor::Panels::SceneView::SceneView
 ) : AViewControllable(p_title, p_opened, p_windowSettings, true),
 	m_sceneManager(EDITOR_CONTEXT(sceneManager))
 {
-	m_camera.SetClearColor({ 0.278f, 0.278f, 0.278f });
-	m_camera.SetFar(1000.0f);
+	m_camera.SetClearColor({ 0.098f, 0.098f, 0.098f });
+	m_camera.SetFar(5000.0f);
 
 	m_image->AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent += [this](auto p_data)
 	{

--- a/Sources/Overload/OvEditor/src/OvEditor/Resources/RawShaders.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Resources/RawShaders.cpp
@@ -35,7 +35,7 @@ out VS_OUT
 void main()
 {
     vs_out.FragPos      = vec3(ubo_Model * vec4(geo_Pos, 1.0));
-    vs_out.TexCoords    = geo_TexCoords;
+    vs_out.TexCoords    = vs_out.FragPos.xz;
 
     gl_Position = ubo_Projection * ubo_View * vec4(vs_out.FragPos, 1.0);
 }
@@ -63,52 +63,51 @@ in VS_OUT
 
 uniform vec3 u_Color;
 
-const float divisions = 1000.0f;
-const float lineWidth = 1.0f;
-const float step = 100.0f;
-const float subdivisions = 4.0f;
-
-vec4 Grid(float p_divisions)
+float MAG(float p_lp)
 {
-    // Pick a coordinate to visualize in a grid
-    vec2 coord = fs_in.TexCoords.xy * p_divisions;
+  const float lineWidth = 1.0f;
 
-    // Compute anti-aliased world-space grid lines
-    vec2 grid = abs(fract(coord - 0.5) - 0.5) / fwidth(coord);
-    float line = min(grid.x, grid.y);
-    float lineResult = lineWidth - min(line, lineWidth);
+  const vec2 coord       = fs_in.TexCoords / p_lp;
+  const vec2 grid        = abs(fract(coord - 0.5) - 0.5) / fwidth(coord);
+  const float line       = min(grid.x, grid.y);
+  const float lineResult = lineWidth - min(line, lineWidth);
 
-    // Just visualize the grid lines directly
-    vec3 fakeViewPos = ubo_ViewPos;
-    fakeViewPos.y = 0.0f;
-    return vec4(vec3(lineResult) * u_Color, 0.05 * lineResult);
+  return lineResult;
+}
+
+float Grid(float height, float a, float b, float c)
+{
+  const float cl   = MAG(a);
+  const float ml   = MAG(b);
+  const float fl   = MAG(c);
+
+  const float cmit =  10.0f;
+  const float cmet =  40.0f;
+  const float mfit =  80.0f;
+  const float mfet =  160.0f;
+
+  const float df   = clamp((height - cmit) / (cmet - cmit), 0.0f, 1.0f);
+  const float dff  = clamp((height - mfit) / (mfet - mfit), 0.0f, 1.0f);
+
+  const float inl  = mix(cl, ml, df);
+  const float fnl  = mix(inl, fl, dff);
+
+  return fnl;
 }
 
 void main()
 {
-	float divs;
+  const float height = distance(ubo_ViewPos.y, fs_in.FragPos.y);
 
-	divs = divisions / pow(2, round((abs(ubo_ViewPos.y) - step / subdivisions) / step));
-	vec4 grid1 = Grid(divs) + Grid(divs / subdivisions);
+  const float gridA = Grid(height, 1.0f, 4.0f, 8.0f);
+  const float gridB = Grid(height, 4.0f, 16.0f, 32.0f);
 
-	divs = divisions / pow(2, round((abs(ubo_ViewPos.y + 50) - step / subdivisions) / step));
-	vec4 grid2 = Grid(divs) + Grid(divs / subdivisions);
+  const float grid  = gridA * 0.5f + gridB;
 
-	float alpha = mod(abs(ubo_ViewPos.y), step);
-	alpha = 0.0;
-
-    FRAGMENT_COLOR = mix(grid1, grid2, alpha);
-
-    vec3 pseudoViewPos = vec3(ubo_ViewPos.x, fs_in.FragPos.y, ubo_ViewPos.z);
-    float distanceToCamera = max(distance(fs_in.FragPos, pseudoViewPos) - abs(ubo_ViewPos.y), 0);
-    
-    float alphaDecreaseDistance = 20.0f;
-    float decreaseDistance = 30.0f;
-    if (distanceToCamera > alphaDecreaseDistance)
-    {
-        float normalizedDistanceToCamera = clamp(distanceToCamera - alphaDecreaseDistance, 0.0f, decreaseDistance) / decreaseDistance;
-        FRAGMENT_COLOR.a *= clamp(1.0f - normalizedDistanceToCamera, 0.0f, 1.0f);
-    }
+  const vec2  viewdirW    = ubo_ViewPos.xz - fs_in.FragPos.xz;
+  const float viewdist    = length(viewdirW);
+  
+  FRAGMENT_COLOR = vec4(u_Color, grid);
 }
 )";
 


### PR DESCRIPTION
Improving the grid. New shader, colors, scale.
The `SceneView` and `AssetView` background have also been updated to match
the new grid.

The grid has been largely scaled up, so it should fix the issue #157

The grid has a size of `5000.0,` while the far plane of `SceneView` and `AssetView` have been pushed to `5000.0`. The grid is also following the editor camera, meaning that you theorically can't see it's limit (Excepted if you go far in Y)

### New grid look
![image](https://user-images.githubusercontent.com/33324216/95276852-526d5180-081a-11eb-9cfd-8a3ab95785e3.png)

### Still customizable
![image](https://user-images.githubusercontent.com/33324216/95276909-79c41e80-081a-11eb-914d-c42fd78ad082.png)
![image](https://user-images.githubusercontent.com/33324216/95276935-86487700-081a-11eb-8803-806ac7271aa9.png)

### Infinite on X and Z
![image](https://user-images.githubusercontent.com/33324216/95276983-a5df9f80-081a-11eb-9b19-2a0399aac48d.png)

### Limitations on Y axis (Far clipping)
![image](https://user-images.githubusercontent.com/33324216/95277021-c6a7f500-081a-11eb-8db1-c27c5ba0e7e8.png)
![image](https://user-images.githubusercontent.com/33324216/95277037-d0315d00-081a-11eb-84f0-81cb5309c2c0.png)


Fixes https://github.com/adriengivry/Overload/issues/157

