### PR TITLE
Increasing camera default move speed

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Core/CameraController.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/CameraController.h
@@ -127,7 +127,7 @@ namespace OvEditor::Core
 		float m_mouseSensitivity = 0.12f;
 		float m_cameraDragSpeed = 0.03f;
 		float m_cameraOrbitSpeed = 0.5f;
-		float m_cameraMoveSpeed = 5.0f;
+		float m_cameraMoveSpeed = 15.0f;
 		float m_focusDistance = 15.0f;
 		float m_focusLerpCoefficient = 8.0f;
 	};

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
@@ -115,8 +115,8 @@ void OvEditor::Panels::MenuBar::CreateSettingsMenu()
 	settingsMenu.CreateWidget<MenuItem>("Spawn actors at origin", "", true, true).ValueChangedEvent		+= EDITOR_BIND(SetActorSpawnAtOrigin, std::placeholders::_1);
 	settingsMenu.CreateWidget<MenuItem>("Vertical Synchronization", "", true, true).ValueChangedEvent	+= [this](bool p_value) { EDITOR_CONTEXT(device)->SetVsync(p_value); };
 	auto& cameraSpeedMenu = settingsMenu.CreateWidget<MenuList>("Camera Speed");
-	cameraSpeedMenu.CreateWidget<OvUI::Widgets::Sliders::SliderInt>(1, 20, 5, OvUI::Widgets::Sliders::ESliderOrientation::HORIZONTAL, "Scene View").ValueChangedEvent += EDITOR_BIND(SetSceneViewCameraSpeed, std::placeholders::_1);
-	cameraSpeedMenu.CreateWidget<OvUI::Widgets::Sliders::SliderInt>(1, 20, 5, OvUI::Widgets::Sliders::ESliderOrientation::HORIZONTAL, "Asset View").ValueChangedEvent += EDITOR_BIND(SetAssetViewCameraSpeed, std::placeholders::_1);
+	cameraSpeedMenu.CreateWidget<OvUI::Widgets::Sliders::SliderInt>(1, 50, 15, OvUI::Widgets::Sliders::ESliderOrientation::HORIZONTAL, "Scene View").ValueChangedEvent += EDITOR_BIND(SetSceneViewCameraSpeed, std::placeholders::_1);
+	cameraSpeedMenu.CreateWidget<OvUI::Widgets::Sliders::SliderInt>(1, 50, 15, OvUI::Widgets::Sliders::ESliderOrientation::HORIZONTAL, "Asset View").ValueChangedEvent += EDITOR_BIND(SetAssetViewCameraSpeed, std::placeholders::_1);
 	auto& cameraPositionMenu = settingsMenu.CreateWidget<MenuList>("Reset Camera");
 	cameraPositionMenu.CreateWidget<MenuItem>("Scene View").ClickedEvent += EDITOR_BIND(ResetSceneViewCameraPosition);
 	cameraPositionMenu.CreateWidget<MenuItem>("Asset View").ClickedEvent += EDITOR_BIND(ResetAssetViewCameraPosition);


### PR DESCRIPTION
In the same idea as camera rotation speed update, I felt like camera
move speed without pressing shift (Shift doubles the camera movement
speed), the movement speed is very low (5 grid units per seconds).
This has been increased to 15 grid units per second.