### PR TITLE
Re-adding "Updating Overload shader versions from 460 to 430" after fixing the issue

### DIFF
--- a/Resources/Engine/Shaders/Lambert.glsl
+++ b/Resources/Engine/Shaders/Lambert.glsl
@@ -1,5 +1,5 @@
 #shader vertex
-#version 460 core
+#version 430 core
 
 layout (location = 0) in vec3 geo_Pos;
 layout (location = 1) in vec2 geo_TexCoords;
@@ -31,7 +31,7 @@ void main()
 }
 
 #shader fragment
-#version 460 core
+#version 430 core
 
 out vec4 FRAGMENT_COLOR;
 

--- a/Resources/Engine/Shaders/Standard.glsl
+++ b/Resources/Engine/Shaders/Standard.glsl
@@ -1,5 +1,5 @@
 #shader vertex
-#version 460 core
+#version 430 core
 
 layout (location = 0) in vec3 geo_Pos;
 layout (location = 1) in vec2 geo_TexCoords;
@@ -49,7 +49,7 @@ void main()
 }
 
 #shader fragment
-#version 460 core
+#version 430 core
 
 /* Global information sent by the engine */
 layout (std140) uniform EngineUBO

--- a/Resources/Engine/Shaders/StandardPBR.glsl
+++ b/Resources/Engine/Shaders/StandardPBR.glsl
@@ -1,5 +1,5 @@
 #shader vertex
-#version 460 core
+#version 430 core
 
 layout (location = 0) in vec3 geo_Pos;
 layout (location = 1) in vec2 geo_TexCoords;
@@ -49,7 +49,7 @@ void main()
 }
 
 #shader fragment
-#version 460 core
+#version 430 core
 
 /* Global information sent by the engine */
 layout (std140) uniform EngineUBO

--- a/Resources/Engine/Shaders/Unlit.glsl
+++ b/Resources/Engine/Shaders/Unlit.glsl
@@ -1,5 +1,5 @@
 #shader vertex
-#version 460 core
+#version 430 core
 
 layout (location = 0) in vec3 geo_Pos;
 layout (location = 1) in vec2 geo_TexCoords;
@@ -27,7 +27,7 @@ void main()
 }
 
 #shader fragment
-#version 460 core
+#version 430 core
 
 out vec4 FRAGMENT_COLOR;
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Resources/RawShaders.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Resources/RawShaders.cpp
@@ -11,7 +11,7 @@ std::pair<std::string, std::string> OvEditor::Resources::RawShaders::GetGrid()
 	std::pair<std::string, std::string> source;
 
 	source.first = R"(
-#version 460 core
+#version 430 core
 
 layout (location = 0) in vec3 geo_Pos;
 layout (location = 1) in vec2 geo_TexCoords;
@@ -42,7 +42,7 @@ void main()
 )";
 
 	source.second = R"(
-#version 460 core
+#version 430 core
 
 out vec4 FRAGMENT_COLOR;
 
@@ -119,7 +119,7 @@ std::pair<std::string, std::string> OvEditor::Resources::RawShaders::GetGizmo()
 	std::pair<std::string, std::string> source;
 
 	source.first = R"(
-#version 460 core
+#version 430 core
 
 layout (location = 0) in vec3 geo_Pos;
 layout (location = 2) in vec3 geo_Normal;
@@ -217,7 +217,7 @@ void main()
 )";
 
 	source.second = R"(
-#version 460 core
+#version 430 core
 
 out vec4 FRAGMENT_COLOR;
 
@@ -241,7 +241,7 @@ std::pair<std::string, std::string> OvEditor::Resources::RawShaders::GetBillboar
 	std::pair<std::string, std::string> source;
 
 	source.first = R"(
-#version 460 core
+#version 430 core
 
 layout (location = 0) in vec3 geo_Pos;
 layout (location = 1) in vec2 geo_TexCoords;
@@ -291,7 +291,7 @@ void main()
 })";
 
 	source.second = R"(
-#version 460 core
+#version 430 core
 
 out vec4 FRAGMENT_COLOR;
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Resources/RawShaders.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Resources/RawShaders.cpp
@@ -136,7 +136,7 @@ layout (std140) uniform EngineUBO
 
 out VS_OUT
 {
-    flat vec3   Color;
+    vec3 Color;
 } vs_out;
 
 uniform bool u_IsBall;

--- a/Sources/Overload/OvRendering/src/OvRendering/Core/ShapeDrawer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Core/ShapeDrawer.cpp
@@ -30,7 +30,7 @@ OvRendering::Core::ShapeDrawer::ShapeDrawer(OvRendering::Core::Renderer& p_rende
 	m_lineMesh = new Resources::Mesh(vertices, { 0, 1 }, 0);
 
 	std::string vertexShader = R"(
-#version 460 core
+#version 430 core
 
 uniform vec3 start;
 uniform vec3 end;
@@ -45,7 +45,7 @@ void main()
 )";
 
 	std::string fragmentShader = R"(
-#version 460 core
+#version 430 core
 
 uniform vec3 color;
 
@@ -60,7 +60,7 @@ void main()
 	m_lineShader = OvRendering::Resources::Loaders::ShaderLoader::CreateFromSource(vertexShader, fragmentShader);
 
 	vertexShader = R"(
-#version 460 core
+#version 430 core
 
 uniform vec3 start;
 uniform vec3 end;
@@ -78,7 +78,7 @@ void main()
 )";
 
 	fragmentShader = R"(
-#version 460 core
+#version 430 core
 
 uniform vec3 color;
 uniform vec3 viewPos;


### PR DESCRIPTION
Reverts adriengivry/Overload#179 and fixes the issue related to the gizmo shader.
The gizmo shader was using the "flat" keyword which requires OpenGL4.5. This keyword wasn't necessary so it has been removed.