### PR TITLE
Add virtual destructor on ISerializable and override ~Actor()

### DIFF
--- a/Sources/Overload/OvCore/include/OvCore/API/ISerializable.h
+++ b/Sources/Overload/OvCore/include/OvCore/API/ISerializable.h
@@ -32,5 +32,10 @@ namespace OvCore::API
 		* @param p_node
 		*/
 		virtual void OnDeserialize(tinyxml2::XMLDocument& p_doc, tinyxml2::XMLNode* p_node) = 0;
+
+		/**
+		* Default polymorphic destructor
+		*/
+		virtual ~ISerializable() = default;
 	};
 }

--- a/Sources/Overload/OvCore/include/OvCore/ECS/Actor.h
+++ b/Sources/Overload/OvCore/include/OvCore/ECS/Actor.h
@@ -39,7 +39,7 @@ namespace OvCore::ECS
 		* Destructor of the actor instance. Force invoke ComponentRemovedEvent and BehaviourRemovedEvent
 		* for every components and behaviours
 		*/
-		~Actor();
+		virtual ~Actor() override;
 
 		/**
 		* Return the current name of the actor
@@ -306,6 +306,12 @@ namespace OvCore::ECS
 		virtual void OnDeserialize(tinyxml2::XMLDocument& p_doc, tinyxml2::XMLNode* p_actorsRoot) override;
 
 	private:
+		/**
+		 * @brief Deleted copy constructor
+		 * @param p_actor
+		 */
+		Actor(const Actor& p_actor) = delete;
+
 		void RecursiveActiveUpdate();
 		void RecursiveWasActiveUpdate();
 


### PR DESCRIPTION
This should make sure we have a proper deletion in memory and not letting the compiler do it for us

Fixes #163 