### PR TITLE
Pushing onto develop now triggers MSBuild (CI/CD)

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,6 +1,10 @@
 name: MSBuild
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   # Path to the solution file relative to the root of the project.


### PR DESCRIPTION
The MSBuild CI build script is now being triggered when pushing
something onto develop. This way, we can keep track of the state of the
code being merged.

Fixes https://github.com/adriengivry/Overload/issues/191