### PR TITLE
Intercept glfw init error and display OpenGL version requirements

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
@@ -13,8 +13,6 @@
 #include "OvEditor/Core/ProjectHub.h"
 #include "OvEditor/Core/Application.h"
 
-#include <OvWindowing/Dialogs/MessageBox.h>
-
 #undef APIENTRY
 #include "Windows.h"
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
@@ -34,7 +34,7 @@ void UpdateWorkingDirectory(const std::string& p_executablePath)
 }
 
 int main(int argc, char** argv);
-void TryRun(std::string projectPath, std::string projectName);
+static void TryRun(const std::string& projectPath, const std::string& projectName);
 
 #ifndef _DEBUG
 INT WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nCmdShow)
@@ -82,7 +82,7 @@ int main(int argc, char** argv)
 	return EXIT_SUCCESS;
 }
 
-void TryRun(std::string projectPath, std::string projectName)
+static void TryRun(const std::string& projectPath, const std::string& projectName)
 {
 	auto errorEvent =
 		[](OvWindowing::Context::EDeviceError, std::string errMsg)


### PR DESCRIPTION
Issue #197 

### Current situation
On some machine without modern enough 3d acceleration, `OvWindowing::Window::CreateGlfwWindow` will throw and the user will get a generic `std::runtime_error` that does not contain the glfw error detail.

```
m_glfwWindow = glfwCreateWindow(static_cast<int>(m_size.first), static_cast<int>(m_size.second), m_title.c_str(), selectedMonitor, nullptr);

if (!m_glfwWindow)
{
	throw std::runtime_error("Failed to create GLFW window");
}
```

### How to reproduce
Start the editor in a virtual machine without 3d acceleration support. Reproduced on Windows 10 in VMWare workstation.

### Suggested solution
The goal is to tell the user about what happened, with minimal impact and risk.

In OvEditor/Main.cpp, `OvEditor::Core::Application app(projectPath, projectName);` is now inside a `TryRun` function.
`TryRun` will
- Add a listener to event `OvWindowing::Context::Device::ErrorEvent`
- Run the `OvEditor::Core::Application` constructor
- Remove the event listener
- Run the application `app->Run();`

### Tests
The fix was tested in Debug and Release mode, both in the Virtual Machine and in a real Windows 10 setup where the error does not occur.

### Screenshot
![image](https://user-images.githubusercontent.com/92279759/141661358-8d1bd33b-878f-4748-aec1-ad6ba1a6b157.png)
