### PR TITLE
improve world transform calculation

### DIFF
--- a/Sources/Overload/OvCore/src/OvCore/ECS/Components/CTransform.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ECS/Components/CTransform.cpp
@@ -12,7 +12,7 @@
 OvCore::ECS::Components::CTransform::CTransform(ECS::Actor& p_owner, OvMaths::FVector3 p_localPosition, OvMaths::FQuaternion p_localRotation, OvMaths::FVector3 p_localScale) :
 AComponent(p_owner)
 {
-	m_transform.GenerateMatrices(p_localPosition, p_localRotation, p_localScale);
+	m_transform.GenerateMatricesLocal(p_localPosition, p_localRotation, p_localScale);
 }
 
 std::string OvCore::ECS::Components::CTransform::GetName()
@@ -164,7 +164,7 @@ void OvCore::ECS::Components::CTransform::OnSerialize(tinyxml2::XMLDocument& p_d
 
 void OvCore::ECS::Components::CTransform::OnDeserialize(tinyxml2::XMLDocument & p_doc, tinyxml2::XMLNode * p_node)
 {
-	m_transform.GenerateMatrices
+	m_transform.GenerateMatricesLocal
 	(
 		OvCore::Helpers::Serializer::DeserializeVec3(p_doc, p_node, "position"),
 		OvCore::Helpers::Serializer::DeserializeQuat(p_doc, p_node, "rotation"),

--- a/Sources/Overload/OvMaths/include/OvMaths/FTransform.h
+++ b/Sources/Overload/OvMaths/include/OvMaths/FTransform.h
@@ -57,17 +57,30 @@ namespace OvMaths
 		bool HasParent() const;
 
 		/**
-		* Initialize transform with raw data
+		* Initialize transform with raw data from world info
 		* @param p_position
 		* @param p_rotation
 		* @param p_scale
 		*/
-		void GenerateMatrices(FVector3 p_position, FQuaternion p_rotation, FVector3 p_scale);
+		void GenerateMatricesWorld(FVector3 p_position, FQuaternion p_rotation, FVector3 p_scale);
+
+		/**
+		* Initialize transform with raw data from local info
+		* @param p_position
+		* @param p_rotation
+		* @param p_scale
+		*/
+		void GenerateMatricesLocal(FVector3 p_position, FQuaternion p_rotation, FVector3 p_scale);
 
 		/**
 		* Re-update world matrix to use parent transformations
 		*/
 		void UpdateWorldMatrix();
+
+		/**
+		* Re-update local matrix to use parent transformations
+		*/
+		void UpdateLocalMatrix();
 
 		/**
 		* Set the position of the transform in the local space

--- a/Sources/Overload/OvMaths/src/OvMaths/FTransform.cpp
+++ b/Sources/Overload/OvMaths/src/OvMaths/FTransform.cpp
@@ -114,7 +114,7 @@ void OvMaths::FTransform::SetLocalRotation(FQuaternion p_newRotation)
 
 void OvMaths::FTransform::SetLocalScale(FVector3 p_newScale)
 {
-	GenerateMatricesWorld(m_localPosition, m_localRotation, p_newScale);
+	GenerateMatricesLocal(m_localPosition, m_localRotation, p_newScale);
 }
 
 void OvMaths::FTransform::SetWorldPosition(FVector3 p_newPosition)


### PR DESCRIPTION
### Summary

The calculation of World Transform was returning incorrect results under certain conditions,

so we changed it to calculate the local matrix from the results of the world matrix computation.

Similarly, when calculating the local matrix, the world matrix is computed from its results.

### Related issue

https://github.com/adriengivry/Overload/issues/240