### PR TITLE
Fixing Hierarchy stack overflow due to parent node manipulation

### DIFF
--- a/Sources/Overload/OvCore/include/OvCore/ECS/Actor.h
+++ b/Sources/Overload/OvCore/include/OvCore/ECS/Actor.h
@@ -101,6 +101,12 @@ namespace OvCore::ECS
 		void DetachFromParent();
 
 		/**
+		* Returns true if this actor transform is descendant of the actor
+		* @param p_actor
+		*/
+		bool IsDescendantOf(const Actor* p_actor) const;
+
+		/**
 		* Returns true if the actor has a parent
 		*/
 		bool HasParent() const;

--- a/Sources/Overload/OvCore/src/OvCore/ECS/Actor.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ECS/Actor.cpp
@@ -148,6 +148,22 @@ void OvCore::ECS::Actor::DetachFromParent()
 	transform.RemoveParent();
 }
 
+bool OvCore::ECS::Actor::IsDescendantOf(const Actor* p_actor) const
+{
+	const Actor* currentParentActor = m_parent;
+
+	while (currentParentActor != nullptr)
+	{
+		if (currentParentActor == p_actor)
+		{
+			return true;
+		}
+		currentParentActor = currentParentActor->GetParent();
+	}
+
+	return false;
+}
+
 bool OvCore::ECS::Actor::HasParent() const
 {
 	return m_parent;

--- a/Sources/Overload/OvCore/src/OvCore/Scripting/LuaActorBinder.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Scripting/LuaActorBinder.cpp
@@ -43,6 +43,7 @@ void OvCore::Scripting::LuaActorBinder::BindActor(sol::state & p_luaState)
 		"IsSelfActive", &Actor::IsSelfActive, // TODO: Add to doc
 		"IsActive", &Actor::IsActive,
 		"SetActive", &Actor::SetActive,
+		"IsDescendantOf", &Actor::IsDescendantOf,
 
 
 		/* Components Getters */

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -282,6 +282,9 @@ void OvEditor::Panels::Hierarchy::AddActorByInstance(OvCore::ECS::Actor & p_acto
 	textSelectable.AddPlugin<OvUI::Plugins::DDSource<std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*>>>("Actor", "Attach to...", std::make_pair(&p_actor, &textSelectable));
 	textSelectable.AddPlugin<OvUI::Plugins::DDTarget<std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*>>>("Actor").DataReceivedEvent += [&p_actor, &textSelectable](std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*> p_element)
 	{
+		if (p_element.second == textSelectable.GetParent())
+			return;
+
 		if (p_element.second->HasParent())
 			p_element.second->GetParent()->UnconsiderWidget(*p_element.second);
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -282,7 +282,7 @@ void OvEditor::Panels::Hierarchy::AddActorByInstance(OvCore::ECS::Actor & p_acto
 	textSelectable.AddPlugin<OvUI::Plugins::DDSource<std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*>>>("Actor", "Attach to...", std::make_pair(&p_actor, &textSelectable));
 	textSelectable.AddPlugin<OvUI::Plugins::DDTarget<std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*>>>("Actor").DataReceivedEvent += [&p_actor, &textSelectable](std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*> p_element)
 	{
-		if (p_element.second == textSelectable.GetParent())
+		if (p_actor.IsDescendantOf(p_element.first))
 			return;
 
 		p_element.first->SetParent(p_actor);

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -283,7 +283,10 @@ void OvEditor::Panels::Hierarchy::AddActorByInstance(OvCore::ECS::Actor & p_acto
 	textSelectable.AddPlugin<OvUI::Plugins::DDTarget<std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*>>>("Actor").DataReceivedEvent += [&p_actor, &textSelectable](std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*> p_element)
 	{
 		if (p_actor.IsDescendantOf(p_element.first))
+		{
+			OVLOG_WARNING("Cannot attach \"" + p_element.first->GetName() + "\" to \"" + p_actor.GetName() + "\" because it is a descendant of the latter.");
 			return;
+		}
 
 		p_element.first->SetParent(p_actor);
 	};

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -285,11 +285,6 @@ void OvEditor::Panels::Hierarchy::AddActorByInstance(OvCore::ECS::Actor & p_acto
 		if (p_element.second == textSelectable.GetParent())
 			return;
 
-		if (p_element.second->HasParent())
-			p_element.second->GetParent()->UnconsiderWidget(*p_element.second);
-
-		textSelectable.ConsiderWidget(*p_element.second);
-
 		p_element.first->SetParent(p_actor);
 	};
 	auto& dispatcher = textSelectable.AddPlugin<OvUI::Plugins::DataDispatcher<std::string>>();


### PR DESCRIPTION
Fixing issue #256 by adding a return statement in the DataReceivedEvent lambda if the Source is the parent of the Target + Removing unnecessary methods call since Actor SetParent will call AttachActorToParent via the AttachEvent event