### PR TITLE
Added actor rename option

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -115,8 +115,10 @@ public:
 	{
 		if (!m_protected)
 		{
-			auto& renameMenu = CreateWidget<OvUI::Widgets::Menu::MenuList>("Rename to...");
 			auto& deleteAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Delete");
+			deleteAction.ClickedEvent += [this] { DeleteItem(); };
+
+			auto& renameMenu = CreateWidget<OvUI::Widgets::Menu::MenuList>("Rename to...");
 
 			auto& nameEditor = renameMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
 			nameEditor.selectAllOnClick = true;
@@ -129,8 +131,6 @@ public:
 					if (size_t pos = nameEditor.content.rfind('.'); pos != std::string::npos)
 						nameEditor.content = nameEditor.content.substr(0, pos);
 			};
-
-			deleteAction.ClickedEvent += [this] { DeleteItem(); };
 
 			nameEditor.EnterPressedEvent += [this](std::string p_newName)
 			{


### PR DESCRIPTION
# Description
* added an option to rename an actor
* renamed HierarchyContextualMenu to ActorContextualMenu
* moved rename action to be shown before delete action in hierarchy for better consistency between contextual menus

# Screenshots
![image](https://github.com/adriengivry/Overload/assets/33324216/6978147e-9b99-45c7-bf83-8ab1b3fbcc41)
_Rename an actor from the hierarchy_

![image](https://github.com/adriengivry/Overload/assets/33324216/b58be594-a967-4d51-a1ff-8328071e2c06)
_Rename action in the asset browser moved to be consistent with the hierarchy (always after delete)_

![rename-contextual-menu](https://github.com/adriengivry/Overload/assets/33324216/a8e29113-b420-4326-982c-b9e72999da82)
_Use case demo_

# Related Issues
Fixes https://github.com/adriengivry/Overload/issues/260