### PR TITLE
Fixed an issue where deleting an actor would leave an empty expandable tree node

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -270,6 +270,14 @@ void OvEditor::Panels::Hierarchy::DeleteActorByInstance(OvCore::ECS::Actor& p_ac
 			result->second->Destroy();
 		}
 
+		if (p_actor.HasParent() && p_actor.GetParent()->GetChildren().size() == 1)
+		{
+			if (auto parentWidget = m_widgetActorLink.find(p_actor.GetParent()); parentWidget != m_widgetActorLink.end())
+			{
+				parentWidget->second->leaf = true;
+			}
+		}
+
 		m_widgetActorLink.erase(result);
 	}
 }


### PR DESCRIPTION
# Description
Deleting an actor that is the single child of another actor would leave this other actor to be displayed as an expandable tree node, while it has no children.

# Screenshots
![248594250-3777920b-fd45-42ca-a7c4-614932009454](https://github.com/adriengivry/Overload/assets/33324216/4ae55933-4d1f-4de4-bc05-636180d730c3)
_Before (tree node still shows an arrow even though there is no child node)_

![fix-actor-leaf-tree-node](https://github.com/adriengivry/Overload/assets/33324216/55cd18ee-4805-4194-bd1f-3c1129125e60)
_After (the tree node's arrow is removed after the last child is removed)_

# Related Issues
Fixes https://github.com/adriengivry/Overload/issues/248