### PR TITLE
Fixed a crash when changing scene while highlighting an actor

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
@@ -33,6 +33,14 @@ OvEditor::Panels::SceneView::SceneView
 		case OvTools::Utils::PathParser::EFileType::MODEL:	EDITOR_EXEC(CreateActorWithModel(path, true));	break;
 		}
 	};
+
+	OvCore::ECS::Actor::DestroyedEvent += [this](const OvCore::ECS::Actor& actor)
+	{
+		if (m_highlightedActor.has_value() && m_highlightedActor->get().GetID() == actor.GetID())
+		{
+			m_highlightedActor = std::nullopt;
+		}
+	};
 }
 
 void OvEditor::Panels::SceneView::Update(float p_deltaTime)


### PR DESCRIPTION
# Description
Added a check to clear the currently highlighted actor if this actor gets deleted

# Related Issues
Fixes https://github.com/adriengivry/Overload/issues/264