### PR TITLE
Double clicking on a scene opens it

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -1286,5 +1286,13 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 			auto& texturePreview = clickableText.AddPlugin<TexturePreview>();
 			texturePreview.SetPath(resourceFormatPath);
 		}
+
+		if (fileType == OvTools::Utils::PathParser::EFileType::SCENE)
+		{
+			clickableText.DoubleClickedEvent += [path]
+			{
+				EDITOR_EXEC(LoadSceneFromDisk(EDITOR_EXEC(GetResourcePath(path))));
+			};
+		}
 	}
 }


### PR DESCRIPTION
# Description
Double clicking on a scene in the Asset Browser now opens it

# Review Guidelines
While this PR doesn't fully solves the issue mentioned in https://github.com/adriengivry/Overload/issues/168, it provides a quick solution to many people struggling to open a scene.
However, we should find a better system to handle asset-specific actions and default actions on double-click, but this would be part of a bigger effort which would involve refactoring the Asset Browser (currently in a very dirty state).

# Screenshots
![scene-double-click](https://github.com/adriengivry/Overload/assets/33324216/67ee14dc-3245-45d3-8f7c-d55c1f2fb8f9)

# Related Issues
Partially addresses: https://github.com/adriengivry/Overload/issues/168

