### PR TITLE
Clear scene view highlighted actor when the mouse exists the view

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
@@ -250,6 +250,10 @@ void OvEditor::Panels::SceneView::HandleActorPicking()
 			}
 		}
 	}
+	else
+	{
+		m_highlightedActor = std::nullopt;
+	}
 
 	if (m_gizmoOperations.IsPicking())
 	{


### PR DESCRIPTION
# Screenshot
![scene-view-clear-highlight](https://github.com/adriengivry/Overload/assets/33324216/fcaf3d86-42e2-4006-b42e-a8fe2fb1223a)

# Related Issues
Fixes https://github.com/adriengivry/Overload/issues/267