### PR TITLE
Added `FrameInfo` editor panel

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/FrameInfo.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/FrameInfo.h
@@ -1,0 +1,41 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <OvUI/Panels/PanelWindow.h>
+#include <OvUI/Widgets/Texts/TextColored.h>
+
+namespace OvEditor::Panels
+{
+	class FrameInfo : public OvUI::Panels::PanelWindow
+	{
+	public:
+		/**
+		* Constructor
+		* @param p_title
+		* @param p_opened
+		* @param p_windowSettings
+		*/
+		FrameInfo
+		(
+			const std::string& p_title,
+			bool p_opened,
+			const OvUI::Settings::PanelWindowSettings& p_windowSettings
+		);
+
+		/**
+		* Update frame info information
+		* @param p_deltaTime
+		*/
+		void Update(float p_deltaTime);
+
+	private:
+		OvUI::Widgets::Texts::TextColored* m_batchCountText;
+		OvUI::Widgets::Texts::TextColored* m_instanceCountText;
+		OvUI::Widgets::Texts::TextColored* m_polyCountText;
+	};
+}

--- a/Sources/Overload/OvEditor/layout.ini
+++ b/Sources/Overload/OvEditor/layout.ini
@@ -1,13 +1,13 @@
 [Window][##dockspace]
 Pos=0,0
-Size=1920,1027
+Size=1600,900
 Collapsed=0
 
 [Window][Asset Browser##2]
-Pos=0,530
-Size=304,497
+Pos=0,425
+Size=310,475
 Collapsed=0
-DockId=0x0000000C,0
+DockId=0x0000000E,0
 
 [Window][Hardware Info##3]
 Pos=1470,24
@@ -16,10 +16,10 @@ Collapsed=0
 DockId=0x00000005,5
 
 [Window][Profiler##4]
-Pos=306,692
-Size=1162,335
+Pos=1257,615
+Size=343,285
 Collapsed=0
-DockId=0x00000004,0
+DockId=0x00000012,0
 
 [Window][Hierarchy##6]
 Pos=0,24
@@ -46,8 +46,8 @@ Collapsed=0
 DockId=0x00000005,4
 
 [Window][Toolbar##12]
-Pos=306,24
-Size=1162,75
+Pos=312,24
+Size=943,74
 Collapsed=0
 DockId=0x00000009,0
 
@@ -92,18 +92,80 @@ Size=1162,335
 Collapsed=0
 DockId=0x00000004,1
 
+[Window][Toolbar##11]
+Pos=636,24
+Size=1319,66
+Collapsed=0
+
+[Window][Project Settings##13]
+Pos=2005,24
+Size=553,1336
+Collapsed=0
+
+[Window][Material Editor##12]
+Pos=3917,24
+Size=1203,817
+Collapsed=0
+
+[Window][Asset Properties##14]
+Pos=881,24
+Size=397,812
+Collapsed=0
+
+[Window][Frame Info##5]
+Pos=1257,615
+Size=343,285
+Collapsed=0
+DockId=0x00000012,1
+
+[Window][Console##6]
+Pos=312,618
+Size=943,282
+Collapsed=0
+DockId=0x00000004,0
+
+[Window][Hierarchy##7]
+Pos=0,24
+Size=310,399
+Collapsed=0
+DockId=0x0000000D,0
+
+[Window][Inspector##8]
+Pos=1257,24
+Size=343,589
+Collapsed=0
+DockId=0x00000011,0
+
+[Window][Scene View##9]
+Pos=312,100
+Size=943,516
+Collapsed=0
+DockId=0x0000000A,0
+
+[Window][Game View##10]
+Pos=312,100
+Size=943,516
+Collapsed=0
+DockId=0x0000000A,1
+
 [Docking][Data]
-DockSpace         ID=0x3F20F338 Window=0xEFEA1D90 Pos=0,24 Size=1920,1003 Split=X NoWindowMenuButton=1
-  DockNode        ID=0x00000007 Parent=0x3F20F338 SizeRef=304,1003 Split=Y NoWindowMenuButton=1 Selected=0xFEC67CA6
-    DockNode      ID=0x0000000B Parent=0x00000007 SizeRef=304,504 NoWindowMenuButton=1 Selected=0x92035EB3
-    DockNode      ID=0x0000000C Parent=0x00000007 SizeRef=304,497 NoWindowMenuButton=1 Selected=0x6AB70705
-  DockNode        ID=0x00000008 Parent=0x3F20F338 SizeRef=1614,1003 Split=X NoWindowMenuButton=1
-    DockNode      ID=0x00000001 Parent=0x00000008 SizeRef=1162,1003 Split=Y NoWindowMenuButton=1
-      DockNode    ID=0x00000003 Parent=0x00000001 SizeRef=1248,666 Split=Y NoWindowMenuButton=1 Selected=0x81B3DE80
-        DockNode  ID=0x00000009 Parent=0x00000003 SizeRef=1298,75 NoWindowMenuButton=1 Selected=0x5D0727F1
-        DockNode  ID=0x0000000A Parent=0x00000003 SizeRef=1298,589 CentralNode=1 NoWindowMenuButton=1 Selected=0x81B3DE80
-      DockNode    ID=0x00000004 Parent=0x00000001 SizeRef=1248,335 NoWindowMenuButton=1 Selected=0x76B58996
-    DockNode      ID=0x00000002 Parent=0x00000008 SizeRef=450,1003 Split=Y NoWindowMenuButton=1 Selected=0x92035EB3
-      DockNode    ID=0x00000005 Parent=0x00000002 SizeRef=670,609 NoWindowMenuButton=1 Selected=0x6DCD1E52
-      DockNode    ID=0x00000006 Parent=0x00000002 SizeRef=670,392 NoWindowMenuButton=1 Selected=0xF3932F03
+DockSpace           ID=0x3F20F338 Window=0xEFEA1D90 Pos=0,24 Size=1600,876 Split=X NoWindowMenuButton=1
+  DockNode          ID=0x0000000F Parent=0x3F20F338 SizeRef=1505,1336 Split=X NoWindowMenuButton=1
+    DockNode        ID=0x00000007 Parent=0x0000000F SizeRef=372,1003 Split=Y NoWindowMenuButton=1 Selected=0xFEC67CA6
+      DockNode      ID=0x0000000B Parent=0x00000007 SizeRef=304,504 NoWindowMenuButton=1 Selected=0x92035EB3
+      DockNode      ID=0x0000000C Parent=0x00000007 SizeRef=304,497 Split=Y NoWindowMenuButton=1 Selected=0x6AB70705
+        DockNode    ID=0x0000000D Parent=0x0000000C SizeRef=405,467 NoWindowMenuButton=1 Selected=0xE5046E25
+        DockNode    ID=0x0000000E Parent=0x0000000C SizeRef=405,555 NoWindowMenuButton=1 Selected=0x6AB70705
+    DockNode        ID=0x00000008 Parent=0x0000000F SizeRef=1131,1003 Split=X NoWindowMenuButton=1
+      DockNode      ID=0x00000001 Parent=0x00000008 SizeRef=1162,1003 Split=Y NoWindowMenuButton=1
+        DockNode    ID=0x00000003 Parent=0x00000001 SizeRef=1248,692 Split=Y NoWindowMenuButton=1 Selected=0x81B3DE80
+          DockNode  ID=0x00000009 Parent=0x00000003 SizeRef=1298,74 NoWindowMenuButton=1 Selected=0x5D0727F1
+          DockNode  ID=0x0000000A Parent=0x00000003 SizeRef=1298,616 CentralNode=1 NoWindowMenuButton=1 Selected=0xF6B4EE16
+        DockNode    ID=0x00000004 Parent=0x00000001 SizeRef=1248,330 NoWindowMenuButton=1 Selected=0xEFBCD82C
+      DockNode      ID=0x00000002 Parent=0x00000008 SizeRef=450,1003 Split=Y NoWindowMenuButton=1 Selected=0x92035EB3
+        DockNode    ID=0x00000005 Parent=0x00000002 SizeRef=670,609 NoWindowMenuButton=1 Selected=0x6DCD1E52
+        DockNode    ID=0x00000006 Parent=0x00000002 SizeRef=670,392 NoWindowMenuButton=1 Selected=0xF3932F03
+  DockNode          ID=0x00000010 Parent=0x3F20F338 SizeRef=411,1336 Split=Y NoWindowMenuButton=1 Selected=0xFD7203C3
+    DockNode        ID=0x00000011 Parent=0x00000010 SizeRef=411,689 NoWindowMenuButton=1 Selected=0xFD7203C3
+    DockNode        ID=0x00000012 Parent=0x00000010 SizeRef=411,333 NoWindowMenuButton=1 Selected=0xC4E707D9
 

--- a/Sources/Overload/OvEditor/layout.ini
+++ b/Sources/Overload/OvEditor/layout.ini
@@ -5,21 +5,21 @@ Collapsed=0
 
 [Window][Asset Browser##2]
 Pos=0,425
-Size=310,475
+Size=326,475
 Collapsed=0
 DockId=0x0000000E,0
 
 [Window][Hardware Info##3]
-Pos=1470,24
-Size=450,609
+Pos=912,618
+Size=330,282
 Collapsed=0
-DockId=0x00000005,5
+DockId=0x00000006,2
 
 [Window][Profiler##4]
-Pos=1257,615
-Size=343,285
+Pos=912,618
+Size=330,282
 Collapsed=0
-DockId=0x00000012,0
+DockId=0x00000006,0
 
 [Window][Hierarchy##6]
 Pos=0,24
@@ -37,37 +37,37 @@ DockId=0x0000000A,0
 Pos=1470,635
 Size=450,392
 Collapsed=0
-DockId=0x00000006,0
+DockId=0x00000002,0
 
 [Window][Help##11]
 Pos=1470,24
 Size=450,609
 Collapsed=0
-DockId=0x00000005,4
+DockId=0x00000002,4
 
 [Window][Toolbar##12]
-Pos=312,24
-Size=943,74
+Pos=328,24
+Size=914,74
 Collapsed=0
 DockId=0x00000009,0
 
 [Window][Material Editor##13]
-Pos=1470,24
-Size=450,609
+Pos=1244,24
+Size=356,876
 Collapsed=0
-DockId=0x00000005,2
+DockId=0x00000010,2
 
 [Window][Project Settings##14]
-Pos=1470,24
-Size=450,609
+Pos=1244,24
+Size=356,876
 Collapsed=0
-DockId=0x00000005,1
+DockId=0x00000010,1
 
 [Window][Asset Properties##15]
-Pos=1470,24
-Size=450,609
+Pos=1244,24
+Size=356,876
 Collapsed=0
-DockId=0x00000005,3
+DockId=0x00000010,3
 
 [Window][Debug##Default]
 Pos=60,60
@@ -78,7 +78,7 @@ Collapsed=0
 Pos=1470,24
 Size=450,1003
 Collapsed=0
-DockId=0x00000005,0
+DockId=0x00000002,0
 
 [Window][Game View##9]
 Pos=306,101
@@ -113,59 +113,63 @@ Size=397,812
 Collapsed=0
 
 [Window][Frame Info##5]
-Pos=1257,615
-Size=343,285
+Pos=912,618
+Size=330,282
 Collapsed=0
-DockId=0x00000012,1
+DockId=0x00000006,1
 
 [Window][Console##6]
-Pos=312,618
-Size=943,282
+Pos=328,618
+Size=582,282
 Collapsed=0
-DockId=0x00000004,0
+DockId=0x00000005,0
 
 [Window][Hierarchy##7]
 Pos=0,24
-Size=310,399
+Size=326,399
 Collapsed=0
 DockId=0x0000000D,0
 
 [Window][Inspector##8]
-Pos=1257,24
-Size=343,589
+Pos=1244,24
+Size=356,876
 Collapsed=0
-DockId=0x00000011,0
+DockId=0x00000010,0
 
 [Window][Scene View##9]
-Pos=312,100
-Size=943,516
+Pos=328,100
+Size=914,516
 Collapsed=0
 DockId=0x0000000A,0
 
 [Window][Game View##10]
-Pos=312,100
-Size=943,516
+Pos=328,100
+Size=914,516
 Collapsed=0
 DockId=0x0000000A,1
 
+[Window][Asset View##11]
+Pos=328,100
+Size=914,516
+Collapsed=0
+DockId=0x0000000A,2
+
 [Docking][Data]
 DockSpace           ID=0x3F20F338 Window=0xEFEA1D90 Pos=0,24 Size=1600,876 Split=X NoWindowMenuButton=1
-  DockNode          ID=0x0000000F Parent=0x3F20F338 SizeRef=1505,1336 Split=X NoWindowMenuButton=1
-    DockNode        ID=0x00000007 Parent=0x0000000F SizeRef=372,1003 Split=Y NoWindowMenuButton=1 Selected=0xFEC67CA6
+  DockNode          ID=0x0000000F Parent=0x3F20F338 SizeRef=1242,1336 Split=X NoWindowMenuButton=1
+    DockNode        ID=0x00000007 Parent=0x0000000F SizeRef=326,1003 Split=Y NoWindowMenuButton=1 Selected=0xFEC67CA6
       DockNode      ID=0x0000000B Parent=0x00000007 SizeRef=304,504 NoWindowMenuButton=1 Selected=0x92035EB3
       DockNode      ID=0x0000000C Parent=0x00000007 SizeRef=304,497 Split=Y NoWindowMenuButton=1 Selected=0x6AB70705
         DockNode    ID=0x0000000D Parent=0x0000000C SizeRef=405,467 NoWindowMenuButton=1 Selected=0xE5046E25
         DockNode    ID=0x0000000E Parent=0x0000000C SizeRef=405,555 NoWindowMenuButton=1 Selected=0x6AB70705
-    DockNode        ID=0x00000008 Parent=0x0000000F SizeRef=1131,1003 Split=X NoWindowMenuButton=1
+    DockNode        ID=0x00000008 Parent=0x0000000F SizeRef=914,1003 Split=X NoWindowMenuButton=1
       DockNode      ID=0x00000001 Parent=0x00000008 SizeRef=1162,1003 Split=Y NoWindowMenuButton=1
         DockNode    ID=0x00000003 Parent=0x00000001 SizeRef=1248,692 Split=Y NoWindowMenuButton=1 Selected=0x81B3DE80
           DockNode  ID=0x00000009 Parent=0x00000003 SizeRef=1298,74 NoWindowMenuButton=1 Selected=0x5D0727F1
           DockNode  ID=0x0000000A Parent=0x00000003 SizeRef=1298,616 CentralNode=1 NoWindowMenuButton=1 Selected=0xF6B4EE16
-        DockNode    ID=0x00000004 Parent=0x00000001 SizeRef=1248,330 NoWindowMenuButton=1 Selected=0xEFBCD82C
-      DockNode      ID=0x00000002 Parent=0x00000008 SizeRef=450,1003 Split=Y NoWindowMenuButton=1 Selected=0x92035EB3
-        DockNode    ID=0x00000005 Parent=0x00000002 SizeRef=670,609 NoWindowMenuButton=1 Selected=0x6DCD1E52
-        DockNode    ID=0x00000006 Parent=0x00000002 SizeRef=670,392 NoWindowMenuButton=1 Selected=0xF3932F03
-  DockNode          ID=0x00000010 Parent=0x3F20F338 SizeRef=411,1336 Split=Y NoWindowMenuButton=1 Selected=0xFD7203C3
-    DockNode        ID=0x00000011 Parent=0x00000010 SizeRef=411,689 NoWindowMenuButton=1 Selected=0xFD7203C3
-    DockNode        ID=0x00000012 Parent=0x00000010 SizeRef=411,333 NoWindowMenuButton=1 Selected=0xC4E707D9
+        DockNode    ID=0x00000004 Parent=0x00000001 SizeRef=1248,330 Split=X Selected=0xEFBCD82C
+          DockNode  ID=0x00000005 Parent=0x00000004 SizeRef=582,282 NoWindowMenuButton=1 Selected=0xEFBCD82C
+          DockNode  ID=0x00000006 Parent=0x00000004 SizeRef=330,282 NoWindowMenuButton=1 Selected=0x2031F374
+      DockNode      ID=0x00000002 Parent=0x00000008 SizeRef=450,1003 NoWindowMenuButton=1 Selected=0x92035EB3
+  DockNode          ID=0x00000010 Parent=0x3F20F338 SizeRef=356,1336 NoWindowMenuButton=1 Selected=0xDB243A07
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
@@ -42,9 +42,8 @@ OvEditor::Core::Context::Context(const std::string& p_projectPath, const std::st
 	deviceSettings.contextMajorVersion = 4;
 	deviceSettings.contextMinorVersion = 3;
 	windowSettings.title = "Overload Editor";
-	windowSettings.width = 1280;
-	windowSettings.height = 720;
-	windowSettings.maximized = true;
+	windowSettings.width = 1600;
+	windowSettings.height = 900;
 
 	/* Window creation */
 	device = std::make_unique<OvWindowing::Context::Device>(deviceSettings);
@@ -53,6 +52,11 @@ OvEditor::Core::Context::Context(const std::string& p_projectPath, const std::st
 	window->SetIconFromMemory(reinterpret_cast<uint8_t*>(iconRaw.data()), 16, 16);
 	inputManager = std::make_unique<OvWindowing::Inputs::InputManager>(*window);
 	window->MakeCurrentContext();
+
+	/* Center Window */
+	auto [monWidth, monHeight] = device->GetMonitorSize();
+	auto [winWidth, winHeight] = window->GetSize();
+	window->SetPosition(monWidth / 2 - winWidth / 2, monHeight / 2 - winHeight / 2);
 
 	device->SetVsync(true);
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -12,6 +12,7 @@
 #include "OvEditor/Panels/AssetBrowser.h"
 #include "OvEditor/Panels/HardwareInfo.h"
 #include "OvEditor/Panels/Profiler.h"
+#include "OvEditor/Panels/FrameInfo.h"
 #include "OvEditor/Panels/Console.h"
 #include "OvEditor/Panels/Inspector.h"
 #include "OvEditor/Panels/Hierarchy.h"
@@ -55,6 +56,7 @@ void OvEditor::Core::Editor::SetupUI()
 	m_panelsManager.CreatePanel<OvEditor::Panels::AssetBrowser>("Asset Browser", true, settings, m_context.engineAssetsPath, m_context.projectAssetsPath, m_context.projectScriptsPath);
 	m_panelsManager.CreatePanel<OvEditor::Panels::HardwareInfo>("Hardware Info", false, settings, 0.2f, 50);
 	m_panelsManager.CreatePanel<OvEditor::Panels::Profiler>("Profiler", true, settings, 0.25f);
+	m_panelsManager.CreatePanel<OvEditor::Panels::FrameInfo>("Frame Info", true, settings);
 	m_panelsManager.CreatePanel<OvEditor::Panels::Console>("Console", true, settings);
 	m_panelsManager.CreatePanel<OvEditor::Panels::Hierarchy>("Hierarchy", true, settings);
 	m_panelsManager.CreatePanel<OvEditor::Panels::Inspector>("Inspector", true, settings);
@@ -77,6 +79,7 @@ void OvEditor::Core::Editor::PreUpdate()
 	m_context.device->PollEvents();
 	m_context.renderer->SetClearColor(0.f, 0.f, 0.f);
 	m_context.renderer->Clear();
+	m_context.renderer->ClearFrameInfo();
 }
 
 void OvEditor::Core::Editor::Update(float p_deltaTime)
@@ -84,8 +87,8 @@ void OvEditor::Core::Editor::Update(float p_deltaTime)
 	HandleGlobalShortcuts();
 	UpdateCurrentEditorMode(p_deltaTime);
 	PrepareRendering(p_deltaTime);
-	UpdateEditorPanels(p_deltaTime);
 	RenderViews(p_deltaTime);
+	UpdateEditorPanels(p_deltaTime);
 	RenderEditorUI(p_deltaTime);
 	m_editorActions.ExecuteDelayedActions();
 }
@@ -163,6 +166,7 @@ void OvEditor::Core::Editor::UpdateEditorPanels(float p_deltaTime)
 {
 	auto& menuBar = m_panelsManager.GetPanelAs<OvEditor::Panels::MenuBar>("Menu Bar");
 	auto& profiler = m_panelsManager.GetPanelAs<OvEditor::Panels::Profiler>("Profiler");
+	auto& frameInfo = m_panelsManager.GetPanelAs<OvEditor::Panels::FrameInfo>("Frame Info");
 	auto& hardwareInfo = m_panelsManager.GetPanelAs<OvEditor::Panels::HardwareInfo>("Hardware Info");
 	auto& sceneView = m_panelsManager.GetPanelAs<OvEditor::Panels::SceneView>("Scene View");
 
@@ -170,6 +174,12 @@ void OvEditor::Core::Editor::UpdateEditorPanels(float p_deltaTime)
 
 	if (m_elapsedFrames == 1) // Let the first frame happen and then make the scene view the first seen view
 		sceneView.Focus();
+
+	if (frameInfo.IsOpened())
+	{
+		PROFILER_SPY("Frame Info Update");
+		frameInfo.Update(p_deltaTime);
+	}
 
 	if (profiler.IsOpened())
 	{

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/FrameInfo.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/FrameInfo.cpp
@@ -1,0 +1,35 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include "OvEditor/Panels/FrameInfo.h"
+
+#include <OvDebug/Logger.h>
+#include <OvUI/Widgets/Visual/Separator.h>
+
+#include "OvEditor/Core/EditorActions.h"
+
+using namespace OvUI::Panels;
+using namespace OvUI::Widgets;
+using namespace OvUI::Types;
+
+OvEditor::Panels::FrameInfo::FrameInfo
+(
+	const std::string& p_title,
+	bool p_opened,
+	const OvUI::Settings::PanelWindowSettings& p_windowSettings
+) : PanelWindow(p_title, p_opened, p_windowSettings)
+{
+	m_batchCountText = &CreateWidget<Texts::TextColored>("");
+	m_instanceCountText = &CreateWidget<Texts::TextColored>("");
+	m_polyCountText = &CreateWidget<Texts::TextColored>("");
+}
+
+void OvEditor::Panels::FrameInfo::Update(float p_deltaTime)
+{
+	m_batchCountText->content = "Batches: " + std::to_string(EDITOR_CONTEXT(renderer)->GetFrameInfo().batchCount);
+	m_instanceCountText->content = "Instances: " + std::to_string(EDITOR_CONTEXT(renderer)->GetFrameInfo().instanceCount);
+	m_polyCountText->content = "Polygons: " + std::to_string(EDITOR_CONTEXT(renderer)->GetFrameInfo().polyCount);
+}


### PR DESCRIPTION
# Description
Added `FrameInfo` editor panel to get details about the instance count, batch count, and poly count (similar to the info you get in a debug build).

Updated the default *layout.ini*

Also updated the default window size to 1600x900. The window now appears at the centre of the current monitor.

# Screenshots
![image](https://github.com/adriengivry/Overload/assets/33324216/fc863221-31bb-4c4e-85de-744f6b509463)
_FrameInfo Panel_

![image](https://github.com/adriengivry/Overload/assets/33324216/fb595031-96cc-41c3-be00-e8013b03d62c)
_Example Use Case_

# Related Issues
Fixes https://github.com/adriengivry/Overload/issues/147