### PR TITLE
Adding vertices count to the FrameInfo panel

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/FrameInfo.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/FrameInfo.h
@@ -37,5 +37,6 @@ namespace OvEditor::Panels
 		OvUI::Widgets::Texts::TextColored* m_batchCountText;
 		OvUI::Widgets::Texts::TextColored* m_instanceCountText;
 		OvUI::Widgets::Texts::TextColored* m_polyCountText;
+		OvUI::Widgets::Texts::TextColored* m_vertexCountText;
 	};
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/FrameInfo.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/FrameInfo.cpp
@@ -23,14 +23,16 @@ OvEditor::Panels::FrameInfo::FrameInfo
 	const OvUI::Settings::PanelWindowSettings& p_windowSettings
 ) : PanelWindow(p_title, p_opened, p_windowSettings)
 {
-	m_batchCountText = &CreateWidget<Texts::TextColored>("");
+	m_batchCountText    = &CreateWidget<Texts::TextColored>("");
 	m_instanceCountText = &CreateWidget<Texts::TextColored>("");
-	m_polyCountText = &CreateWidget<Texts::TextColored>("");
+	m_polyCountText     = &CreateWidget<Texts::TextColored>("");
+	m_vertexCountText = &CreateWidget<Texts::TextColored>("");
 }
 
 void OvEditor::Panels::FrameInfo::Update(float p_deltaTime)
 {
-    m_batchCountText->content = "Batches: " + OvTools::Utils::Format::ReadableNumber(EDITOR_CONTEXT(renderer)->GetFrameInfo().batchCount);
+    m_batchCountText->content    = "Batches: "   + OvTools::Utils::Format::ReadableNumber(EDITOR_CONTEXT(renderer)->GetFrameInfo().batchCount);
 	m_instanceCountText->content = "Instances: " + OvTools::Utils::Format::ReadableNumber(EDITOR_CONTEXT(renderer)->GetFrameInfo().instanceCount);
-    m_polyCountText->content = "Polygons: " + OvTools::Utils::Format::ReadableNumber(EDITOR_CONTEXT(renderer)->GetFrameInfo().polyCount);
+	m_polyCountText->content     = "Polygons: "  + OvTools::Utils::Format::ReadableNumber(EDITOR_CONTEXT(renderer)->GetFrameInfo().polyCount);
+	m_vertexCountText->content = "Vertices: "  + OvTools::Utils::Format::ReadableNumber(EDITOR_CONTEXT(renderer)->GetFrameInfo().vertexCount);
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/FrameInfo.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/FrameInfo.cpp
@@ -26,6 +26,7 @@ OvEditor::Panels::FrameInfo::FrameInfo
 	m_batchCountText    = &CreateWidget<Texts::TextColored>("");
 	m_instanceCountText = &CreateWidget<Texts::TextColored>("");
 	m_polyCountText     = &CreateWidget<Texts::TextColored>("");
+	m_polyCountText->lineBreak = false;
 	m_vertexCountText = &CreateWidget<Texts::TextColored>("");
 }
 

--- a/Sources/Overload/OvRendering/include/OvRendering/Core/Renderer.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Core/Renderer.h
@@ -39,6 +39,7 @@ namespace OvRendering::Core
 			uint64_t batchCount		= 0;
 			uint64_t instanceCount	= 0;
 			uint64_t polyCount		= 0;
+			uint64_t vertexCount	= 0;
 		};
 
 		/**

--- a/Sources/Overload/OvRendering/src/OvRendering/Core/Renderer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Core/Renderer.cpp
@@ -199,6 +199,7 @@ void OvRendering::Core::Renderer::ClearFrameInfo()
 	m_frameInfo.batchCount		= 0;
 	m_frameInfo.instanceCount	= 0;
 	m_frameInfo.polyCount		= 0;
+	m_frameInfo.vertexCount	= 0;
 }
 
 void OvRendering::Core::Renderer::Draw(Resources::IMesh& p_mesh, Settings::EPrimitiveMode p_primitiveMode, uint32_t p_instances)
@@ -207,7 +208,8 @@ void OvRendering::Core::Renderer::Draw(Resources::IMesh& p_mesh, Settings::EPrim
 	{
 		++m_frameInfo.batchCount;
 		m_frameInfo.instanceCount += p_instances;
-		m_frameInfo.polyCount += (p_mesh.GetIndexCount() / 3) * p_instances;
+		m_frameInfo.polyCount     += p_mesh.GetIndexCount() / 3 * p_instances;
+		m_frameInfo.vertexCount   += p_mesh.GetVertexCount() * p_instances;
 
 		p_mesh.Bind();
 		


### PR DESCRIPTION
# Description
Added `VertexCount` to the FrameInfo editor panel.

# Screenshots
![FrameInfoPanel](https://github.com/adriengivry/Overload/assets/32653095/f156af84-048a-46a0-9258-d37ddda1551b)

# Related Issues
Fixes https://github.com/adriengivry/Overload/issues/275
