### PR TITLE
WidgetContainer memory management refacto

### DIFF
--- a/Sources/Overload/OvCore/include/OvCore/ECS/Actor.h
+++ b/Sources/Overload/OvCore/include/OvCore/ECS/Actor.h
@@ -331,7 +331,7 @@ namespace OvCore::ECS
 		static OvTools::Eventing::Event<Actor&>				DestroyedEvent;
 		static OvTools::Eventing::Event<Actor&>				CreatedEvent;
 		static OvTools::Eventing::Event<Actor&, Actor&>		AttachEvent;
-		static OvTools::Eventing::Event<Actor&>				DettachEvent;
+		static OvTools::Eventing::Event<Actor&, Actor*>				DettachEvent;
 
 	private:
 		/* Settings */

--- a/Sources/Overload/OvCore/src/OvCore/ECS/Actor.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ECS/Actor.cpp
@@ -25,7 +25,7 @@
 OvTools::Eventing::Event<OvCore::ECS::Actor&> OvCore::ECS::Actor::DestroyedEvent;
 OvTools::Eventing::Event<OvCore::ECS::Actor&> OvCore::ECS::Actor::CreatedEvent;
 OvTools::Eventing::Event<OvCore::ECS::Actor&, OvCore::ECS::Actor&> OvCore::ECS::Actor::AttachEvent;
-OvTools::Eventing::Event<OvCore::ECS::Actor&> OvCore::ECS::Actor::DettachEvent;
+OvTools::Eventing::Event<OvCore::ECS::Actor&, OvCore::ECS::Actor*> OvCore::ECS::Actor::DettachEvent;
 
 OvCore::ECS::Actor::Actor(int64_t p_actorID, const std::string & p_name, const std::string & p_tag, bool& p_playing) :
 	m_actorID(p_actorID),
@@ -131,7 +131,7 @@ void OvCore::ECS::Actor::SetParent(Actor& p_parent)
 
 void OvCore::ECS::Actor::DetachFromParent()
 {
-	DettachEvent.Invoke(*this);
+	DettachEvent.Invoke(*this, m_parent);
 
 	/* Remove the actor from the parent children list */
 	if (m_parent)

--- a/Sources/Overload/OvCore/src/OvCore/ECS/Components/CCamera.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ECS/Components/CCamera.cpp
@@ -143,13 +143,13 @@ void OvCore::ECS::Components::CCamera::OnInspector(OvUI::Internal::WidgetContain
     auto currentProjectionMode = GetProjectionMode();
 
 	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Field of view", std::bind(&CCamera::GetFov, this), std::bind(&CCamera::SetFov, this, std::placeholders::_1));
-    auto& fovWidget = *p_root.GetWidgets()[p_root.GetWidgets().size() - 1].first;
-    auto& fovWidgetLabel = *p_root.GetWidgets()[p_root.GetWidgets().size() - 2].first;
+    auto& fovWidget = *p_root.GetWidgets()[p_root.GetWidgets().size() - 1];
+    auto& fovWidgetLabel = *p_root.GetWidgets()[p_root.GetWidgets().size() - 2];
     fovWidget.enabled = fovWidgetLabel.enabled = currentProjectionMode == OvRendering::Settings::EProjectionMode::PERSPECTIVE;
 
 	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Size", std::bind(&CCamera::GetSize, this), std::bind(&CCamera::SetSize, this, std::placeholders::_1));
-    auto& sizeWidget = *p_root.GetWidgets()[p_root.GetWidgets().size() - 1].first;
-    auto& sizeWidgetLabel = *p_root.GetWidgets()[p_root.GetWidgets().size() - 2].first;
+    auto& sizeWidget = *p_root.GetWidgets()[p_root.GetWidgets().size() - 1];
+    auto& sizeWidgetLabel = *p_root.GetWidgets()[p_root.GetWidgets().size() - 2];
     sizeWidget.enabled = sizeWidgetLabel.enabled = currentProjectionMode == OvRendering::Settings::EProjectionMode::ORTHOGRAPHIC;
 
 	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Near", std::bind(&CCamera::GetNear, this), std::bind(&CCamera::SetNear, this, std::placeholders::_1));

--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/Hierarchy.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/Hierarchy.h
@@ -65,7 +65,7 @@ namespace OvEditor::Panels
 		* Detach the given actor linked widget from its parent widget
 		* @param p_actor
 		*/
-		void DetachFromParent(OvCore::ECS::Actor& p_actor);
+		void DetachFromParent(OvCore::ECS::Actor& p_actor, OvCore::ECS::Actor* p_parentActor);
 
 		/**
 		* Delete the widget referencing the given actor

--- a/Sources/Overload/OvGame/include/OvGame/Utils/FPSCounter.h
+++ b/Sources/Overload/OvGame/include/OvGame/Utils/FPSCounter.h
@@ -32,7 +32,7 @@ namespace OvGame::Utils
 		void Update(float p_deltaTime);
 
 	private:
-		OvUI::Widgets::Texts::TextColored m_text;
+		OvUI::Widgets::Texts::TextColored& m_text;
 
 		OvWindowing::Window& m_window;
 		float m_elapsed = 0.0f;

--- a/Sources/Overload/OvGame/src/OvGame/Utils/FPSCounter.cpp
+++ b/Sources/Overload/OvGame/src/OvGame/Utils/FPSCounter.cpp
@@ -6,13 +6,12 @@
 
 #include "OvGame/Utils/FPSCounter.h"
 
-OvGame::Utils::FPSCounter::FPSCounter(OvWindowing::Window& p_window) : m_window(p_window)
+OvGame::Utils::FPSCounter::FPSCounter(OvWindowing::Window& p_window) : m_text(CreateWidget<OvUI::Widgets::Texts::TextColored>()), m_window(p_window)
 {
 	m_text.color = OvUI::Types::Color::Yellow;
 	m_defaultHorizontalAlignment = OvUI::Settings::EHorizontalAlignment::RIGHT;
 	m_defaultPosition = { static_cast<float>(m_window.GetSize().first) - 10.0f , 10.0f };
 	m_text.content = "999 FPS";
-	ConsiderWidget(m_text, false);
 }
 
 void OvGame::Utils::FPSCounter::Update(float p_deltaTime)

--- a/Sources/Overload/OvTools/CallbackQueue.h
+++ b/Sources/Overload/OvTools/CallbackQueue.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <queue>
+#include <functional>
+
+namespace OvTools::Utils
+{
+	class CallbackQueue : public std::queue<std::function<void()>>
+	{
+	public:
+		void Process()
+		{
+			while (!empty())
+			{
+				auto& callback = front();
+				callback();
+				pop();
+			}
+		}
+	};
+}

--- a/Sources/Overload/OvUI/include/OvUI/Internal/WidgetContainer.h
+++ b/Sources/Overload/OvUI/include/OvUI/Internal/WidgetContainer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "OvUI/Widgets/AWidget.h"
@@ -40,17 +41,7 @@ namespace OvUI::Internal
 		*/
 		void RemoveAllWidgets();
 
-		/**
-		* Consider a widget
-		* @param p_manageMemory
-		*/
-		void ConsiderWidget(Widgets::AWidget& p_widget, bool p_manageMemory = true);
-
-		/**
-		* Unconsider a widget
-		* @param p_widget
-		*/
-		void UnconsiderWidget(Widgets::AWidget& p_widget);
+		void TransferOwnership(Widgets::AWidget& p_widget, WidgetContainer& p_widgetCoontainer);
 
 		/**
 		* Collect garbages by removing widgets marked as "Destroyed"
@@ -74,8 +65,8 @@ namespace OvUI::Internal
 		template <typename T, typename ... Args>
 		T& CreateWidget(Args&&... p_args)
 		{
-			m_widgets.emplace_back(new T(p_args...), Internal::EMemoryMode::INTERNAL_MANAGMENT);
-			T& instance = *reinterpret_cast<T*>(m_widgets.back().first);
+			m_widgets.emplace_back(std::make_unique<T>(p_args...));
+			T& instance = *static_cast<T*>(m_widgets.back().get());
 			instance.SetParent(this);
 			return instance;
 		}
@@ -83,10 +74,10 @@ namespace OvUI::Internal
 		/**
 		* Returns the widgets and their memory management mode
 		*/
-		std::vector<std::pair<OvUI::Widgets::AWidget*, Internal::EMemoryMode>>& GetWidgets();
+		std::vector<std::unique_ptr<Widgets::AWidget>>& GetWidgets();
 
 	protected:
-		std::vector<std::pair<OvUI::Widgets::AWidget*, Internal::EMemoryMode>> m_widgets;
+		std::vector<std::unique_ptr<Widgets::AWidget>> m_widgets;
         bool m_reversedDrawOrder = false;
 	};
 }

--- a/Sources/Overload/OvUI/include/OvUI/Panels/APanel.h
+++ b/Sources/Overload/OvUI/include/OvUI/Panels/APanel.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <unordered_map>
 
+#include "../../../../OvTools/CallbackQueue.h"
 #include "OvUI/Internal/WidgetContainer.h"
 
 namespace OvUI::Panels
@@ -42,8 +43,10 @@ namespace OvUI::Panels
 
 	protected:
 		std::string m_panelID;
+		OvTools::Utils::CallbackQueue m_callbackQueue;
 
 	private:
 		static uint64_t __PANEL_ID_INCREMENT;
+		
 	};
 }

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/AButton.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/AButton.h
@@ -19,6 +19,9 @@ namespace OvUI::Widgets::Buttons
 	*/
 	class AButton : public AWidget
 	{
+	public:
+		AButton() = default;
+		virtual ~AButton() override = default;
 	protected:
 		void _Draw_Impl() override = 0;
 

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/Button.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/Button.h
@@ -28,7 +28,7 @@ namespace OvUI::Widgets::Buttons
 		* @param p_disabled
 		*/
 		Button(const std::string& p_label = "", const OvMaths::FVector2& p_size = OvMaths::FVector2(0.f, 0.f), bool p_disabled = false);
-
+		virtual ~Button() override = default;
 	protected:
 		void _Draw_Impl() override;
 

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/ButtonArrow.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/ButtonArrow.h
@@ -23,7 +23,7 @@ namespace OvUI::Widgets::Buttons
 		* @param p_direction
 		*/
 		ButtonArrow(ImGuiDir p_direction = ImGuiDir_None);
-
+		virtual ~ButtonArrow() override = default;
 	protected:
 		void _Draw_Impl() override;
 

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/ButtonColored.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/ButtonColored.h
@@ -29,7 +29,7 @@ namespace OvUI::Widgets::Buttons
 		* @param p_enableAlpha
 		*/
 		ButtonColored(const std::string& p_label = "", const Types::Color& p_color = {}, const OvMaths::FVector2& p_size =OvMaths::FVector2(0.f, 0.f), bool p_enableAlpha = true);
-
+		virtual ~ButtonColored() override = default;
 	protected:
 		void _Draw_Impl() override;
 

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/ButtonImage.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/ButtonImage.h
@@ -26,7 +26,7 @@ namespace OvUI::Widgets::Buttons
 		* @param p_size
 		*/
 		ButtonImage(uint32_t p_textureID, const OvMaths::FVector2& p_size);
-
+		virtual ~ButtonImage() override = default;
 	protected:
 		void _Draw_Impl() override;
 

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/ButtonSmall.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/ButtonSmall.h
@@ -24,7 +24,7 @@ namespace OvUI::Widgets::Buttons
 		* @param p_label
 		*/
 		ButtonSmall(const std::string& p_label = "");
-
+		virtual ~ButtonSmall() override = default;
 	protected:
 		void _Draw_Impl() override;
 

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Drags/DragDouble.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Drags/DragDouble.h
@@ -34,5 +34,7 @@ namespace OvUI::Widgets::Drags
 			const std::string& p_label = "",
 			const std::string& p_format = "%.6f"
 		);
+
+		virtual ~DragDouble() override = default;
 	};
 }

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Drags/DragFloat.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Drags/DragFloat.h
@@ -34,5 +34,6 @@ namespace OvUI::Widgets::Drags
 			const std::string& p_label = "",
 			const std::string& p_format = "%.3f"
 		);
+		virtual ~DragFloat() override = default;
 	};
 }

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Drags/DragInt.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Drags/DragInt.h
@@ -34,5 +34,6 @@ namespace OvUI::Widgets::Drags
 			const std::string& p_label = "",
 			const std::string& p_format = "%d"
 		);
+		virtual ~DragInt() override = default;
 	};
 }

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/Columns.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/Columns.h
@@ -38,7 +38,7 @@ namespace OvUI::Widgets::Layout
 
 			for (auto it = m_widgets.begin(); it != m_widgets.end();)
 			{
-				it->first->Draw();
+				it->get()->Draw();
 
 				++it;
 

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/NewLine.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/NewLine.h
@@ -15,6 +15,10 @@ namespace OvUI::Widgets::Layout
 	*/
 	class NewLine : public AWidget
 	{
+	public:
+		NewLine() = default;
+		virtual ~NewLine() override = default;
+
 	protected:
 		void _Draw_Impl() override;
 	};

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/Spacing.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/Spacing.h
@@ -21,6 +21,8 @@ namespace OvUI::Widgets::Layout
 		* @param p_spaces
 		*/
 		Spacing(uint16_t p_spaces = 1);
+		virtual ~Spacing() override = default;
+
 
 	protected:
 		void _Draw_Impl() override;

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/TreeNode.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/TreeNode.h
@@ -27,7 +27,7 @@ namespace OvUI::Widgets::Layout
 		* @param p_arrowClickToOpen
 		*/
 		TreeNode(const std::string& p_name = "", bool p_arrowClickToOpen = false);
-
+		virtual ~TreeNode() override = default;
 		/**
 		* Open the tree node
 		*/

--- a/Sources/Overload/OvUI/src/OvUI/Internal/WidgetContainer.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Internal/WidgetContainer.cpp
@@ -70,11 +70,10 @@ void OvUI::Internal::WidgetContainer::DrawWidgets()
 			it->get()->Draw();
 	}
 	else
-	{
+	{ 
 		for (const auto& widget : m_widgets)
 		{
-			if (widget.get() != nullptr)
-				widget->Draw();
+			widget->Draw();
 		}
 	}
 }

--- a/Sources/Overload/OvUI/src/OvUI/Panels/APanel.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Panels/APanel.cpp
@@ -18,7 +18,10 @@ OvUI::Panels::APanel::APanel()
 void OvUI::Panels::APanel::Draw()
 {
 	if (enabled)
+	{
+		m_callbackQueue.Process();
 		_Draw_Impl();
+	}
 }
 
 const std::string & OvUI::Panels::APanel::GetPanelID() const


### PR DESCRIPTION
Addressing issue #281 and composing Panels with CallbackQueue in order to allow widgets ownership manipulation before iterate on them.

▶️ The WidgetContainer is now replacing Consider / Unconsider methods for widgets manipulation by transferring the ownership of them. This introduced issues where the plugins was transferring the ownership as the same time we are iterating other them.

▶️ In order to fix this issue the CallbackQueue class has been implemented and now composed Panels, this allows us to handle widget manipulation before Drawing them.

Before the CallbackQueue implementation:

Draw the widgets -> Execute the plugin before Drawing the current widget -> Drag a Treenode -> the plugin call an Actor remove parent method -> Actor send an Event -> We handle the event directly in the Hierarchy Panel and remove the ownership of the current widget -> Crash: we are currently iterating other widget ❌

After the CallbackQueue implementation:

Draw the widgets -> Execute the plugin before Drawing the current widget -> Drag a Treenode -> the plugin call an Actor remove parent method -> Actor send an Event -> **the Hierarchy Panel enqueue the event** -> Finishing to drawing the widgets -> **processing the event before the next draw** ✔️