### PR TITLE
Update msbuild.yml

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Generate premake5 solution
       working-directory: ${{env.SOLUTION_FILE_PATH}}
       run: ..\..\Dependencies\premake5\bin\premake5.exe vs2022
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v2
 
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}


### PR DESCRIPTION
Bump checkout v3 to v4 and setup-msbuild v1 to v2 (they moved from deprecated dependencies like nodejs 16, to a LTS)