### PR TITLE
Fixed FTransform implementation to avoid copying the parent pointer and the notifiers

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Core/GizmoBehaviour.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/GizmoBehaviour.h
@@ -140,7 +140,7 @@ namespace OvEditor::Core
 		OvCore::ECS::Actor* m_target = nullptr;
 		EGizmoOperation m_currentOperation;
 		EDirection m_direction;
-		OvMaths::FTransform* m_originalTransform;
+		OvMaths::FTransform m_originalTransform;
 		OvMaths::FVector3 m_initialOffset;
 		OvMaths::FVector2 m_originMouse;
 		OvMaths::FVector2 m_currentMouse;

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/GizmoBehaviour.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/GizmoBehaviour.cpp
@@ -35,7 +35,7 @@ void OvEditor::Core::GizmoBehaviour::StartPicking(OvCore::ECS::Actor& p_target, 
 	m_target = &p_target;
 	m_firstMouse = true;
 	m_firstPick = true;
-	m_originalTransform = &p_target.transform.GetFTransform();
+	m_originalTransform = p_target.transform.GetFTransform();
 	m_distanceToActor = OvMaths::FVector3::Distance(p_cameraPosition, m_target->transform.GetWorldPosition());
 	m_currentOperation = p_operation;
 	m_direction = p_direction;
@@ -73,13 +73,13 @@ OvMaths::FVector3 OvEditor::Core::GizmoBehaviour::GetRealDirection(bool p_relati
 	switch (m_direction)
 	{
 	case OvEditor::Core::GizmoBehaviour::EDirection::X:
-		result = p_relative ? m_originalTransform->GetWorldRight() : m_originalTransform->GetLocalRight();
+		result = p_relative ? m_originalTransform.GetWorldRight() : m_originalTransform.GetLocalRight();
 		break;
 	case OvEditor::Core::GizmoBehaviour::EDirection::Y:
-		result = p_relative ? m_originalTransform->GetWorldUp() : m_originalTransform->GetLocalUp();
+		result = p_relative ? m_originalTransform.GetWorldUp() : m_originalTransform.GetLocalUp();
 		break;
 	case OvEditor::Core::GizmoBehaviour::EDirection::Z:
-		result = p_relative ? m_originalTransform->GetWorldForward() : m_originalTransform->GetLocalForward();
+		result = p_relative ? m_originalTransform.GetWorldForward() : m_originalTransform.GetLocalForward();
 		break;
 	}
 
@@ -88,8 +88,8 @@ OvMaths::FVector3 OvEditor::Core::GizmoBehaviour::GetRealDirection(bool p_relati
 
 OvMaths::FVector2 OvEditor::Core::GizmoBehaviour::GetScreenDirection(const OvMaths::FMatrix4& p_viewMatrix, const OvMaths::FMatrix4& p_projectionMatrix, const OvMaths::FVector2& p_viewSize) const
 {
-	auto start = m_originalTransform->GetWorldPosition();
-	auto end = m_originalTransform->GetWorldPosition() + GetRealDirection(true) * 0.01f;
+	auto start = m_originalTransform.GetWorldPosition();
+	auto end = m_originalTransform.GetWorldPosition() + GetRealDirection(true) * 0.01f;
 
 	auto start2D = OvMaths::FVector2();
 	{
@@ -127,7 +127,7 @@ void OvEditor::Core::GizmoBehaviour::ApplyTranslation(const OvMaths::FMatrix4& p
 
 	OvMaths::FVector3 direction = GetRealDirection(true);
 
-	OvMaths::FVector3 planePoint = m_originalTransform->GetWorldPosition();
+	OvMaths::FVector3 planePoint = m_originalTransform.GetWorldPosition();
 
 	const float denom = OvMaths::FVector3::Dot(ray, planeNormal);
 
@@ -143,7 +143,7 @@ void OvEditor::Core::GizmoBehaviour::ApplyTranslation(const OvMaths::FMatrix4& p
 
 	if (m_firstPick)
 	{
-		m_initialOffset = m_originalTransform->GetWorldPosition() - point;
+		m_initialOffset = m_originalTransform.GetWorldPosition() - point;
 		m_firstPick = false;
 	}
 
@@ -162,7 +162,7 @@ void OvEditor::Core::GizmoBehaviour::ApplyTranslation(const OvMaths::FMatrix4& p
 void OvEditor::Core::GizmoBehaviour::ApplyRotation(const OvMaths::FMatrix4& p_viewMatrix, const OvMaths::FMatrix4& p_projectionMatrix, const OvMaths::FVector2& p_viewSize) const
 {
 	auto unitsPerPixel = 0.2f;
-	auto originRotation = m_originalTransform->GetWorldRotation();
+	auto originRotation = m_originalTransform.GetWorldRotation();
 
 	auto screenDirection = GetScreenDirection(p_viewMatrix, p_projectionMatrix, p_viewSize);
 	screenDirection = OvMaths::FVector2(-screenDirection.y, screenDirection.x);
@@ -182,7 +182,7 @@ void OvEditor::Core::GizmoBehaviour::ApplyRotation(const OvMaths::FMatrix4& p_vi
 void OvEditor::Core::GizmoBehaviour::ApplyScale(const OvMaths::FMatrix4& p_viewMatrix, const OvMaths::FMatrix4& p_projectionMatrix, const OvMaths::FVector2& p_viewSize) const
 {
 	auto unitsPerPixel = 0.01f;
-	auto originScale = m_originalTransform->GetWorldScale();
+	auto originScale = m_originalTransform.GetWorldScale();
 
 	auto screenDirection = GetScreenDirection(p_viewMatrix, p_projectionMatrix, p_viewSize);
 

--- a/Sources/Overload/OvMaths/include/OvMaths/FTransform.h
+++ b/Sources/Overload/OvMaths/include/OvMaths/FTransform.h
@@ -34,6 +34,19 @@ namespace OvMaths
 		~FTransform();
 
 		/**
+		* Copy constructor
+		* Will make sure that the parent pointer isn't copied and that the world position, rotation and scale are preserved
+		* even after removing the link to the parent
+		*/
+		FTransform(const FTransform& p_other);
+
+		/**
+		* Assignment operator overload, to make sure that the parent pointer isn't modified and that the world position,
+		* rotation and scale are properly set to reflect the other transform.
+		*/
+		FTransform& operator=(const FTransform& p_other);
+
+		/**
 		* Simple callback that will treat parent notifications
 		* @param p_notification
 		*/

--- a/Sources/Overload/OvMaths/src/OvMaths/FTransform.cpp
+++ b/Sources/Overload/OvMaths/src/OvMaths/FTransform.cpp
@@ -18,6 +18,22 @@ OvMaths::FTransform::~FTransform()
 	Notifier.NotifyChildren(Internal::TransformNotifier::ENotification::TRANSFORM_DESTROYED);
 }
 
+OvMaths::FTransform::FTransform(const FTransform& p_other) :
+	FTransform(p_other.m_worldPosition, p_other.m_worldRotation, p_other.m_worldScale)
+{
+}
+
+OvMaths::FTransform& OvMaths::FTransform::operator=(const FTransform& p_other)
+{
+	GenerateMatricesWorld(
+		p_other.m_worldPosition,
+		p_other.m_worldRotation,
+		p_other.m_worldScale
+	);
+
+	return *this;
+}
+
 void OvMaths::FTransform::NotificationHandler(Internal::TransformNotifier::ENotification p_notification)
 {
 	switch (p_notification)


### PR DESCRIPTION
Instead of changing the way we use the `FTransform`, we should make copying an `FTransform` a "valid" operation.

These newly implemented copy constructor and assignment operators ensure that the reference to the parent isn't passed down to the copy, and that the notifiers aren't copied either.