### PR TITLE
Add hint to prioritize AMD discrete GPU

### DIFF
--- a/Sources/Overload/OvRendering/include/OvRendering/Utils/Defines.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Utils/Defines.h
@@ -12,4 +12,5 @@
 extern "C"\
 {\
 	__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;\
+	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;\
 }


### PR DESCRIPTION
when AMD driver finds this variable with the appropriate value, it enables high-performance graphics mode.