### PR TITLE
Added proper support for collapsing to `GroupCollapsable`, and set default to not collapsed

### DIFF
--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/GroupCollapsable.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/GroupCollapsable.h
@@ -33,6 +33,7 @@ namespace OvUI::Widgets::Layout
 		std::string name;
 		bool closable = false;
 		bool opened = true;
+		bool collapsed = false;
 		OvTools::Eventing::Event<> CloseEvent;
 		OvTools::Eventing::Event<> OpenEvent;
 	};

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/GroupCollapsable.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/GroupCollapsable.cpp
@@ -16,8 +16,12 @@ void OvUI::Widgets::Layout::GroupCollapsable::_Draw_Impl()
 {
 	bool previouslyOpened = opened;
 
+	ImGui::SetNextItemOpen(!collapsed);
+
 	if (ImGui::CollapsingHeader(name.c_str(), closable ? &opened : nullptr))
 		Group::_Draw_Impl();
+
+	collapsed = !ImGui::TreeNodeBehaviorIsOpen(ImGui::GetID(name.c_str()), ImGuiTreeNodeFlags_None);
 
 	if (opened != previouslyOpened)
 	{


### PR DESCRIPTION
## Description
Improved `GroupCollapsable` to make it possible to change its collapsed state programmatically (now default to unfolded).
The `GroupCollapsable` widget is not set to unfolded (`collapsed = false`) by default.

## Related Issues
Fixes #321