### PR TITLE
Fixed OvGame build folder generation

### DIFF
--- a/Sources/Overload/OvEditor/premake5.lua
+++ b/Sources/Overload/OvEditor/premake5.lua
@@ -25,13 +25,13 @@ project "OvEditor"
 		"xcopy \"%{resdir}Editor\\*\" \"%{builddir}%{cfg.buildcfg}\\Data\\Editor\" /y /i /r /e /q",
 		"xcopy \"%{prj.location}\\Layout.ini\" \"%{builddir}%{cfg.buildcfg}\\Config\\\" /y /i",
 
-		"xcopy /Y /I /Q /D \"%{outputdir}Debug\\%{prj.name}\\*.exe\" \"%{builddir}%{cfg.buildcfg}\\\"",
-		"xcopy /Y /I /Q /D \"%{outputdir}Debug\\%{prj.name}\\*.dll\" \"%{builddir}%{cfg.buildcfg}\\\"",
-		"xcopy /Y /I /Q /D \"%{outputdir}Release\\%{prj.name}\\*.exe\" \"%{builddir}%{cfg.buildcfg}\\\"",
-		"xcopy /Y /I /Q /D \"%{outputdir}Release\\%{prj.name}\\*.dll\" \"%{builddir}%{cfg.buildcfg}\\\"",
+		"xcopy /Y /I /Q /D \"%{outputdir}%{cfg.buildcfg}\\%{prj.name}\\*.exe\" \"%{builddir}%{cfg.buildcfg}\\\"",
+		"xcopy /Y /I /Q /D \"%{outputdir}%{cfg.buildcfg}\\%{prj.name}\\*.dll\" \"%{builddir}%{cfg.buildcfg}\\\"",
 
 		"xcopy \"%{outputdir}Debug\\OvGame\\*.exe\" \"%{builddir}%{cfg.buildcfg}\\Builder\\Development\" /y /i /c",
+		"xcopy \"%{outputdir}Debug\\OvGame\\*.dll\" \"%{builddir}%{cfg.buildcfg}\\Builder\\Development\" /y /i /c",
 		"xcopy \"%{outputdir}Release\\OvGame\\*.exe\" \"%{builddir}%{cfg.buildcfg}\\Builder\\Shipping\" /y /i /c",
+		"xcopy \"%{outputdir}Release\\OvGame\\*.dll\" \"%{builddir}%{cfg.buildcfg}\\Builder\\Shipping\" /y /i /c",
 
 		"EXIT /B 0"
 	}

--- a/Sources/Overload/OvGame/premake5.lua
+++ b/Sources/Overload/OvGame/premake5.lua
@@ -14,15 +14,11 @@ project "OvGame"
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
 	characterset ("MBCS")
+    debugdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 
 	postbuildcommands {
-		"for /f \"delims=|\" %%i in ('dir /B /S \"%{dependdir}\\*.dll\"') do xcopy /Q /Y \"%%i\" \"%{builddir}%{cfg.buildcfg}\\%{prj.name}\"",
-		
-		"xcopy /Y /I /Q /D \"%{outputdir}Debug\\%{prj.name}\\*.exe\" \"%{builddir}%{cfg.buildcfg}\\Builder\\Development\"",
-		"xcopy /Y /I /Q /D \"%{outputdir}Debug\\%{prj.name}\\*.dll\" \"%{builddir}%{cfg.buildcfg}\\Builder\\Development\"",
-		"xcopy /Y /I /Q /D \"%{outputdir}Release\\%{prj.name}\\*.exe\" \"%{builddir}%{cfg.buildcfg}\\Builder\\Shipping\"",
-		"xcopy /Y /I /Q /D \"%{outputdir}Release\\%{prj.name}\\*.dll\" \"%{builddir}%{cfg.buildcfg}\\Builder\\Shipping\"",
-
+		"for /f \"delims=|\" %%i in ('dir /B /S \"%{dependdir}\\*.dll\"') do xcopy /Q /Y \"%%i\" \"%{outputdir}%{cfg.buildcfg}\\%{prj.name}\"",
+        "xcopy \"%{resdir}Engine\\*\" \"%{outputdir}%{cfg.buildcfg}\\%{prj.name}\\Data\\Engine\" /y /i /r /e /q",
 		"EXIT /B 0"
 	}
 

--- a/Sources/Overload/OvGame/src/OvGame/Core/Context.cpp
+++ b/Sources/Overload/OvGame/src/OvGame/Core/Context.cpp
@@ -28,18 +28,18 @@ OvGame::Core::Context::Context() :
 
 	/* Settings */
 	OvWindowing::Settings::DeviceSettings deviceSettings;
-	deviceSettings.contextMajorVersion = projectSettings.Get<int>("opengl_major");
-	deviceSettings.contextMinorVersion = projectSettings.Get<int>("opengl_minor");
-	deviceSettings.samples = projectSettings.Get<int>("samples");
+	projectSettings.TryGet("opengl_major", deviceSettings.contextMajorVersion);
+	projectSettings.TryGet("opengl_minor", deviceSettings.contextMinorVersion);
+	projectSettings.TryGet("samples", deviceSettings.samples);
 
 	OvWindowing::Settings::WindowSettings windowSettings;
-	windowSettings.title = projectSettings.Get<std::string>("executable_name");
-	windowSettings.width = projectSettings.Get<int>("x_resolution");
-	windowSettings.height = projectSettings.Get<int>("y_resolution");
+	projectSettings.TryGet("executable_name", windowSettings.title);
+	projectSettings.TryGet("x_resolution", windowSettings.width);
+	projectSettings.TryGet("y_resolution", windowSettings.height);
 	windowSettings.maximized = false;
 	windowSettings.resizable = false;
-	windowSettings.fullscreen = projectSettings.Get<bool>("fullscreen");
-	windowSettings.samples = projectSettings.Get<int>("samples");
+	projectSettings.TryGet("fullscreen", windowSettings.fullscreen);
+	projectSettings.TryGet("samples", windowSettings.samples);
 
 	/* Window creation */
 	device = std::make_unique<OvWindowing::Context::Device>(deviceSettings);
@@ -49,10 +49,10 @@ OvGame::Core::Context::Context() :
 	inputManager = std::make_unique<OvWindowing::Inputs::InputManager>(*window);
 	window->MakeCurrentContext();
 
-	device->SetVsync(projectSettings.Get<bool>("vsync"));
+	device->SetVsync(projectSettings.GetOrDefault<bool>("vsync", true));
 
 	OvRendering::Data::PipelineState basePSO;
-	basePSO.multisample = projectSettings.Get<bool>("multisampling");
+	basePSO.multisample = projectSettings.GetOrDefault<bool>("multisampling", false);
 
 	/* Graphics context creation */
 	driver = std::make_unique<OvRendering::Context::Driver>(OvRendering::Settings::DriverSettings{

--- a/Sources/Overload/OvGame/src/OvGame/Core/Game.cpp
+++ b/Sources/Overload/OvGame/src/OvGame/Core/Game.cpp
@@ -80,6 +80,14 @@ void RenderCurrentScene(
 			p_renderer.DrawFrame();
 			p_renderer.EndFrame();
 		}
+		else
+		{
+			p_renderer.Clear(true, true, true);
+		}
+	}
+	else
+	{
+		p_renderer.Clear(true, true, true);
 	}
 }
 

--- a/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.h
+++ b/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.h
@@ -56,6 +56,14 @@ namespace OvTools::Filesystem
 		T GetOrDefault(const std::string& p_key, T p_default);
 
 		/**
+		* Try to get the value attached to the given key
+		* @param p_key
+		* @param p_outValue
+		*/
+		template<typename T>
+		bool TryGet(const std::string& p_key, T& p_outValue);
+
+		/**
 		* Set a new value to the given key (Not applied to the real file untill Rewrite() or Save() is called)
 		* @param p_key
 		* @param p_value

--- a/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.inl
+++ b/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.inl
@@ -57,6 +57,18 @@ namespace OvTools::Filesystem
 	}
 
 	template<typename T>
+	inline bool IniFile::TryGet(const std::string& p_key, T& p_outValue)
+	{
+		if (IsKeyExisting(p_key))
+		{
+			p_outValue = Get<T>(p_key);
+			return true;
+		}
+
+		return false;
+	}
+
+	template<typename T>
 	inline bool IniFile::Set(const std::string& p_key, const T& p_value)
 	{
 		if (IsKeyExisting(p_key))

--- a/Sources/Overload/OvWindowing/include/OvWindowing/Settings/WindowSettings.h
+++ b/Sources/Overload/OvWindowing/include/OvWindowing/Settings/WindowSettings.h
@@ -27,17 +27,17 @@ namespace OvWindowing::Settings
 		/**
 		* Title of the window (Displayed in the title bar)
 		*/
-		std::string title;
+		std::string title = "Overload";
 
 		/**
 		* Width in pixels of the window
 		*/
-		uint16_t width;
+		uint16_t width = 800;
 
 		/**
 		* Height in pixels of the window
 		*/
-		uint16_t height;
+		uint16_t height = 600;
 
 		/**
 		* Minimum width of the window.


### PR DESCRIPTION
# Description
* Fixed OvGame to properly generate the output folder required to make a build
* Added "TryGet" method to the IniLoader, so we can load a value from an ini file, OR keep the current value if the ini file isn't found
* Updated OvGame to make it "runnable" without a project. This will allow for easier debugging, and potentially testing test projects directly without the editor.
* Updated window settings to default to 800x600

# To-Do
- [x] Merge https://github.com/adriengivry/Overload/pull/315
- [x] Update base branch to develop

# Related Issues
Fixes https://github.com/adriengivry/Overload/issues/325