### PR TITLE
Fixed frustum culling debugger (and re-enabled frustum light culling)

### DIFF
--- a/Sources/Overload/OvCore/include/OvCore/Rendering/SceneRenderer.h
+++ b/Sources/Overload/OvCore/include/OvCore/Rendering/SceneRenderer.h
@@ -40,7 +40,7 @@ namespace OvCore::Rendering
 		struct SceneDescriptor
 		{
 			OvCore::SceneSystem::Scene& scene;
-			std::optional<OvRendering::Data::Frustum> frustumOverride;
+			OvTools::Utils::OptRef<const OvRendering::Data::Frustum> frustumOverride;
 			OvTools::Utils::OptRef<OvRendering::Data::Material> overrideMaterial;
 			OvTools::Utils::OptRef<OvRendering::Data::Material> fallbackMaterial;
 		};

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/SceneRenderer.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/SceneRenderer.cpp
@@ -91,8 +91,11 @@ void OvCore::Rendering::SceneRenderer::BeginFrame(const OvRendering::Data::Frame
 
 	auto& sceneDescriptor = GetDescriptor<SceneDescriptor>();
 
+	const bool frustumLightCulling = p_frameDescriptor.camera.value().HasFrustumLightCulling();
+
 	AddDescriptor<OvRendering::Features::LightingRenderFeature::LightingDescriptor>({
 		FindActiveLights(sceneDescriptor.scene),
+		frustumLightCulling ? sceneDescriptor.frustumOverride : std::nullopt
 	});
 
 	OvRendering::Core::CompositeRenderer::BeginFrame(p_frameDescriptor);
@@ -137,7 +140,8 @@ OvCore::Rendering::SceneRenderer::AllDrawables OvCore::Rendering::SceneRenderer:
 	auto& scene = sceneDescriptor.scene;
 	auto overrideMaterial = sceneDescriptor.overrideMaterial;
 	auto fallbackMaterial = sceneDescriptor.fallbackMaterial;
-	std::optional<OvRendering::Data::Frustum> frustum = std::nullopt;
+
+	OvTools::Utils::OptRef<const OvRendering::Data::Frustum> frustum;
 
 	if (camera.HasFrustumGeometryCulling())
 	{

--- a/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
@@ -75,8 +75,9 @@ namespace OvEditor::Settings
 
 		inline static Property<bool> ShowGeometryBounds = { false };
 		inline static Property<bool> ShowLightBounds = { false };
-		inline static Property<bool> ShowGeometryFrustumCullingInSceneView = { false };
-		inline static Property<bool> ShowLightFrustumCullingInSceneView = { false };
+		inline static Property<bool> EditorFrustumGeometryCulling = { false };
+		inline static Property<bool> EditorFrustumLightCulling = { false };
+		inline static Property<bool> DebugFrustumCulling = { false };
 		inline static Property<float> LightBillboardScale = { 0.5f };
 		inline static Property<float> TranslationSnapUnit = { 1.0f };
 		inline static Property<float> RotationSnapUnit = { 15.0f };

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
@@ -37,8 +37,6 @@ void OvEditor::Panels::AView::_Draw_Impl()
 
 void OvEditor::Panels::AView::InitFrame()
 {
-	auto camera = GetCamera();
-
 	m_renderer->AddDescriptor<OvCore::Rendering::SceneRenderer::SceneDescriptor>(
 		CreateSceneDescriptor()
 	);

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
@@ -8,6 +8,7 @@
 
 #include "OvEditor/Panels/AView.h"
 #include "OvEditor/Core/EditorActions.h"
+#include "OvEditor/Settings/EditorSettings.h"
 
 OvEditor::Panels::AView::AView
 (
@@ -36,6 +37,11 @@ void OvEditor::Panels::AView::_Draw_Impl()
 
 void OvEditor::Panels::AView::InitFrame()
 {
+	auto camera = GetCamera();
+
+	camera->SetFrustumGeometryCulling(Settings::EditorSettings::EditorFrustumGeometryCulling);
+	camera->SetFrustumLightCulling(Settings::EditorSettings::EditorFrustumLightCulling);
+
 	m_renderer->AddDescriptor<OvCore::Rendering::SceneRenderer::SceneDescriptor>(
 		CreateSceneDescriptor()
 	);

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
@@ -39,9 +39,6 @@ void OvEditor::Panels::AView::InitFrame()
 {
 	auto camera = GetCamera();
 
-	camera->SetFrustumGeometryCulling(Settings::EditorSettings::EditorFrustumGeometryCulling);
-	camera->SetFrustumLightCulling(Settings::EditorSettings::EditorFrustumLightCulling);
-
 	m_renderer->AddDescriptor<OvCore::Rendering::SceneRenderer::SceneDescriptor>(
 		CreateSceneDescriptor()
 	);

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AViewControllable.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AViewControllable.cpp
@@ -8,6 +8,7 @@
 #include "OvEditor/Rendering/DebugSceneRenderer.h"
 #include "OvEditor/Rendering/GridRenderPass.h"
 #include "OvEditor/Core/EditorActions.h"
+#include "OvEditor/Settings/EditorSettings.h"
 
 const OvMaths::FVector3 kDefaultGridColor{ 0.176f, 0.176f, 0.176f };
 const OvMaths::FVector3 kDefaultClearColor{ 0.098f, 0.098f, 0.098f };
@@ -35,6 +36,9 @@ void OvEditor::Panels::AViewControllable::Update(float p_deltaTime)
 
 void OvEditor::Panels::AViewControllable::InitFrame()
 {
+	m_camera.SetFrustumGeometryCulling(Settings::EditorSettings::EditorFrustumGeometryCulling);
+	m_camera.SetFrustumLightCulling(Settings::EditorSettings::EditorFrustumLightCulling);
+
 	AView::InitFrame();
 
 	m_renderer->AddDescriptor<Rendering::GridRenderPass::GridDescriptor>({

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
@@ -143,9 +143,9 @@ void OvEditor::Panels::MenuBar::InitializeSettingsMenu()
 	auto& debuggingMenu = m_settingsMenu->CreateWidget<MenuList>("Debugging");
 	debuggingMenu.CreateWidget<MenuItem>("Show geometry bounds", "", true, Settings::EditorSettings::ShowGeometryBounds).ValueChangedEvent += [this](bool p_value) { Settings::EditorSettings::ShowGeometryBounds = p_value; };
 	debuggingMenu.CreateWidget<MenuItem>("Show lights bounds", "", true, Settings::EditorSettings::ShowLightBounds).ValueChangedEvent += [this](bool p_value) { Settings::EditorSettings::ShowLightBounds = p_value; };
-	auto& subMenu = debuggingMenu.CreateWidget<MenuList>("Frustum culling visualizer...");
-	subMenu.CreateWidget<MenuItem>("For geometry", "", true, Settings::EditorSettings::ShowGeometryFrustumCullingInSceneView).ValueChangedEvent += [this](bool p_value) { Settings::EditorSettings::ShowGeometryFrustumCullingInSceneView = p_value; };
-	subMenu.CreateWidget<MenuItem>("For lights", "", true, Settings::EditorSettings::ShowLightFrustumCullingInSceneView).ValueChangedEvent += [this](bool p_value) { Settings::EditorSettings::ShowLightFrustumCullingInSceneView = p_value; };
+	debuggingMenu.CreateWidget<MenuItem>("Debug Frustum Culling", "", true, Settings::EditorSettings::DebugFrustumCulling).ValueChangedEvent += [this](bool p_value) { Settings::EditorSettings::DebugFrustumCulling = p_value; };
+	debuggingMenu.CreateWidget<MenuItem>("Editor Frustum Geometry Culling", "", true, Settings::EditorSettings::EditorFrustumGeometryCulling).ValueChangedEvent += [this](bool p_value) { Settings::EditorSettings::EditorFrustumGeometryCulling = p_value; };
+	debuggingMenu.CreateWidget<MenuItem>("Editor Frustum Light Culling", "", true, Settings::EditorSettings::EditorFrustumLightCulling).ValueChangedEvent += [this](bool p_value) { Settings::EditorSettings::EditorFrustumLightCulling = p_value; };
 }
 
 void OvEditor::Panels::MenuBar::CreateFileMenu()

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
@@ -102,6 +102,20 @@ OvCore::Rendering::SceneRenderer::SceneDescriptor OvEditor::Panels::SceneView::C
 {
 	auto descriptor = AViewControllable::CreateSceneDescriptor();
 	descriptor.fallbackMaterial = m_fallbackMaterial;
+
+	if (Settings::EditorSettings::DebugFrustumCulling)
+	{
+		auto& scene = *GetScene();
+
+		if (auto mainCameraComponent = scene.FindMainCamera())
+		{
+			auto& sceneCamera = mainCameraComponent->GetCamera();
+			m_camera.SetFrustumGeometryCulling(sceneCamera.HasFrustumGeometryCulling());
+			m_camera.SetFrustumLightCulling(sceneCamera.HasFrustumLightCulling());
+			descriptor.frustumOverride = sceneCamera.GetFrustum();
+		}
+	}
+
 	return descriptor;
 }
 

--- a/Sources/Overload/OvRendering/include/OvRendering/Features/LightingRenderFeature.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Features/LightingRenderFeature.h
@@ -24,6 +24,7 @@ namespace OvRendering::Features
 		struct LightingDescriptor
 		{
 			LightSet lights;
+			OvTools::Utils::OptRef<const OvRendering::Data::Frustum> frustumOverride;
 		};
 
 		/**

--- a/Sources/Overload/OvRendering/src/OvRendering/Features/LightingRenderFeature.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Features/LightingRenderFeature.cpp
@@ -34,7 +34,9 @@ void OvRendering::Features::LightingRenderFeature::OnBeginFrame(const Data::Fram
 	auto& frameDescriptor = m_renderer.GetFrameDescriptor();
 
 	std::vector<OvMaths::FMatrix4> lightMatrices;
-	auto frustum = frameDescriptor.camera->GetLightFrustum();
+	auto frustum = lightDescriptor.frustumOverride ?
+		lightDescriptor.frustumOverride :
+		frameDescriptor.camera->GetLightFrustum();
 
 	for (auto light : lightDescriptor.lights)
 	{


### PR DESCRIPTION
## Description
* Frustum culling can now be used in the editor to speed up the rendering (Scene View, Asset View...)!
* Frustum culling debugging now works properly (override frustum culling by using the main camera frustum)

## Review Guidance
- Disabled by default, enable "Editor Frustum Geometry Culling" and "Editor Frustum Light Culling" to test it with the scene view camera:
![image](https://github.com/user-attachments/assets/279e1245-e722-4365-bc35-b0740deac74b)


## To-Do
- [x] Merge https://github.com/adriengivry/Overload/pull/315
- [x] Update base branch to develop
- [x] Fix weird toggle bug (toggle is broken when enabling/disabling frustum culling)

## Related Issues
Fixes #322