### PR TITLE
Added serialization (ini) of editor settings

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
@@ -73,6 +73,16 @@ namespace OvEditor::Settings
 		*/
 		EditorSettings() = delete;
 
+		/**
+		* Save the settings
+		*/
+		static void Save();
+
+		/**
+		* Load the settings
+		*/
+		static void Load();
+
 		inline static Property<bool> ShowGeometryBounds = { false };
 		inline static Property<bool> ShowLightBounds = { false };
 		inline static Property<bool> EditorFrustumGeometryCulling = { true };

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -23,6 +23,7 @@
 #include "OvEditor/Panels/MaterialEditor.h"
 #include "OvEditor/Panels/ProjectSettings.h"
 #include "OvEditor/Panels/AssetProperties.h"
+#include "OvEditor/Settings/EditorSettings.h"
 
 using namespace OvCore::ResourceManagement;
 using namespace OvEditor::Panels;
@@ -34,6 +35,7 @@ OvEditor::Core::Editor::Editor(Context& p_context) :
 	m_panelsManager(m_canvas),
 	m_editorActions(m_context, m_panelsManager)
 {
+	Settings::EditorSettings::Load();
 	SetupUI();
 
 	m_context.sceneManager.LoadEmptyLightedScene();
@@ -41,6 +43,7 @@ OvEditor::Core::Editor::Editor(Context& p_context) :
 
 OvEditor::Core::Editor::~Editor()
 {
+	Settings::EditorSettings::Save();
 	m_context.sceneManager.UnloadCurrentScene();
 }
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Settings/EditorSettings.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Settings/EditorSettings.cpp
@@ -5,3 +5,44 @@
 */
 
 #include "OvEditor/Settings/EditorSettings.h"
+#include <OvTools/Filesystem/IniFile.h>
+
+template<class T>
+void LoadIniEntry(OvTools::Filesystem::IniFile& iniFile, const std::string& entry, OvEditor::Settings::EditorSettings::Property<T>& out)
+{
+	if (iniFile.IsKeyExisting(entry))
+	{
+		out = iniFile.Get<T>(entry);
+	}
+}
+
+void OvEditor::Settings::EditorSettings::Save()
+{
+	std::string editorSettingsPath = std::string(getenv("APPDATA")) + "\\OverloadTech\\OvEditor\\editor.ini";
+	OvTools::Filesystem::IniFile iniFile(editorSettingsPath);
+	iniFile.RemoveAll();
+	iniFile.Add("show_geometry_bounds", ShowGeometryBounds.Get());
+	iniFile.Add("show_light_bounds", ShowLightBounds.Get());
+	iniFile.Add("editor_frustum_geometry_culling", EditorFrustumGeometryCulling.Get());
+	iniFile.Add("editor_frustum_light_culling", EditorFrustumLightCulling.Get());
+	iniFile.Add("light_billboard_scale", LightBillboardScale.Get());
+	iniFile.Add("translation_snap_unit", TranslationSnapUnit.Get());
+	iniFile.Add("rotation_snap_unit", RotationSnapUnit.Get());
+	iniFile.Add("scaling_snap_unit", ScalingSnapUnit.Get());
+	iniFile.Rewrite();
+}
+
+void OvEditor::Settings::EditorSettings::Load()
+{
+	std::string editorSettingsPath = std::string(getenv("APPDATA")) + "\\OverloadTech\\OvEditor\\editor.ini";
+	OvTools::Filesystem::IniFile iniFile(editorSettingsPath);
+
+	LoadIniEntry<bool>(iniFile, "show_geometry_bounds", ShowGeometryBounds);
+	LoadIniEntry<bool>(iniFile, "show_light_bounds", ShowLightBounds);
+	LoadIniEntry<bool>(iniFile, "show_geometry_frustum_culling_in_scene_view", EditorFrustumGeometryCulling);
+	LoadIniEntry<bool>(iniFile, "show_light_frustum_culling_in_scene_view", EditorFrustumLightCulling);
+	LoadIniEntry<float>(iniFile, "light_billboard_scale", LightBillboardScale);
+	LoadIniEntry<float>(iniFile, "translation_snap_unit", TranslationSnapUnit);
+	LoadIniEntry<float>(iniFile, "rotation_snap_unit", RotationSnapUnit);
+	LoadIniEntry<float>(iniFile, "scaling_snap_unit", ScalingSnapUnit);
+}


### PR DESCRIPTION
## Description
* Serialize/deserialize settings present in `EditorSettings` respectively on editor start and stop
* Doesn't cover all the settings yet, as some exposed in the menu bar don't rely on `EditorSettings` (i.e. grid color, camera speed) Follow up issue: #353 

## Related Issues
Fixes https://github.com/adriengivry/Overload/issues/23