### PR TITLE
Fixed editor view rendering to properly skip drawing a view if it's not visible

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -223,19 +223,19 @@ void OvEditor::Core::Editor::RenderViews(float p_deltaTime)
 		sceneView.Update(p_deltaTime);
 	}
 
-	if (assetView.IsOpened())
+	if (assetView.IsOpened() && assetView.IsVisible())
 	{
 		PROFILER_SPY("Asset View Rendering");
 		assetView.Render();
 	}
 
-	if (gameView.IsOpened())
+	if (gameView.IsOpened() && gameView.IsVisible())
 	{
 		PROFILER_SPY("Game View Rendering");
 		gameView.Render();
 	}
 
-	if (sceneView.IsOpened())
+	if (sceneView.IsOpened() && sceneView.IsVisible())
 	{
 		PROFILER_SPY("Scene View Rendering");
 		sceneView.Render();

--- a/Sources/Overload/OvUI/include/OvUI/Panels/PanelWindow.h
+++ b/Sources/Overload/OvUI/include/OvUI/Panels/PanelWindow.h
@@ -74,6 +74,11 @@ namespace OvUI::Panels
 		*/
 		bool IsAppearing() const;
 
+		/**
+		* Returns true if the panel is visible
+		*/
+		bool IsVisible() const;
+
         /**
         * Scrolls to the bottom of the window
         */

--- a/Sources/Overload/OvUI/src/OvUI/Panels/PanelWindow.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Panels/PanelWindow.cpp
@@ -87,6 +87,14 @@ bool OvUI::Panels::PanelWindow::IsAppearing() const
 		return false;
 }
 
+bool OvUI::Panels::PanelWindow::IsVisible() const
+{
+	if (auto window = ImGui::FindWindowByName((name + GetPanelID()).c_str()); window)
+		return !window->Hidden;
+	else
+		return false;
+}
+
 void OvUI::Panels::PanelWindow::ScrollToBottom()
 {
     m_mustScrollToBottom = true;


### PR DESCRIPTION
## Description
Added a `IsVisible` method to the `PanelWindow`, and used it to skip view rendering if the view isn't visible.
This mostly doubles the framerate in the editor! We don't have to render the scene view and game view at all time.

## Related Issues
N/A