### PR TITLE
Fix OvGame not rendering properly

### DIFF
--- a/Sources/Overload/OvGame/include/OvGame/Core/Context.h
+++ b/Sources/Overload/OvGame/include/OvGame/Core/Context.h
@@ -62,6 +62,7 @@ namespace OvGame::Core
 		std::unique_ptr<OvAudio::Core::AudioEngine> audioEngine;
 		std::unique_ptr<OvAudio::Core::AudioPlayer> audioPlayer;
 		std::unique_ptr<OvCore::Scripting::ScriptInterpreter> scriptInterpreter;
+		std::unique_ptr<OvRendering::Buffers::Framebuffer> framebuffer;
 
 		OvCore::SceneSystem::SceneManager sceneManager;
 

--- a/Sources/Overload/OvGame/src/OvGame/Core/Context.cpp
+++ b/Sources/Overload/OvGame/src/OvGame/Core/Context.cpp
@@ -94,6 +94,8 @@ OvGame::Core::Context::Context() :
 
 	/* Scripting */
 	scriptInterpreter = std::make_unique<OvCore::Scripting::ScriptInterpreter>(projectScriptsPath);
+
+	framebuffer = std::make_unique<OvRendering::Buffers::Framebuffer>(windowSettings.width, windowSettings.height);
 }
 
 OvGame::Core::Context::~Context()

--- a/Sources/Overload/OvGame/src/OvGame/Core/Game.cpp
+++ b/Sources/Overload/OvGame/src/OvGame/Core/Game.cpp
@@ -75,11 +75,7 @@ void RenderCurrentScene(
 			frameDescriptor.renderWidth = windowWidth;
 			frameDescriptor.renderHeight = windowHeight;
 			frameDescriptor.camera = camera->GetCamera();
-
-			if (p_context.framebuffer)
-			{
-				frameDescriptor.outputBuffer = *p_context.framebuffer;
-			}
+			frameDescriptor.outputBuffer = *p_context.framebuffer;
 
 			p_renderer.BeginFrame(frameDescriptor);
 			p_renderer.DrawFrame();
@@ -126,15 +122,8 @@ void OvGame::Core::Game::Update(float p_deltaTime)
 
 		RenderCurrentScene(m_sceneRenderer, m_context);
 
-		if (m_context.framebuffer)
-		{
-			auto [windowWidth, windowHeight] = m_context.window->GetSize();
-
-			glBlitNamedFramebuffer(m_context.framebuffer->GetID(), 0,
-				0, 0, m_context.framebuffer->GetWidth(), m_context.framebuffer->GetHeight(),
-				0, 0, windowWidth, windowHeight,
-				GL_COLOR_BUFFER_BIT, GL_LINEAR);
-		}
+		auto [windowWidth, windowHeight] = m_context.window->GetSize();
+		m_context.framebuffer->BlitToBackBuffer(windowWidth, windowHeight);
 	}
 
 	m_context.sceneManager.Update();

--- a/Sources/Overload/OvGame/src/OvGame/Core/Game.cpp
+++ b/Sources/Overload/OvGame/src/OvGame/Core/Game.cpp
@@ -76,6 +76,11 @@ void RenderCurrentScene(
 			frameDescriptor.renderHeight = windowHeight;
 			frameDescriptor.camera = camera->GetCamera();
 
+			if (p_context.framebuffer)
+			{
+				frameDescriptor.outputBuffer = *p_context.framebuffer;
+			}
+
 			p_renderer.BeginFrame(frameDescriptor);
 			p_renderer.DrawFrame();
 			p_renderer.EndFrame();
@@ -120,6 +125,16 @@ void OvGame::Core::Game::Update(float p_deltaTime)
 		}
 
 		RenderCurrentScene(m_sceneRenderer, m_context);
+
+		if (m_context.framebuffer)
+		{
+			auto [windowWidth, windowHeight] = m_context.window->GetSize();
+
+			glBlitNamedFramebuffer(m_context.framebuffer->GetID(), 0,
+				0, 0, m_context.framebuffer->GetWidth(), m_context.framebuffer->GetHeight(),
+				0, 0, windowWidth, windowHeight,
+				GL_COLOR_BUFFER_BIT, GL_LINEAR);
+		}
 	}
 
 	m_context.sceneManager.Update();

--- a/Sources/Overload/OvRendering/include/OvRendering/Buffers/Framebuffer.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Buffers/Framebuffer.h
@@ -85,6 +85,13 @@ namespace OvRendering::Buffers
 		*/
 		void GenerateMipMaps() const;
 
+		/**
+		* Blit the framebuffer to the back buffer
+		* @param p_backBufferWidth
+		* @param p_backBufferHeight
+		*/
+		void BlitToBackBuffer(uint16_t p_backBufferWidth, uint16_t p_backBufferHeight) const;
+
 	private:
 		uint16_t m_width = 0;
 		uint16_t m_height = 0;

--- a/Sources/Overload/OvRendering/src/OvRendering/Buffers/Framebuffer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Buffers/Framebuffer.cpp
@@ -151,3 +151,11 @@ void OvRendering::Buffers::Framebuffer::GenerateMipMaps() const
 	glGenerateMipmap(GL_TEXTURE_2D);
 	glBindTexture(GL_TEXTURE_2D, 0);
 }
+
+void OvRendering::Buffers::Framebuffer::BlitToBackBuffer(uint16_t p_backBufferWidth, uint16_t p_backBufferHeight) const
+{
+	glBlitNamedFramebuffer(m_bufferID, 0,
+		0, 0, m_width, m_height,
+		0, 0, p_backBufferWidth, p_backBufferHeight,
+		GL_COLOR_BUFFER_BIT, GL_LINEAR);
+}


### PR DESCRIPTION
## Description
`OvGame` isn't properly rendering the game since post-process effects have been added. It seems like drawing directly to the backbuffer isn't supported anymore, as the renderer relies on an output framebuffer.

This PR adds a framebuffer to `OvGame`, and implements a solution to blit the framebuffer onto the backbuffer.

## Related Issues
Fixes #337
Fixes https://github.com/adriengivry/Overload/issues/331

