### PR TITLE
Enable Frustum Culling by default

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
@@ -75,9 +75,9 @@ namespace OvEditor::Settings
 
 		inline static Property<bool> ShowGeometryBounds = { false };
 		inline static Property<bool> ShowLightBounds = { false };
-		inline static Property<bool> EditorFrustumGeometryCulling = { false };
-		inline static Property<bool> EditorFrustumLightCulling = { false };
-		inline static Property<bool> DebugFrustumCulling = { false };
+		inline static Property<bool> EditorFrustumGeometryCulling = { true };
+		inline static Property<bool> EditorFrustumLightCulling = { true };
+		inline static Property<bool> DebugFrustumCulling = { true };
 		inline static Property<float> LightBillboardScale = { 0.5f };
 		inline static Property<float> TranslationSnapUnit = { 1.0f };
 		inline static Property<float> RotationSnapUnit = { 15.0f };

--- a/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
@@ -77,7 +77,7 @@ namespace OvEditor::Settings
 		inline static Property<bool> ShowLightBounds = { false };
 		inline static Property<bool> EditorFrustumGeometryCulling = { true };
 		inline static Property<bool> EditorFrustumLightCulling = { true };
-		inline static Property<bool> DebugFrustumCulling = { true };
+		inline static Property<bool> DebugFrustumCulling = { false };
 		inline static Property<float> LightBillboardScale = { 0.5f };
 		inline static Property<float> TranslationSnapUnit = { 1.0f };
 		inline static Property<float> RotationSnapUnit = { 15.0f };

--- a/Sources/Overload/OvRendering/src/OvRendering/Entities/Camera.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Entities/Camera.cpp
@@ -20,8 +20,8 @@ OvRendering::Entities::Camera::Camera(OvTools::Utils::OptRef<OvMaths::FTransform
 	m_clearColorBuffer(true),
 	m_clearDepthBuffer(true),
 	m_clearStencilBuffer(true),
-	m_frustumGeometryCulling(false),
-	m_frustumLightCulling(false),
+	m_frustumGeometryCulling(true),
+	m_frustumLightCulling(true),
 	m_frustum{}
 {
 }


### PR DESCRIPTION
Closes: #345

1. Change `EditorSettings.h` properties which affect Frustum Culling from `false` to `true`.