### PR TITLE
Fixed clear color alpha was set to 0.0f

### DIFF
--- a/Sources/Overload/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
@@ -58,11 +58,14 @@ void OvRendering::Core::ABaseRenderer::BeginFrame(const Data::FrameDescriptor& p
 	m_basePipelineState = m_driver.CreatePipelineState();
 	SetViewport(0, 0, p_frameDescriptor.renderWidth, p_frameDescriptor.renderHeight);
 
+	OvMaths::FVector4 clearColor = p_frameDescriptor.camera.value().GetClearColor();
+	clearColor.w = 1.0f;
+
 	Clear(
 		p_frameDescriptor.camera->GetClearColorBuffer(),
 		p_frameDescriptor.camera->GetClearDepthBuffer(),
 		p_frameDescriptor.camera->GetClearStencilBuffer(),
-		p_frameDescriptor.camera.value().GetClearColor()
+		clearColor
 	);
 
 	p_frameDescriptor.camera->CacheMatrices(p_frameDescriptor.renderWidth, p_frameDescriptor.renderHeight);

--- a/Sources/Overload/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
@@ -58,14 +58,11 @@ void OvRendering::Core::ABaseRenderer::BeginFrame(const Data::FrameDescriptor& p
 	m_basePipelineState = m_driver.CreatePipelineState();
 	SetViewport(0, 0, p_frameDescriptor.renderWidth, p_frameDescriptor.renderHeight);
 
-	OvMaths::FVector4 clearColor = p_frameDescriptor.camera.value().GetClearColor();
-	clearColor.w = 1.0f;
-
 	Clear(
 		p_frameDescriptor.camera->GetClearColorBuffer(),
 		p_frameDescriptor.camera->GetClearDepthBuffer(),
 		p_frameDescriptor.camera->GetClearStencilBuffer(),
-		clearColor
+		{ p_frameDescriptor.camera.value().GetClearColor(), 1.0f }
 	);
 
 	p_frameDescriptor.camera->CacheMatrices(p_frameDescriptor.renderWidth, p_frameDescriptor.renderHeight);


### PR DESCRIPTION
## Description
For some reason, even though the clear color `w` value (alpha component), was set to `0.0f` (which is the default when constructing a `FVector4` from a `FVector3`, the views would render properly in the editor. After some changes (I'm assuming updating C++ version from 17 to 20), this behaviour changed, and view backgrounds stop being rendered properly.

This PR fixes the issue by enforcing the alpha to be 1.0f.

## Related Issues
Fixes #356 