### PR TITLE
 Added GetPathToAppdata util function and removed getenv() usage

### DIFF
--- a/Sources/Overload/OvDebug/src/OvDebug/FileHandler.cpp
+++ b/Sources/Overload/OvDebug/src/OvDebug/FileHandler.cpp
@@ -7,6 +7,7 @@
 #define _CRT_SECURE_NO_WARNINGS // Enable getenv
 
 #include <OvTools/Time/Date.h>
+#include <OvTools/Utils/SystemCalls.h>
 
 #include "OvDebug/FileHandler.h"
 
@@ -21,7 +22,7 @@ std::string OvDebug::FileHandler::__APP_LAUNCH_DATE			= OvTools::Time::Date::Get
 std::string const OvDebug::FileHandler::__LOG_EXTENSION		= ".ovlog";
 
 std::ofstream OvDebug::FileHandler::OUTPUT_FILE;
-std::string OvDebug::FileHandler::LOG_FILE_PATH = std::string(getenv("APPDATA")) + std::string("\\OverloadTech\\OvEditor\\Log\\") + __APP_LAUNCH_DATE + __LOG_EXTENSION;
+std::string OvDebug::FileHandler::LOG_FILE_PATH = OvTools::Utils::SystemCalls::GetPathToAppdata() + std::string("\\OverloadTech\\OvEditor\\Log\\") + __APP_LAUNCH_DATE + __LOG_EXTENSION;
 
 void OvDebug::FileHandler::Log(const LogData& p_logData)
 {

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
@@ -8,6 +8,7 @@
 
 #include <OvRendering/Entities/Light.h>
 #include <OvCore/Global/ServiceLocator.h>
+#include <OvTools/Utils/SystemCalls.h>
 
 #include "OvEditor/Core/Context.h"
 
@@ -63,19 +64,19 @@ OvEditor::Core::Context::Context(const std::string& p_projectPath, const std::st
 	/* Graphics context creation */
 	driver = std::make_unique<OvRendering::Context::Driver>(OvRendering::Settings::DriverSettings{ true });
 
-	std::filesystem::create_directories(std::string(getenv("APPDATA")) + "\\OverloadTech\\OvEditor\\");
+	std::filesystem::create_directories(OvTools::Utils::SystemCalls::GetPathToAppdata() + "\\OverloadTech\\OvEditor\\");
 
 	uiManager = std::make_unique<OvUI::Core::UIManager>(window->GetGlfwWindow(), OvUI::Styling::EStyle::ALTERNATIVE_DARK);
 	uiManager->LoadFont("Ruda_Big", editorAssetsPath + "\\Fonts\\Ruda-Bold.ttf", 16);
 	uiManager->LoadFont("Ruda_Small", editorAssetsPath + "\\Fonts\\Ruda-Bold.ttf", 12);
 	uiManager->LoadFont("Ruda_Medium", editorAssetsPath + "\\Fonts\\Ruda-Bold.ttf", 14);
 	uiManager->UseFont("Ruda_Medium");
-	uiManager->SetEditorLayoutSaveFilename(std::string(getenv("APPDATA")) + "\\OverloadTech\\OvEditor\\layout.ini");
+	uiManager->SetEditorLayoutSaveFilename(OvTools::Utils::SystemCalls::GetPathToAppdata() + "\\OverloadTech\\OvEditor\\layout.ini");
 	uiManager->SetEditorLayoutAutosaveFrequency(60.0f);
 	uiManager->EnableEditorLayoutSave(true);
 	uiManager->EnableDocking(true);
 
-	if (!std::filesystem::exists(std::string(getenv("APPDATA")) + "\\OverloadTech\\OvEditor\\layout.ini"))
+	if (!std::filesystem::exists(OvTools::Utils::SystemCalls::GetPathToAppdata() + "\\OverloadTech\\OvEditor\\layout.ini"))
 		uiManager->ResetLayout("Config\\layout.ini");
 
 	/* Audio */

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -154,7 +154,7 @@ void OvEditor::Core::EditorActions::Build(bool p_autoRun, bool p_tempFolder)
 
 	if (p_tempFolder)
 	{
-		destinationFolder = std::string(getenv("APPDATA")) + "\\OverloadTech\\OvEditor\\TempBuild\\";
+		destinationFolder = OvTools::Utils::SystemCalls::GetPathToAppdata() + "\\OverloadTech\\OvEditor\\TempBuild\\";
 		try
 		{
 			std::filesystem::remove_all(destinationFolder);

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/ProjectHub.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/ProjectHub.cpp
@@ -20,12 +20,13 @@
 #include <OvUI/Widgets/InputFields/InputText.h>
 
 #include <OvTools/Utils/PathParser.h>
+#include <OvTools/Utils/SystemCalls.h>
 
 #include <OvWindowing/Dialogs/SaveFileDialog.h>
 #include <OvWindowing/Dialogs/OpenFileDialog.h>
 #include <OvWindowing/Dialogs/MessageBox.h>
 
-#define PROJECTS_FILE std::string(std::string(getenv("APPDATA")) + "\\OverloadTech\\OvEditor\\projects.ini")
+#define PROJECTS_FILE std::string(OvTools::Utils::SystemCalls::GetPathToAppdata() + "\\OverloadTech\\OvEditor\\projects.ini")
 
 class ProjectHubPanel : public OvUI::Panels::PanelWindow
 {
@@ -40,7 +41,7 @@ public:
 		movable = false;
 		titleBar = false;
 
-		std::filesystem::create_directories(std::string(getenv("APPDATA")) + "\\OverloadTech\\OvEditor\\");
+		std::filesystem::create_directories(OvTools::Utils::SystemCalls::GetPathToAppdata() + "\\OverloadTech\\OvEditor\\");
 
 		SetSize({ 1000, 580 });
 		SetPosition({ 0.f, 0.f });

--- a/Sources/Overload/OvTools/include/OvTools/Utils/SystemCalls.h
+++ b/Sources/Overload/OvTools/include/OvTools/Utils/SystemCalls.h
@@ -43,5 +43,10 @@ namespace OvTools::Utils
 		* @param p_url
 		*/
 		static void OpenURL(const std::string& p_url);
+
+		/**
+		* Return the path to APPDATA
+ 		*/
+		static std::string GetPathToAppdata();
 	};
 }

--- a/Sources/Overload/OvTools/src/OvTools/Utils/SystemCalls.cpp
+++ b/Sources/Overload/OvTools/src/OvTools/Utils/SystemCalls.cpp
@@ -9,6 +9,8 @@
 
 #include <Windows.h>
 #include <ShlObj.h>
+#include <memory>
+#include <assert.h>
 
 void OvTools::Utils::SystemCalls::ShowInExplorer(const std::string & p_path)
 {
@@ -34,22 +36,16 @@ void OvTools::Utils::SystemCalls::OpenURL(const std::string& p_url)
 
 std::string OvTools::Utils::SystemCalls::GetPathToAppdata()
 {
-	PWSTR path = nullptr;
-	std::string result;
-
-	HRESULT getPath = SHGetKnownFolderPath(FOLDERID_RoamingAppData, 0, nullptr, &path);
+	// Retrieve app-data path
+	PWSTR rawPath = nullptr;
+	const HRESULT hr = SHGetKnownFolderPath(FOLDERID_RoamingAppData, 0, nullptr, &rawPath);
+	std::unique_ptr<wchar_t, decltype(&CoTaskMemFree)> path(rawPath, CoTaskMemFree);
+	assert(SUCCEEDED(hr) && "Failed to get AppData path");
 	
-	// We get a wide string back which we need to convert back to a utf-8 string
-	if (SUCCEEDED(getPath)) {
-		// If size == 0, we have errors and are not able to convert the wide string
-		int size = WideCharToMultiByte(CP_UTF8, 0, path, -1, nullptr, 0, nullptr, nullptr);
-		if (size > 0) {
-			std::string converted(size - 1, 0);
-			WideCharToMultiByte(CP_UTF8, 0, path, -1, &converted[0], size, nullptr, nullptr);
-			result = converted;
-		}
-		CoTaskMemFree(path);
-	}
-	
-	return result;
+	// Convert app-data path from wide char to UTF-8 string
+	const int size_needed = WideCharToMultiByte(CP_UTF8, 0, path.get(), -1, nullptr, 0, nullptr, nullptr);
+	assert(size_needed > 0 && "failed to convert from wide char to UTF-8");
+	std::string appDataPath(size_needed, 0);
+	WideCharToMultiByte(CP_UTF8, 0, path.get(), -1, &appDataPath[0], size_needed, nullptr, nullptr);
+	return appDataPath;
 }

--- a/Sources/Overload/OvTools/src/OvTools/Utils/SystemCalls.cpp
+++ b/Sources/Overload/OvTools/src/OvTools/Utils/SystemCalls.cpp
@@ -8,6 +8,7 @@
 #include "OvTools/Utils/SystemCalls.h"
 
 #include <Windows.h>
+#include <ShlObj.h>
 
 void OvTools::Utils::SystemCalls::ShowInExplorer(const std::string & p_path)
 {
@@ -29,4 +30,26 @@ void OvTools::Utils::SystemCalls::EditFile(const std::string & p_file)
 void OvTools::Utils::SystemCalls::OpenURL(const std::string& p_url)
 {
 	ShellExecute(0, 0, p_url.c_str(), 0, 0, SW_SHOW);
+}
+
+std::string OvTools::Utils::SystemCalls::GetPathToAppdata()
+{
+	PWSTR path = nullptr;
+	std::string result;
+
+	HRESULT getPath = SHGetKnownFolderPath(FOLDERID_RoamingAppData, 0, nullptr, &path);
+	
+	// We get a wide string back which we need to convert back to a utf-8 string
+	if (SUCCEEDED(getPath)) {
+		// If size == 0, we have errors and are not able to convert the wide string
+		int size = WideCharToMultiByte(CP_UTF8, 0, path, -1, nullptr, 0, nullptr, nullptr);
+		if (size > 0) {
+			std::string converted(size - 1, 0);
+			WideCharToMultiByte(CP_UTF8, 0, path, -1, &converted[0], size, nullptr, nullptr);
+			result = converted;
+		}
+		CoTaskMemFree(path);
+	}
+	
+	return result;
 }


### PR DESCRIPTION
Closes: #352 

1. Used `SHGetKnownFolderPath` to retrieve `APPDATA` path and wrapped it inside a util function in `OvTools::Utils::SystemCalls`.
2. Removed usage of `getenv` resulting in warnings by `OvTools::Util::SystemCalls::GetPathToAppdata`.