### PR TITLE
Fixed release build workflow

### DIFF
--- a/OpenInVisualStudio.bat
+++ b/OpenInVisualStudio.bat
@@ -1,7 +1,7 @@
 @echo off
 
 REM Call the GenerateProjects script
-call %~dp0\Scripts\GenerateProjects.bat
+call "%~dp0\Scripts\GenerateProjects.bat"
 
 REM Check if the project generation was successful
 if %errorlevel% neq 0 (
@@ -10,6 +10,6 @@ if %errorlevel% neq 0 (
 )
 
 REM Call the OpenSolution script
-call %~dp0\Scripts\MSVC\OpenSolution.bat
+call "%~dp0\Scripts\MSVC\OpenSolution.bat"
 
 exit /b 0

--- a/Scripts/GenerateProjects.bat
+++ b/Scripts/GenerateProjects.bat
@@ -2,8 +2,8 @@
 SET version=%~1%
 if "%~1"=="" SET version="vs2022"
 
-SET premake_path=%~dp0\..\Dependencies\premake5\bin\premake5.exe
+SET premake_path="%~dp0\..\Dependencies\premake5\bin\premake5.exe"
 
-pushd %~dp0\..\Sources\Overload
+pushd "%~dp0\..\Sources\Overload"
 call %premake_path% %version%
 popd

--- a/Scripts/MSVC/BuildAll.bat
+++ b/Scripts/MSVC/BuildAll.bat
@@ -5,7 +5,7 @@ setlocal enabledelayedexpansion
 set "CONFIGURATION=%~1"
 
 :: Generate the projects
-pushd %~dp0\..\
+pushd "%~dp0\..\"
 call GenerateProjects vs2022 %CONFIGURATION%
 popd
 
@@ -59,7 +59,7 @@ echo msbuild.exe found at: "!MSBUILD_PATH!"
 echo.
 
 :: Build the solution
-pushd %~dp0..\..\Sources\Overload\
+pushd "%~dp0..\..\Sources\Overload\"
 if "%CONFIGURATION%"=="" (
     echo Building with default configuration configuration...
     "!MSBUILD_PATH!" Overload.sln -m -verbosity:minimal

--- a/Scripts/MSVC/MakeReleaseBuild.bat
+++ b/Scripts/MSVC/MakeReleaseBuild.bat
@@ -1,20 +1,53 @@
-pushd %~dp0
+pushd "%~dp0"
+
 call .\BuildAll.bat Debug
+if %ERRORLEVEL% neq 0 (
+    echo Debug build failed. Exiting.
+    exit /b %ERRORLEVEL%
+)
+
 call .\BuildAll.bat Release
-popd
+if %ERRORLEVEL% neq 0 (
+    echo Release build failed. Exiting.
+    exit /b %ERRORLEVEL%
+)
 
 :: The output is located in a folder called ..\..\Build\Release. Create an archive with this folder's content, and name the archive Overload-<version>-<platform>.zip.
 for /f "delims=" %%v in (..\..\VERSION.txt) do set version=%%v
 set platform=win32_x64
 
+
 :: Navigate to the release folder
-pushd ..\..\Build\Release
+pushd ..\..\Build\
+
+:: Delete any existing folder with the name Overload-%version%-%platform%
+if exist Overload-%version%-%platform% (
+    rmdir /s /q Overload-%version%-%platform%
+)
+
+:: Copy the folder "Release" to a new folder called "Overload-%version%-%platform%"
+xcopy Release\ ..\Releases\Overload-%version%-%platform% /E /I
 
 :: Ensure the Releases folder exists
-mkdir ..\..\Releases
+if not exist ..\Releases (
+    mkdir ..\Releases
+)
 
-:: Create the archive
-powershell Compress-Archive -Path * -DestinationPath ..\..\Releases\Overload-%version%-%platform%.zip
+:: Create the archive, but first delete any existing archive with the same name
+if exist ..\Releases\Overload-%version%-%platform%.zip (
+    del ..\Releases\Overload-%version%-%platform%.zip
+)
+powershell Compress-Archive -Path ..\Releases\Overload-%version%-%platform%\ -DestinationPath ..\Releases\Overload-%version%-%platform%.zip -Force
+echo Archive created: ..\Releases\Overload-%version%-%platform%.zip
+
+:: Delete temporary build
+if exist ..\Releases\Overload-%version%-%platform% (
+    rmdir /s /q ..\Releases\Overload-%version%-%platform%
+    echo Temporary build deleted.
+)
 
 :: Return to the original directory
 popd
+popd
+
+exit /b 0

--- a/Scripts/MSVC/MakeReleaseBuild.bat
+++ b/Scripts/MSVC/MakeReleaseBuild.bat
@@ -46,6 +46,9 @@ if exist ..\Releases\Overload-%version%-%platform% (
     echo Temporary build deleted.
 )
 
+:: Open the output folder in the file explorer
+explorer ..\Releases
+
 :: Return to the original directory
 popd
 popd

--- a/Scripts/MSVC/OpenSolution.bat
+++ b/Scripts/MSVC/OpenSolution.bat
@@ -1,6 +1,6 @@
 @echo off
 
-pushd %~dp0..\..\Sources\Overload\
+pushd "%~dp0..\..\Sources\Overload\"
 start Overload.sln
 
 exit /b 0

--- a/Scripts/RunEditor.bat
+++ b/Scripts/RunEditor.bat
@@ -7,10 +7,10 @@ set "CONFIGURATION=%~1"
 :: Build the solution
 if "%CONFIGURATION%"=="" (
     echo Launching Overload Editor in Debug mode...
-    start %~dp0\..\Build\Debug\OvEditor.exe
+    start "%~dp0\..\Build\Debug\OvEditor.exe"
 ) else (
     echo Launching Overload Editor in %CONFIGURATION% mode...
-    start %~dp0\..\Build\%CONFIGURATION%\OvEditor.exe
+    start "%~dp0\..\Build\%CONFIGURATION%\OvEditor.exe"
 )
 
 if %errorlevel% neq 0 (

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
@@ -42,7 +42,7 @@ OvEditor::Core::Context::Context(const std::string& p_projectPath, const std::st
 	OvWindowing::Settings::DeviceSettings deviceSettings;
 	deviceSettings.contextMajorVersion = 4;
 	deviceSettings.contextMinorVersion = 3;
-	windowSettings.title = "Overload Editor";
+	windowSettings.title = "Overload (" + std::string(OVERLOAD_VERSION) + ")";
 	windowSettings.width = 1600;
 	windowSettings.height = 900;
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
@@ -42,7 +42,7 @@ OvEditor::Core::Context::Context(const std::string& p_projectPath, const std::st
 	OvWindowing::Settings::DeviceSettings deviceSettings;
 	deviceSettings.contextMajorVersion = 4;
 	deviceSettings.contextMinorVersion = 3;
-	windowSettings.title = "Overload (" + std::string(OVERLOAD_VERSION) + ")";
+	windowSettings.title = "Overload";
 	windowSettings.width = 1600;
 	windowSettings.height = 900;
 

--- a/Sources/Overload/OvWindowing/include/OvWindowing/Settings/WindowSettings.h
+++ b/Sources/Overload/OvWindowing/include/OvWindowing/Settings/WindowSettings.h
@@ -27,7 +27,7 @@ namespace OvWindowing::Settings
 		/**
 		* Title of the window (Displayed in the title bar)
 		*/
-		std::string title = "Overload";
+		std::string title = "Window";
 
 		/**
 		* Width in pixels of the window


### PR DESCRIPTION
## Description
- Updated `MakeReleaseBuild.bat` script to interrupt if a build fail
- Added a folder inside of the archive, to make extraction easier
- Fixed some errors that would show up if the `Releases/` folder already exists or the release build has already been produced.
- Added call to open the output folder in the file explorer after a build
- Added proper support for spaces in path to Overload