### PR TITLE
Fixed invalid default scene when created through the asset browser

### DIFF
--- a/Sources/Overload/OvCore/include/OvCore/SceneSystem/Scene.h
+++ b/Sources/Overload/OvCore/include/OvCore/SceneSystem/Scene.h
@@ -46,6 +46,16 @@ namespace OvCore::SceneSystem
 		~Scene();
 
 		/**
+		* Add a default camera to the scene
+		*/
+		void AddDefaultCamera();
+
+		/**
+		* Add default lights to the scene
+		*/
+		void AddDefaultLights();
+
+		/**
 		* Play the scene
 		*/
 		void Play();

--- a/Sources/Overload/OvCore/include/OvCore/SceneSystem/SceneManager.h
+++ b/Sources/Overload/OvCore/include/OvCore/SceneSystem/SceneManager.h
@@ -48,9 +48,9 @@ namespace OvCore::SceneSystem
 		void LoadEmptyScene();
 
 		/**
-		* Load an empty lighted scene in memory
+		* Load a default scene in memory
 		*/
-		void LoadEmptyLightedScene();
+		void LoadDefaultScene();
 
 		/**
 		* Load specific scene in memory
@@ -108,7 +108,7 @@ namespace OvCore::SceneSystem
 
 	private:
 		const std::string m_sceneRootFolder;
-		Scene* m_currentScene = nullptr;
+		std::unique_ptr<Scene> m_currentScene = nullptr;
 
 		bool m_currentSceneLoadedFromPath = false;
 		std::string m_currentSceneSourcePath = "";

--- a/Sources/Overload/OvCore/src/OvCore/SceneSystem/Scene.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/SceneSystem/Scene.cpp
@@ -7,7 +7,9 @@
 #include <algorithm>
 #include <string>
 
-#include "OvCore/SceneSystem/Scene.h"
+#include <OvCore/SceneSystem/Scene.h>
+#include <OvCore/ECS/Components/CDirectionalLight.h>
+#include <OvCore/ECS/Components/CAmbientSphereLight.h>
 
 OvCore::SceneSystem::Scene::Scene()
 {
@@ -22,6 +24,25 @@ OvCore::SceneSystem::Scene::~Scene()
 	});
 
 	m_actors.clear();
+}
+
+void OvCore::SceneSystem::Scene::AddDefaultCamera()
+{
+	auto& camera = CreateActor("Main Camera");
+	camera.AddComponent<ECS::Components::CCamera>();
+	camera.transform.SetLocalPosition({ 0.0f, 3.0f, 8.0f });
+	camera.transform.SetLocalRotation(OvMaths::FQuaternion({ 20.0f, 180.0f, 0.0f }));
+}
+
+void OvCore::SceneSystem::Scene::AddDefaultLights()
+{
+	auto& directionalLight = CreateActor("Directional Light");
+	directionalLight.AddComponent<ECS::Components::CDirectionalLight>().SetIntensity(0.75f);
+	directionalLight.transform.SetLocalPosition({ 0.0f, 10.0f, 0.0f });
+	directionalLight.transform.SetLocalRotation(OvMaths::FQuaternion({ 120.0f, -40.0f, 0.0f }));
+
+	auto& ambientLight = CreateActor("Ambient Light");
+	ambientLight.AddComponent<ECS::Components::CAmbientSphereLight>().SetRadius(10000.0f);
 }
 
 void OvCore::SceneSystem::Scene::Play()

--- a/Sources/Overload/OvCore/src/OvCore/SceneSystem/SceneManager.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/SceneSystem/SceneManager.cpp
@@ -45,32 +45,17 @@ void OvCore::SceneSystem::SceneManager::LoadAndPlayDelayed(const std::string& p_
 void OvCore::SceneSystem::SceneManager::LoadEmptyScene()
 {
 	UnloadCurrentScene();
-
-	m_currentScene = new Scene();
-
+	m_currentScene.reset(new Scene());
 	SceneLoadEvent.Invoke();
 }
 
-void OvCore::SceneSystem::SceneManager::LoadEmptyLightedScene()
+void OvCore::SceneSystem::SceneManager::LoadDefaultScene()
 {
 	UnloadCurrentScene();
-
-	m_currentScene = new Scene();
-
+	m_currentScene.reset(new Scene());
+	m_currentScene->AddDefaultCamera();
+	m_currentScene->AddDefaultLights();
 	SceneLoadEvent.Invoke();
-
-	auto& directionalLight = m_currentScene->CreateActor("Directional Light");
-	directionalLight.AddComponent<ECS::Components::CDirectionalLight>().SetIntensity(0.75f);
-	directionalLight.transform.SetLocalPosition({ 0.0f, 10.0f, 0.0f });
-	directionalLight.transform.SetLocalRotation(OvMaths::FQuaternion({ 120.0f, -40.0f, 0.0f }));
-
-	auto& ambientLight = m_currentScene->CreateActor("Ambient Light");
-	ambientLight.AddComponent<ECS::Components::CAmbientSphereLight>().SetRadius(10000.0f);
-
-	auto& camera = m_currentScene->CreateActor("Main Camera");
-	camera.AddComponent<ECS::Components::CCamera>();
-	camera.transform.SetLocalPosition({ 0.0f, 3.0f, 8.0f });
-	camera.transform.SetLocalRotation(OvMaths::FQuaternion({ 20.0f, 180.0f, 0.0f }));
 }
 
 bool OvCore::SceneSystem::SceneManager::LoadScene(const std::string& p_path, bool p_absolute)
@@ -114,8 +99,7 @@ void OvCore::SceneSystem::SceneManager::UnloadCurrentScene()
 {
 	if (m_currentScene)
 	{
-		delete m_currentScene;
-		m_currentScene = nullptr;
+		m_currentScene.release();
 		SceneUnloadEvent.Invoke();
 	}
 
@@ -124,12 +108,12 @@ void OvCore::SceneSystem::SceneManager::UnloadCurrentScene()
 
 bool OvCore::SceneSystem::SceneManager::HasCurrentScene() const
 {
-	return m_currentScene;
+	return m_currentScene != nullptr;
 }
 
 OvCore::SceneSystem::Scene* OvCore::SceneSystem::SceneManager::GetCurrentScene() const
 {
-	return m_currentScene;
+	return m_currentScene.get();
 }
 
 std::string OvCore::SceneSystem::SceneManager::GetCurrentSceneSourcePath() const

--- a/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -303,9 +303,10 @@ namespace OvEditor::Core
 
 		/**
 		* Save the current scene to the given path
+		* @param p_sceneToSave
 		* @param p_path
 		*/
-		void SaveCurrentSceneTo(const std::string& p_path);
+		void SaveSceneToDisk(OvCore::SceneSystem::Scene& p_scene, const std::string& p_path);
 
 		/**
 		* Load a scene from the disk

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -36,7 +36,7 @@ OvEditor::Core::Editor::Editor(Context& p_context) :
 {
 	SetupUI();
 
-	m_context.sceneManager.LoadEmptyLightedScene();
+	m_context.sceneManager.LoadDefaultScene();
 }
 
 OvEditor::Core::Editor::~Editor()

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -279,8 +279,11 @@ public:
 					++fails;
 				} while (std::filesystem::exists(finalPath));
 
-				std::ofstream outfile(finalPath);
-				outfile << "<root><scene><actors><actor><name>Directional Light</name><tag></tag><active>true</active><id>1</id><parent>0</parent><components><component><type>class OvCore::ECS::Components::CDirectionalLight</type><data><diffuse><x>1</x><y>1</y><z>1</z></diffuse><specular><x>1</x><y>1</y><z>1</z></specular><intensity>0.75</intensity></data></component><component><type>class OvCore::ECS::Components::CTransform</type><data><position><x>0</x><y>10</y><z>0</z></position><rotation><x>0.81379771</x><y>-0.17101006</y><z>0.29619816</z><w>0.46984628</w></rotation><scale><x>1</x><y>1</y><z>1</z></scale></data></component></components><behaviours/></actor><actor><name>Ambient Light</name><tag></tag><active>true</active><id>2</id><parent>0</parent><components><component><type>class OvCore::ECS::Components::CAmbientSphereLight</type><data><ambient><x>1</x><y>1</y><z>1</z></ambient><intensity>0.1</intensity><radius>10000</radius></data></component><component><type>class OvCore::ECS::Components::CTransform</type><data><position><x>0</x><y>0</y><z>0</z></position><rotation><x>0</x><y>0</y><z>0</z><w>1</w></rotation><scale><x>1</x><y>1</y><z>1</z></scale></data></component></components><behaviours/></actor><actor><name>Main Camera</name><tag></tag><active>true</active><id>3</id><parent>0</parent><components><component><type>class OvCore::ECS::Components::CCamera</type><data><fov>45</fov><near>0.1</near><far>1000</far><clear_color><x>0.1921569</x><y>0.3019608</y><z>0.47450981</z></clear_color></data></component><component><type>class OvCore::ECS::Components::CTransform</type><data><position><x>0</x><y>3</y><z>8</z></position><rotation><x>-7.5904039e-09</x><y>0.98480773</y><z>-0.17364819</z><w>-4.3047311e-08</w></rotation><scale><x>1</x><y>1</y><z>1</z></scale></data></component></components><behaviours/></actor></actors></scene></root>" << std::endl; // Empty scene content
+				auto emptyScene = OvCore::SceneSystem::Scene{};
+				emptyScene.AddDefaultCamera();
+				emptyScene.AddDefaultLights();
+
+				EDITOR_EXEC(SaveSceneToDisk(emptyScene, finalPath));
 
 				ItemAddedEvent.Invoke(finalPath);
 				Close();


### PR DESCRIPTION
## User Problem
Scenes created through the asset browser: `Create... > Scene` are "pre-generated" and "pre-serialized". However, this method forces us to update the serialized version of the default scene when our components change.
This issue led to many errors showing up in the console when creating a scene through the asset browser, and then opening it.

## Proposed Changes
This PR addresses this issue by adding some tools to create a default scene, and serialize it, when a default scene is requested by the asset browser. This new workflow also make it easier to maintain what a "default scene" should look like, as it is more consistent and shared between parts of the engine.

## Notes
Also updated the `SceneManager::m_currentScene` variable type from `Scene*` to `std::unique_ptr<Scene*>` to follow the RAII idiom.