### PR TITLE
Fixed compilation warnings

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
@@ -60,6 +60,7 @@ std::array<int, 4> FindBestFitWindowSizeAndPosition(std::array<int, 4> p_workAre
 	}
 
 	OVASSERT(false, "No resolution found to fit the work area");
+	return {};
 }
 
 OvEditor::Core::Context::Context(const std::string& p_projectPath, const std::string& p_projectName) :

--- a/Sources/Overload/OvEditor/src/OvEditor/Settings/EditorSettings.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Settings/EditorSettings.cpp
@@ -4,8 +4,11 @@
 * @licence: MIT
 */
 
-#include "OvEditor/Settings/EditorSettings.h"
+#include <filesystem>
+
+#include <OvEditor/Settings/EditorSettings.h>
 #include <OvTools/Filesystem/IniFile.h>
+#include <OvTools/Utils/SystemCalls.h>
 
 template<class T>
 void LoadIniEntry(OvTools::Filesystem::IniFile& iniFile, const std::string& entry, OvEditor::Settings::EditorSettings::Property<T>& out)
@@ -16,10 +19,20 @@ void LoadIniEntry(OvTools::Filesystem::IniFile& iniFile, const std::string& entr
 	}
 }
 
+OvTools::Filesystem::IniFile GetEditorIniFile()
+{
+	const auto filePath = std::filesystem::path{ OvTools::Utils::SystemCalls::GetPathToAppdata() } /
+		"OverloadTech" /
+		"OvEditor" /
+		"editor.ini";
+
+	return OvTools::Filesystem::IniFile{ filePath.string() };
+}
+
 void OvEditor::Settings::EditorSettings::Save()
 {
-	std::string editorSettingsPath = std::string(getenv("APPDATA")) + "\\OverloadTech\\OvEditor\\editor.ini";
-	OvTools::Filesystem::IniFile iniFile(editorSettingsPath);
+	OvTools::Filesystem::IniFile iniFile = GetEditorIniFile();
+
 	iniFile.RemoveAll();
 	iniFile.Add("show_geometry_bounds", ShowGeometryBounds.Get());
 	iniFile.Add("show_light_bounds", ShowLightBounds.Get());
@@ -34,8 +47,7 @@ void OvEditor::Settings::EditorSettings::Save()
 
 void OvEditor::Settings::EditorSettings::Load()
 {
-	std::string editorSettingsPath = std::string(getenv("APPDATA")) + "\\OverloadTech\\OvEditor\\editor.ini";
-	OvTools::Filesystem::IniFile iniFile(editorSettingsPath);
+	OvTools::Filesystem::IniFile iniFile = GetEditorIniFile();
 
 	LoadIniEntry<bool>(iniFile, "show_geometry_bounds", ShowGeometryBounds);
 	LoadIniEntry<bool>(iniFile, "show_light_bounds", ShowLightBounds);

--- a/Sources/Overload/OvRendering/include/OvRendering/Core/CompositeRenderer.inl
+++ b/Sources/Overload/OvRendering/include/OvRendering/Core/CompositeRenderer.inl
@@ -78,5 +78,6 @@ namespace OvRendering::Core
 		}
 
 		OVASSERT(true, "Couldn't find a render pass matching the given type T.");
+		return *static_cast<T*>(nullptr);
 	}
 }


### PR DESCRIPTION
## Description
While planning the 1.4 release, we've noticed a few warnings. This PR addresses the following warnings:
- **warning C4715:** `OvRendering::Core::CompositeRenderer::GetPass<OvEditor::Rendering::PickingRenderPass>`: not all control paths return a value.
- **warning C4715:** `FindBestFitWindowSizeAndPosition`: not all control paths return a value.
- **warning C4996:** `getenv`: This function or variable may be unsafe.