### PR TITLE
[WIP] Fixed grid blending

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/DebugSceneRenderer.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/DebugSceneRenderer.cpp
@@ -173,6 +173,9 @@ protected:
 	{
 		TracyGpuZone("DebugActorRenderPass");
 
+		// Clear stencil buffer for outline rendering
+		m_renderer.Clear(false, false, true);
+
 		auto& debugSceneDescriptor = m_renderer.GetDescriptor<OvEditor::Rendering::DebugSceneRenderer::DebugSceneDescriptor>();
 
 		if (debugSceneDescriptor.selectedActor)
@@ -572,7 +575,7 @@ OvEditor::Rendering::DebugSceneRenderer::DebugSceneRenderer(OvRendering::Context
 	AddFeature<OvEditor::Rendering::OutlineRenderFeature>();
 	AddFeature<OvEditor::Rendering::GizmoRenderFeature>();
 
-	AddPass<GridRenderPass>("Grid", OvRendering::Settings::ERenderPassOrder::Debug);
+	AddPass<GridRenderPass>("Grid", OvRendering::Settings::ERenderPassOrder::Opaque + 1);
 	AddPass<DebugCamerasRenderPass>("Debug Cameras", OvRendering::Settings::ERenderPassOrder::Debug);
 	AddPass<DebugLightsRenderPass>("Debug Lights", OvRendering::Settings::ERenderPassOrder::Debug);
 	AddPass<DebugActorRenderPass>("Debug Actor", OvRendering::Settings::ERenderPassOrder::Debug);

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/GridRenderPass.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/GridRenderPass.cpp
@@ -23,7 +23,7 @@ OvEditor::Rendering::GridRenderPass::GridRenderPass(OvRendering::Core::Composite
 	m_gridMaterial.SetBlendable(true);
 	m_gridMaterial.SetBackfaceCulling(false);
 	m_gridMaterial.SetDepthWriting(false);
-	m_gridMaterial.SetDepthTest(false);
+	m_gridMaterial.SetDepthTest(true);
 }
 
 void OvEditor::Rendering::GridRenderPass::Draw(OvRendering::Data::PipelineState p_pso)
@@ -47,24 +47,10 @@ void OvEditor::Rendering::GridRenderPass::Draw(OvRendering::Data::PipelineState 
 
 	m_gridMaterial.SetProperty("u_Color", gridDescriptor.gridColor);
 
-	// Stencil test to ensure the grid doesn't render over any other scene geometry
-	pso.stencilTest = true;
-	pso.stencilOpFail = OvRendering::Settings::EOperation::KEEP;
-	pso.depthOpFail = OvRendering::Settings::EOperation::KEEP;
-	pso.bothOpFail = OvRendering::Settings::EOperation::REPLACE;
-	pso.stencilFuncOp = OvRendering::Settings::EComparaisonAlgorithm::NOTEQUAL;
-	pso.stencilFuncRef = 1;
-	pso.stencilFuncMask = 0xFF;
-
 	m_renderer.GetFeature<DebugModelRenderFeature>()
 	.DrawModelWithSingleMaterial(pso, *EDITOR_CONTEXT(editorResources)->GetModel("Plane"), m_gridMaterial, model);
-
-	pso.stencilTest = false;
 
 	debugShapeRenderer.DrawLine(pso, OvMaths::FVector3(-gridSize + gridDescriptor.viewPosition.x, 0.0f, 0.0f), OvMaths::FVector3(gridSize + gridDescriptor.viewPosition.x, 0.0f, 0.0f), OvMaths::FVector3(1.0f, 0.0f, 0.0f), 1.0f);
 	debugShapeRenderer.DrawLine(pso, OvMaths::FVector3(0.0f, -gridSize + gridDescriptor.viewPosition.y, 0.0f), OvMaths::FVector3(0.0f, gridSize + gridDescriptor.viewPosition.y, 0.0f), OvMaths::FVector3(0.0f, 1.0f, 0.0f), 1.0f);
 	debugShapeRenderer.DrawLine(pso, OvMaths::FVector3(0.0f, 0.0f, -gridSize + gridDescriptor.viewPosition.z), OvMaths::FVector3(0.0f, 0.0f, gridSize + gridDescriptor.viewPosition.z), OvMaths::FVector3(0.0f, 0.0f, 1.0f), 1.0f);
-
-	// Clear stencil buffer
-	m_renderer.Clear(false, false, true);
 }


### PR DESCRIPTION
## Description
* Fixed grid blending
  * Moved grid render pass to right after opaques, so that transparent objects can properly blend with it
  * Removed unused stencil usage
* Added stencil clear to `DebugActorRenderPass` for outline rendering (was necessary since the clear was removed from the `GridRendererPass`)

## Additional Notes
A side effect of moving the `GridRenderPass` to `Opaque + 1` instead of `Debug` (last), means that post-processing will apply to the grid, including FXAA and auto-exposure. In Cargo, this results in the grid looking brighter. However, since grid color can be tweaked from editor settings, this shouldn't be too much of an issue. It also helps the grid to better fit in within the scene. An issue with this approach is that colored lines might be affect by post-process effects, so they might not reflect the primary colors (red, greed, blue)

## To-Do
- [ ] Address issue in Fig 4. (axis lines colors affected by post-processing effects). We could separate the grid rendering into 2 passes: GridRenderPass (Opaque + 1), AxisIndicator (Debug)

## Related Issues
Fixes #380 

## Screenshots
![image](https://github.com/user-attachments/assets/945935d2-3dc7-4621-bcaa-728ffadf3f7b)
_Fig 1. Cargo Game_

![image](https://github.com/user-attachments/assets/3e561ec2-132f-4573-907b-8316299c6961)
_Fig 2. Empty scene with post-processing and a white cube_

![image](https://github.com/user-attachments/assets/58860196-ce62-4fff-90e5-e19ba632815e)
_Fig 3. Empty scene with post-processing and a white cube **after** adjusting scene view colors_

![image](https://github.com/user-attachments/assets/bc7bcdf7-67d5-4418-9e60-846c3dd0c3d3)
_Fig 4. When post-processing effects are enabled, the colored lines don't match the primary colors_