### PR TITLE
Fixed a crash when editing a material generated from a model

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -685,7 +685,7 @@ namespace
 			{
 				for (const std::string& materialName : model->GetMaterialNames())
 				{
-					const auto finalPath = FindAvailableFilePath(filePath / (materialName + ".ovmat"));
+					const auto finalPath = FindAvailableFilePath(filePath.parent_path() / (materialName + ".ovmat"));
 
 					const std::string fileContent = std::format(
 						"<root><shader>:Shaders\\{}.ovfx</shader></root>",


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
It used to crash when editing a material generated from a model, which is **bad**!

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #562 

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.