### PR TITLE
Fixed wrong path to `GenerateProjects.bat` when using `BuildAll.bat`

### DIFF
--- a/Scripts/Linux/BuildAll.sh
+++ b/Scripts/Linux/BuildAll.sh
@@ -7,8 +7,8 @@ CONFIGURATION="${1:-debug}"
 CONFIG_LOWER=$(echo "$CONFIGURATION" | tr '[:upper:]' '[:lower:]')
 
 # Generate the projects
-pushd "$(dirname "$0")/.." > /dev/null
-./Linux/GenerateProjects.sh gmake
+pushd "$(dirname "$0")" > /dev/null
+./GenerateProjects.sh gmake
 popd > /dev/null
 
 # Build the solution

--- a/Scripts/Windows/BuildAll.bat
+++ b/Scripts/Windows/BuildAll.bat
@@ -5,7 +5,7 @@ setlocal enabledelayedexpansion
 set "CONFIGURATION=%~1"
 
 :: Generate the projects
-pushd "%~dp0\..\"
+pushd "%~dp0"
 call GenerateProjects vs2022 %CONFIGURATION%
 popd
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
- Fixes wrong path to `GenerateProjects.bat` when using `BuildAll.bat`.
