### PR TITLE
Workaround for buggy mouse cursor with RDP

### DIFF
--- a/Sources/OvWindowing/src/OvWindowing/Window.cpp
+++ b/Sources/OvWindowing/src/OvWindowing/Window.cpp
@@ -234,6 +234,10 @@ void OvWindowing::Window::SetCursorMode(Cursor::ECursorMode p_cursorMode)
 {
 	m_cursorMode = p_cursorMode;
 
+	// Workaround to avoid mouse issues with RDP sessions on Windows. (https://github.com/glfw/glfw/issues/2463)
+	// This effectively disable the DISABLED cursor mode when in a remote session.
+	// This is far from ideal, but at least it prevents the mouse from going crazy,
+	// which keeps the application usable.
 #if defined(_WIN32)
 	if (p_cursorMode == Cursor::ECursorMode::DISABLED && GetSystemMetrics(SM_REMOTESESSION))
 	{


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Workaround that disables the "disable mouse cursor" functionality when using remote desktop.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #624 

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.
