### PR TITLE
[WIP] Added automatic DPI scaling to editor

### DIFF
--- a/Sources/OvUI/include/OvUI/Core/UIManager.h
+++ b/Sources/OvUI/include/OvUI/Core/UIManager.h
@@ -96,6 +96,12 @@ namespace OvUI::Core
 		*/
 		void EnableDocking(bool p_value);
 
+		/**
+		* Enable DPI scaling
+		* @param p_value
+		*/
+		void EnableDPIScaling(bool p_value);
+
         /**
         * Reset the UI layout to the given configuration file
         * @param p_config

--- a/Sources/OvUI/src/OvUI/Core/UIManager.cpp
+++ b/Sources/OvUI/src/OvUI/Core/UIManager.cpp
@@ -33,6 +33,9 @@ OvUI::Core::UIManager::UIManager(GLFWwindow* p_glfwWindow, Styling::EStyle p_sty
 	ImGui::CreateContext();
 
 	ImGui::GetIO().ConfigWindowsMoveFromTitleBarOnly = true; /* Disable moving windows by dragging another thing than the title bar */
+	ImGuiIO& io = ImGui::GetIO();
+	io.ConfigFlags |= ImGuiConfigFlags_DpiEnableScaleViewports;
+	io.ConfigFlags |= ImGuiConfigFlags_DpiEnableScaleFonts;
 	EnableDocking(false);
 
 	ApplyStyle(p_style);

--- a/Sources/OvUI/src/OvUI/Core/UIManager.cpp
+++ b/Sources/OvUI/src/OvUI/Core/UIManager.cpp
@@ -32,8 +32,8 @@ OvUI::Core::UIManager::UIManager(GLFWwindow* p_glfwWindow, Styling::EStyle p_sty
 {
 	ImGui::CreateContext();
 
-	ImGui::GetIO().ConfigWindowsMoveFromTitleBarOnly = true; /* Disable moving windows by dragging another thing than the title bar */
 	ImGuiIO& io = ImGui::GetIO();
+	io.ConfigWindowsMoveFromTitleBarOnly = true; /* Disable moving windows by dragging another thing than the title bar */
 	io.ConfigFlags |= ImGuiConfigFlags_DpiEnableScaleViewports;
 	io.ConfigFlags |= ImGuiConfigFlags_DpiEnableScaleFonts;
 	EnableDocking(false);

--- a/Sources/OvUI/src/OvUI/Core/UIManager.cpp
+++ b/Sources/OvUI/src/OvUI/Core/UIManager.cpp
@@ -32,10 +32,9 @@ OvUI::Core::UIManager::UIManager(GLFWwindow* p_glfwWindow, Styling::EStyle p_sty
 {
 	ImGui::CreateContext();
 
-	ImGuiIO& io = ImGui::GetIO();
-	io.ConfigWindowsMoveFromTitleBarOnly = true; /* Disable moving windows by dragging another thing than the title bar */
-	io.ConfigFlags |= ImGuiConfigFlags_DpiEnableScaleViewports;
-	io.ConfigFlags |= ImGuiConfigFlags_DpiEnableScaleFonts;
+	ImGui::GetIO().ConfigWindowsMoveFromTitleBarOnly = true; /* Disable moving windows by dragging another thing than the title bar */
+
+	EnableDPIScaling(true);
 	EnableDocking(false);
 
 	ApplyStyle(p_style);
@@ -142,7 +141,23 @@ void OvUI::Core::UIManager::EnableDocking(bool p_value)
 		ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_DockingEnable;
 }
 
-void OvUI::Core::UIManager::ResetLayout(const std::string& p_config) const
+void OvUI::Core::UIManager::EnableDPIScaling(bool p_value)
+{
+	ImGuiIO& io = ImGui::GetIO();
+
+	const auto dpiScalingFlags = ImGuiConfigFlags_DpiEnableScaleViewports | ImGuiConfigFlags_DpiEnableScaleFonts;
+
+	if (p_value)
+	{
+		io.ConfigFlags |= dpiScalingFlags;
+	}
+	else
+	{
+		io.ConfigFlags &= ~dpiScalingFlags;
+	}
+}
+
+void OvUI::Core::UIManager::ResetLayout(const std::string &p_config) const
 {
     ImGui::LoadIniSettingsFromDisk(p_config.c_str());
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->

This PR enables the following ImGui config flags:
- `ImGuiConfigFlags_DpiEnableScaleViewports`
- `ImGuiConfigFlags_DpiEnableScaleFonts`

Note: ImGui mentions:
```cpp
ImGuiConfigFlags_DpiEnableScaleViewports= 1 << 14,  // [BETA: Don't use] FIXME-DPI: Reposition and resize imgui windows when the DpiScale of a viewport changed (mostly useful for the main viewport hosting other window). Note that resizing the main window itself is up to your application.
ImGuiConfigFlags_DpiEnableScaleFonts    = 1 << 15,  // [BETA: Don't use] FIXME-DPI: Request bitmap-scaled fonts to match DpiScale. This is a very low-quality workaround. The correct way to handle DPI is _currently_ to replace the atlas and/or fonts in the Platform_OnChangedViewport callback, but this is all early work in progress.
```
So we might need to do more investigation whether this is the right approach.

**Edit: It seems like these config options do not exist anymore on ImGui's latest.**
**Edit 2: These options are now in `ImGuiIO`, as `ConfigDpiScaleFonts` and `ConfigDpiScaleViewports`**

**To-Do:**
- [ ] Fix some buttons don't scale properly
- [ ] Validate on a variety of screen sizes

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #(issue number)

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

**MacBook Pro M1 (Asahi Linux) 3456x2160**
| Before | After |
| - | - |
| <img width="3460" height="2116" alt="image" src="https://github.com/user-attachments/assets/dd497427-6cd5-4d7a-9a34-71228cf4ac97" /> | <img width="3460" height="2116" alt="image" src="https://github.com/user-attachments/assets/d7842050-0492-44c8-b05c-2f0abce19643" /> |
