### PR TITLE
Update GLBackend - Fix stack smashing

### DIFF
--- a/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLBackend.cpp
+++ b/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLBackend.cpp
@@ -87,18 +87,21 @@ namespace
 		return static_cast<bool>(result);
 	}
 
-	int GetInt(uint32_t p_parameter)
+	int GetInt(uint32_t p_parameter) 
 	{
-		GLint result;
-		glGetIntegerv(p_parameter, &result);
-		return static_cast<int>(result);
+		GLint result[4] = {}; // HACK! The crash occurs because 
+		                      // glGetIntegerv receives a variable
+                                      // integer value ​​depending on the enum;
+                                      // this is not a definitive solution!
+		glGetIntegerv(p_parameter, result);
+		return static_cast<int>(result[0]);
 	}
 
 	int GetInt(uint32_t p_parameter, uint32_t p_index)
 	{
-		GLint result;
-		glGetIntegeri_v(p_parameter, p_index, &result);
-		return static_cast<int>(result);
+		GLint result[4]; // The highest value that the function returns. 
+		glGetIntegeri_v(p_parameter, p_index, result);
+		return static_cast<int>(result[0]);
 	}
 
 	float GetFloat(uint32_t p_parameter)


### PR DESCRIPTION
## Description
Fixing the stack smashing that occurs when compiling with the debug configuration by setting a default integer on the glGetIntegerv params.

## Related Issue(s)
Fixes #634

## Review Guidance
GOTO: Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLBackend.cpp.
Changed functions: int GetInt(uint32_t p_parameter) and int GetInt(uint32_t p_parameter, uint32_t p_index).
Lines: ~90 and  ~100

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
