### PR TITLE
Fix Buffer Overflow

### DIFF
--- a/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLBackend.cpp
+++ b/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLBackend.cpp
@@ -89,16 +89,16 @@ namespace
 
 	int GetInt(uint32_t p_parameter)
 	{
-		GLint result;
-		glGetIntegerv(p_parameter, &result);
-		return static_cast<int>(result);
+		GLint result[4];
+		glGetIntegerv(p_parameter, result);
+		return static_cast<int>(result[0);
 	}
 
 	int GetInt(uint32_t p_parameter, uint32_t p_index)
 	{
-		GLint result;
-		glGetIntegeri_v(p_parameter, p_index, &result);
-		return static_cast<int>(result);
+		GLint result[4];
+		glGetIntegeri_v(p_parameter, p_index, result);
+		return static_cast<int>(result[0]);
 	}
 
 	float GetFloat(uint32_t p_parameter)


### PR DESCRIPTION
Update GetInt functions to use array for results with a fixed size of 4

## Description
### Fix for Buffer Overflow by limiting the number of integers in GLint:
```cpp
//GLBackend.cpp

GLint result[4]; // Fixed size of 4

glGetIntegerv(p_parameter, result); // The max size of glGetIntegerv is 4

return static_cast<int>(result[0]);
```

## Related Issue(s)
Fixes #634

## Checklist
- [x] My code follows the project's code style guidelines
- [x] My changes don't generate new warnings or errors

## See also

[Why a fixed value of 4?](https://stackoverflow.com/a/19016823)