### PR TITLE
Fix Inputs.GetMousePos to return FVector2 instead of FVector3

### DIFF
--- a/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaGlobalBindings.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaGlobalBindings.cpp
@@ -198,7 +198,7 @@ void BindLuaGlobal(sol::state& p_luaState)
 		"GetMouseButton", [](EMouseButton p_button) { return OVSERVICE(InputManager).GetMouseButtonState(p_button) == EMouseButtonState::MOUSE_DOWN; },
 		"GetMousePos", []() {
 			const auto mousePos = OVSERVICE(InputManager).GetMousePosition();
-			return FVector3(static_cast<float>(mousePos.first), static_cast<float>(mousePos.second));
+			return FVector2(static_cast<float>(mousePos.first), static_cast<float>(mousePos.second));
 		},
 		"GetMouseScroll", []() {
 			const auto scroll = OVSERVICE(InputManager).GetMouseScroll();


### PR DESCRIPTION
## Summary

Inputs.GetMousePos currently returns an FVector3 while the scripting API documentation specifies a Vector2.

This pull request updates the Lua binding to return an FVector2, ensuring consistency with the documented behavior and with Inputs.GetMouseScroll.

## Changes

- Updated Inputs.GetMousePos in LuaGlobalBindings.cpp
- Replaced FVector3 with FVector2

## Testing

The project builds successfully after the change.

A Lua test script was used to observe the returned value:

```lua
return {
    OnStart = function()
        Debug.LogInfo(
            tostring(Inputs:GetMousePos())
        )
    end,
}
```

Before:
- Returned a Vector3 (x, y, z)
<img width="835" height="241" alt="1" src="https://github.com/user-attachments/assets/5bd03a4a-a715-4507-a60b-9fc0bfc6ba65" />

After:
- Returns a Vector2 (x, y)
<img width="837" height="242" alt="2" src="https://github.com/user-attachments/assets/71c4ef8c-e991-47b9-816d-803fb59a70da" />

## Related issue

Closes #447