### PR TITLE
[DO NOT MERGE] Added .vscode config for linux

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug OvEditor (Debug)",
+      "type": "lldb",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/Build/Debug",
+      "program": "${workspaceFolder}/Build/Debug/OvEditor",
+      "preLaunchTask": "Build (Debug x64)"
+    },
+    {
+      "name": "Debug OvEditor (Release)",
+      "type": "lldb",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/Build/Release",
+      "program": "${workspaceFolder}/Build/Release/OvEditor",
+      "preLaunchTask": "Build (Release x64)"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,15 @@
       "cwd": "${workspaceFolder}/Build/Release",
       "program": "${workspaceFolder}/Build/Release/OvEditor",
       "preLaunchTask": "Build (Release x64)"
+    },
+    {
+      "name": "Debug OvEditor (Publish)",
+      "type": "lldb",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/Build/Publish",
+      "program": "${workspaceFolder}/Build/Publish/OvEditor",
+      "preLaunchTask": "Build (Publish x64)"
     }
+
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -77,6 +77,36 @@
       "dependsOn": []
     },
     {
+      "label": "Build (Publish x64)",
+      "type": "shell",
+      "command": "bear --append -- make -j$(nproc) config=publish_x64",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": false
+      },
+      "problemMatcher": {
+        "owner": "cpp",
+        "fileLocation": ["relative", "${workspaceFolder}"],
+        "pattern": {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      },
+      "dependsOn": []
+    },
+    {
       "label": "Clean",
       "type": "shell",
       "command": "make clean",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,95 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Generate",
+      "type": "shell",
+      "command": "./gen_proj.sh gmake",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Build (Debug x64)",
+      "type": "shell",
+      "command": "bear -- make -j$(nproc) config=debug_x64",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": false
+      },
+      "problemMatcher": {
+        "owner": "cpp",
+        "fileLocation": ["relative", "${workspaceFolder}"],
+        "pattern": {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      },
+      "dependsOn": []
+    },
+    {
+      "label": "Build (Release x64)",
+      "type": "shell",
+      "command": "bear -- make -j$(nproc) config=release_x64",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": false
+      },
+      "problemMatcher": {
+        "owner": "cpp",
+        "fileLocation": ["relative", "${workspaceFolder}"],
+        "pattern": {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      },
+      "dependsOn": []
+    },
+    {
+      "label": "Clean",
+      "type": "shell",
+      "command": "make clean",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,7 +19,7 @@
     {
       "label": "Build (Debug x64)",
       "type": "shell",
-      "command": "bear -- make -j$(nproc) config=debug_x64",
+      "command": "bear --append -- make -j$(nproc) config=debug_x64",
       "options": {
         "cwd": "${workspaceFolder}"
       },
@@ -49,7 +49,7 @@
     {
       "label": "Build (Release x64)",
       "type": "shell",
-      "command": "bear -- make -j$(nproc) config=release_x64",
+      "command": "bear --append -- make -j$(nproc) config=release_x64",
       "options": {
         "cwd": "${workspaceFolder}"
       },


### PR DESCRIPTION
> [!WARNING]
> This PR is not meant to be merged, it's just a convenient way for users to retrieve a pre-configured `.vscode/` for Overload when using Linux.

Want a cool `.vscode`? Run:
```bash
git checkout origin/feature/vscode_linux -- .vscode && git rm -r --cached .vscode
```

## To-Do
- [x] Fix `bear` to use `--append`
