### PR TITLE
Improved `ExecuteCommand` safety

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -768,6 +768,13 @@ bool OvEditor::Core::EditorActions::OpenInCodeEditor(const std::filesystem::path
 	{
 		auto preferredPath = p_path;
 		preferredPath.make_preferred();
+
+		if (command.find("{path}") == std::string::npos)
+		{
+			OVLOG_ERROR("Failed to open in code editor, missing {path} in custom command.");
+			return false;
+		}
+
 		OvTools::Utils::String::ReplaceAll(command, "{path}", p_path.string());
 		if (!OvTools::Utils::SystemCalls::ExecuteCommand(command))
 		{

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -771,7 +771,7 @@ bool OvEditor::Core::EditorActions::OpenInCodeEditor(const std::filesystem::path
 		OvTools::Utils::String::ReplaceAll(command, "{path}", p_path.string());
 		if (!OvTools::Utils::SystemCalls::ExecuteCommand(command))
 		{
-			OVLOG_ERROR(std::format("Failed to open in code editor using command: {}", command));
+			OVLOG_ERROR(std::format("Failed to open in code editor using command: \"{}\"", command));
 			return false;
 		}
 	}

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -887,18 +887,18 @@ OvEditor::Panels::AssetBrowser::AssetBrowser
 		);
 	}
 
-	auto& refreshButton = CreateWidget<Buttons::Button>("Rescan assets");
+	auto& refreshButton = CreateWidget<Buttons::Button>("Refresh");
 	refreshButton.ClickedEvent += std::bind(&AssetBrowser::Refresh, this);
 	refreshButton.lineBreak = false;
 	refreshButton.idleBackgroundColor = { 0.f, 0.5f, 0.0f };
 
-	auto& importButton = CreateWidget<Buttons::Button>("Import asset");
+	auto& importButton = CreateWidget<Buttons::Button>("Import Asset");
 	importButton.ClickedEvent += EDITOR_BIND(ImportAsset, EDITOR_CONTEXT(projectAssetsPath).string());
 	importButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
 	importButton.lineBreak = false;
 
-	auto& codeEditorButton = CreateWidget<Buttons::Button>("Open in code editor");
-	codeEditorButton.ClickedEvent += [this] { EDITOR_EXEC(OpenInCodeEditor(EDITOR_CONTEXT(projectFolder))); };
+	auto& codeEditorButton = CreateWidget<Buttons::Button>("Edit Scripts");
+	codeEditorButton.ClickedEvent += [this] { EDITOR_EXEC(OpenInCodeEditor(EDITOR_CONTEXT(projectScriptsPath))); };
 	codeEditorButton.idleBackgroundColor = { 0.1f, 0.3f, 0.7f };
 
 	m_assetList = &CreateWidget<Layout::Group>();

--- a/Sources/OvTools/src/OvTools/Utils/SystemCalls.cpp
+++ b/Sources/OvTools/src/OvTools/Utils/SystemCalls.cpp
@@ -10,20 +10,26 @@
 #ifdef _WIN32
 #include <Windows.h>
 #include <ShlObj.h>
+#include <cstdio>
+#define popen  _popen
+#define pclose _pclose
 #else
 #include <cstdlib>
 #include <unistd.h>
 #include <pwd.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #endif
 
 #include <cassert>
+#include <format>
+#include <memory>
 
 namespace
 {
 	bool CommandExists(const std::string_view p_cmd)
 	{
-		const std::string cmd{p_cmd};
+		const std::string cmd{ p_cmd };
 #ifdef _WIN32
 		std::string checkCmd = "where " + cmd + " > NUL 2>&1";
 #else
@@ -31,7 +37,11 @@ namespace
 #endif
 		FILE* pipe = popen(checkCmd.c_str(), "r");
 		if (!pipe) return false;
+#ifdef _WIN32
+		return pclose(pipe) == 0;
+#else
 		return WEXITSTATUS(pclose(pipe)) == 0;
+#endif
 	}
 }
 

--- a/Sources/OvTools/src/OvTools/Utils/SystemCalls.cpp
+++ b/Sources/OvTools/src/OvTools/Utils/SystemCalls.cpp
@@ -17,9 +17,23 @@
 #include <sys/types.h>
 #endif
 
-#include <assert.h>
-#include <format>
-#include <memory>
+#include <cassert>
+
+namespace
+{
+	bool CommandExists(const std::string_view p_cmd)
+	{
+		const std::string cmd{p_cmd};
+#ifdef _WIN32
+		std::string checkCmd = "where " + cmd + " > NUL 2>&1";
+#else
+		std::string checkCmd = "command -v " + cmd + " > /dev/null 2>&1";
+#endif
+		FILE* pipe = popen(checkCmd.c_str(), "r");
+		if (!pipe) return false;
+		return WEXITSTATUS(pclose(pipe)) == 0;
+	}
+}
 
 void OvTools::Utils::SystemCalls::ShowInExplorer(const std::string & p_path)
 {
@@ -119,6 +133,11 @@ std::string OvTools::Utils::SystemCalls::GetPathToAppdata()
 
 bool OvTools::Utils::SystemCalls::ExecuteCommand(const std::string_view p_command)
 {
+	if (!CommandExists(p_command))
+	{
+		return false;
+	}
+
 #if defined(_WIN32)
 	STARTUPINFO startupInfo;
 	PROCESS_INFORMATION processInfo;

--- a/Sources/OvTools/src/OvTools/Utils/SystemCalls.cpp
+++ b/Sources/OvTools/src/OvTools/Utils/SystemCalls.cpp
@@ -10,9 +10,6 @@
 #ifdef _WIN32
 #include <Windows.h>
 #include <ShlObj.h>
-#include <cstdio>
-#define popen  _popen
-#define pclose _pclose
 #else
 #include <cstdlib>
 #include <unistd.h>
@@ -29,17 +26,15 @@ namespace
 {
 	bool CommandExists(const std::string_view p_cmd)
 	{
-		const std::string cmd{ p_cmd };
 #ifdef _WIN32
-		std::string checkCmd = "where " + cmd + " > NUL 2>&1";
+
+		const std::string cmd{ p_cmd.substr(0, p_cmd.find(' ')) };
+		const std::string query{ "where /q " + cmd + " 2>NUL" };
+		return std::system(query.c_str()) == 0;
 #else
-		std::string checkCmd = "command -v " + cmd + " > /dev/null 2>&1";
-#endif
+		std::string checkCmd = "command -v " + std::string(p_cmd) + " > /dev/null 2>&1";
 		FILE* pipe = popen(checkCmd.c_str(), "r");
 		if (!pipe) return false;
-#ifdef _WIN32
-		return pclose(pipe) == 0;
-#else
 		return WEXITSTATUS(pclose(pipe)) == 0;
 #endif
 	}
@@ -143,11 +138,6 @@ std::string OvTools::Utils::SystemCalls::GetPathToAppdata()
 
 bool OvTools::Utils::SystemCalls::ExecuteCommand(const std::string_view p_command)
 {
-	if (!CommandExists(p_command))
-	{
-		return false;
-	}
-
 #if defined(_WIN32)
 	STARTUPINFO startupInfo;
 	PROCESS_INFORMATION processInfo;
@@ -158,28 +148,42 @@ bool OvTools::Utils::SystemCalls::ExecuteCommand(const std::string_view p_comman
 
 	std::string command = std::format("cmd.exe /c {}", p_command);
 
-	bool success = (CreateProcess(
-		nullptr,							// Application name (nullptr uses command line)
-		command.data(),						// Command to execute
-		nullptr,							// Process security attributes
-		nullptr,							// Thread security attributes
-		FALSE,								// Do not inherit handles
-		CREATE_NO_WINDOW,					// Run the process without a window
-		nullptr,							// Environment variables
-		nullptr,							// Current directory
-		&startupInfo,						// STARTUPINFO structure
-		&processInfo						// PROCESS_INFORMATION structure
-	));
+	bool success = CreateProcess(
+		nullptr,			// Application name (nullptr uses command line)
+		command.data(),			// Command to execute
+		nullptr,			// Process security attributes
+		nullptr,			// Thread security attributes
+		FALSE,				// Do not inherit handles
+		CREATE_NO_WINDOW,		// Run the process without a window
+		nullptr,			// Environment variables
+		nullptr,			// Current directory
+		&startupInfo,			// STARTUPINFO structure
+		&processInfo			// PROCESS_INFORMATION structure
+	);
 
-	// Wait until child process exits.
+	if (!success)
+		return false;
+
+	// Wait until child process exits
 	WaitForSingleObject(processInfo.hProcess, INFINITE);
+
+	// Check the exit code of the child process
+	DWORD exitCode = 0;
+	GetExitCodeProcess(processInfo.hProcess, &exitCode);
 
 	// Close the process and thread handles
 	CloseHandle(processInfo.hProcess);
 	CloseHandle(processInfo.hThread);
 
-	return success;
+	return exitCode == 0;
 #else
+	// Best way I found to reliably check if the command is going to succeed on UNIX.
+	// Running the command detached doesn't give us enough information on the exit code.
+	if (!CommandExists(p_command))
+	{
+		return false;
+	}
+
 	std::string command{ p_command };
 	command += " &"; // Ensures the command is run detached on UNIX
 	return std::system(command.c_str()) == 0;

--- a/Sources/OvTools/src/OvTools/Utils/SystemCalls.cpp
+++ b/Sources/OvTools/src/OvTools/Utils/SystemCalls.cpp
@@ -32,7 +32,7 @@ namespace
 		const std::string query{ "where /q " + cmd + " 2>NUL" };
 		return std::system(query.c_str()) == 0;
 #else
-		std::string checkCmd = "command -v " + std::string(p_cmd) + " > /dev/null 2>&1";
+		std::string checkCmd = std::format("command -v {} > /dev/null 2>&1", p_cmd);
 		FILE* pipe = popen(checkCmd.c_str(), "r");
 		if (!pipe) return false;
 		return WEXITSTATUS(pclose(pipe)) == 0;


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
- On Linux, added an early exit to `ExecuteCommand` in case the command doesn't exist.
- On Windows, improved `ExecuteCommand` to properly return `true` or `false` based on its return code.
- Added an error message when the custom code command doesn't contain `{path}`
- Also renamed "Open in code editor" button in **Asset Browser** to "Edit Scripts", and changed its behavior to open the `Scripts/` folder in the code editor instead of the project folder (ideal for `.luarc.json`)
- Also renamed "Reload Assets" button to "Refresh"

## To-Do
- [x] Fix Windows implementation (commands not working anymore, rip)
- [x] Test heavily on multiple platforms/setups

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #(issue number)

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [ ] My code follows the project's code style guidelines
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes don't generate new warnings or errors