### PR TITLE
Exposed Lua script properties through inspector

### DIFF
--- a/Sources/OvCore/include/OvCore/ECS/Components/Behaviour.h
+++ b/Sources/OvCore/include/OvCore/ECS/Components/Behaviour.h
@@ -6,7 +6,11 @@
 
 #pragma once
 
+#include <map>
+#include <string>
+
 #include <OvCore/ECS/Components/CPhysicalObject.h>
+#include <OvCore/Scripting/Common/ScriptPropertyValue.h>
 #include <OvTools/Utils/OptRef.h>
 #include <OvCore/Scripting/ScriptEngine.h>
 
@@ -164,6 +168,7 @@ namespace OvCore::ECS::Components
 
 	private:
 		std::unique_ptr<Scripting::Script> m_script;
+		std::map<std::string, Scripting::ScriptPropertyValue> m_scriptProperties;
 	};
 
 	template<>

--- a/Sources/OvCore/include/OvCore/ECS/Components/Behaviour.h
+++ b/Sources/OvCore/include/OvCore/ECS/Components/Behaviour.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <map>
+#include <set>
 #include <string>
 
 #include <OvCore/ECS/Components/CPhysicalObject.h>
@@ -168,7 +169,9 @@ namespace OvCore::ECS::Components
 
 	private:
 		std::unique_ptr<Scripting::Script> m_script;
+		std::map<std::string, Scripting::ScriptPropertyValue> m_scriptDefaults;
 		std::map<std::string, Scripting::ScriptPropertyValue> m_scriptProperties;
+		std::set<std::string> m_unlockedProperties;
 	};
 
 	template<>

--- a/Sources/OvCore/include/OvCore/Scripting/Common/ScriptPropertyValue.h
+++ b/Sources/OvCore/include/OvCore/Scripting/Common/ScriptPropertyValue.h
@@ -1,0 +1,19 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <string>
+#include <variant>
+
+namespace OvCore::Scripting
+{
+	/**
+	* Represents a primitive script property value (boolean, number, or string).
+	* This type is backend-agnostic and used by Behaviour to store and expose script fields.
+	*/
+	using ScriptPropertyValue = std::variant<bool, double, std::string>;
+}

--- a/Sources/OvCore/include/OvCore/Scripting/Common/TScript.h
+++ b/Sources/OvCore/include/OvCore/Scripting/Common/TScript.h
@@ -6,7 +6,12 @@
 
 #pragma once
 
+#include <map>
+#include <optional>
+#include <string>
+
 #include <OvCore/Scripting/Common/EScriptingLanguage.h>
+#include <OvCore/Scripting/Common/ScriptPropertyValue.h>
 
 namespace OvCore::Scripting
 {
@@ -39,6 +44,23 @@ namespace OvCore::Scripting
 		* Return the context of the script
 		*/
 		inline const Context& GetContext() const { return m_context; }
+		inline Context& GetContext() { return m_context; }
+
+		/**
+		* Returns all primitive properties and their default values as defined by the script.
+		*/
+		std::map<std::string, ScriptPropertyValue> GetDefaultProperties() const;
+
+		/**
+		* Returns the live value of a named property from the script's runtime state.
+		* Returns std::nullopt if the property does not exist or cannot be read.
+		*/
+		std::optional<ScriptPropertyValue> GetProperty(const std::string& p_key) const;
+
+		/**
+		* Sets the value of a named property in the script's runtime state.
+		*/
+		void SetProperty(const std::string& p_key, const ScriptPropertyValue& p_value);
 
 	protected:
 		Context m_context;

--- a/Sources/OvCore/src/OvCore/ECS/Components/Behaviour.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/Behaviour.cpp
@@ -4,6 +4,8 @@
 * @licence: MIT
 */
 
+#include <utility>
+
 #include <tinyxml2.h>
 
 #include <OvCore/ECS/Actor.h>
@@ -14,9 +16,8 @@
 
 #include <OvDebug/Logger.h>
 
-#include <OvUI/Widgets/Texts/TextColored.h>
 #include <OvUI/Widgets/Layout/Dummy.h>
-#include <OvUI/Widgets/Visual/Separator.h>
+#include <OvUI/Widgets/Texts/TextColored.h>
 
 OvCore::ECS::Components::Behaviour::Behaviour(ECS::Actor& p_owner, const std::string& p_name) :
 	name(p_name), AComponent(p_owner)
@@ -50,19 +51,15 @@ void OvCore::ECS::Components::Behaviour::SetScript(std::unique_ptr<Scripting::Sc
 	}
 
 	// Collect fresh defaults from the script, then merge with any same-type user overrides.
-	auto defaults = m_script->GetDefaultProperties();
-	std::map<std::string, Scripting::ScriptPropertyValue> newProperties;
+	auto old = std::exchange(m_scriptProperties, {});
 
-	for (auto& [key, defaultVal] : defaults)
+	for (auto& [key, defaultVal] : m_script->GetDefaultProperties())
 	{
-		const auto it = m_scriptProperties.find(key);
-		if (it != m_scriptProperties.end() && it->second.index() == defaultVal.index())
-			newProperties[key] = it->second;
-		else
-			newProperties[key] = defaultVal;
+		auto it = old.find(key);
+		m_scriptProperties[key] = (it != old.end() && it->second.index() == defaultVal.index())
+			? std::move(it->second)
+			: std::move(defaultVal);
 	}
-
-	m_scriptProperties = std::move(newProperties);
 
 	// Push user overrides back into the live script.
 	for (const auto& [key, val] : m_scriptProperties)
@@ -165,23 +162,13 @@ void OvCore::ECS::Components::Behaviour::OnSerialize(tinyxml2::XMLDocument & p_d
 	{
 		tinyxml2::XMLElement* elem = p_doc.NewElement(fieldKey.c_str());
 
-		std::visit([elem](auto&& v) {
-			using T = std::decay_t<decltype(v)>;
+		std::visit([elem]<typename T>(const T& v) {
 			if constexpr (std::is_same_v<T, bool>)
-			{
-				elem->SetAttribute("type", "bool");
-				elem->SetText(v);
-			}
+				{ elem->SetAttribute("type", "bool");   elem->SetText(v); }
 			else if constexpr (std::is_same_v<T, double>)
-			{
-				elem->SetAttribute("type", "number");
-				elem->SetText(v);
-			}
-			else if constexpr (std::is_same_v<T, std::string>)
-			{
-				elem->SetAttribute("type", "string");
-				elem->SetText(v.c_str());
-			}
+				{ elem->SetAttribute("type", "number"); elem->SetText(v); }
+			else
+				{ elem->SetAttribute("type", "string"); elem->SetText(v.c_str()); }
 		}, fieldValue);
 
 		propsNode->InsertEndChild(elem);
@@ -195,41 +182,35 @@ void OvCore::ECS::Components::Behaviour::OnDeserialize(tinyxml2::XMLDocument & p
 
 	for (const tinyxml2::XMLElement* elem = propsNode->FirstChildElement(); elem; elem = elem->NextSiblingElement())
 	{
-		const char* name = elem->Name();
-		const char* type = elem->Attribute("type");
+		const char* const name = elem->Name();
+		const char* const type = elem->Attribute("type");
 		if (!name || !type) continue;
 
-		const std::string nameStr(name);
-		const std::string typeStr(type);
-
-		// Only apply the loaded value when the key exists in m_scriptProperties (populated by
-		// SetScript) AND the type matches, to guard against stale or type-changed fields.
-		auto it = m_scriptProperties.find(nameStr);
+		auto it = m_scriptProperties.find(name);
 		if (it == m_scriptProperties.end()) continue;
 
-		if (typeStr == "bool" && std::holds_alternative<bool>(it->second))
+		const std::string_view typeStr{type};
+		auto& val = it->second;
+
+		if (typeStr == "bool" && std::holds_alternative<bool>(val))
 		{
-			bool val = false;
-			elem->QueryBoolText(&val);
-			it->second = val;
+			bool v = false;
+			elem->QueryBoolText(&v);
+			val = v;
 		}
-		else if (typeStr == "number" && std::holds_alternative<double>(it->second))
+		else if (typeStr == "number" && std::holds_alternative<double>(val))
 		{
-			double val = 0.0;
-			elem->QueryDoubleText(&val);
-			it->second = val;
+			double v = 0.0;
+			elem->QueryDoubleText(&v);
+			val = v;
 		}
-		else if (typeStr == "string" && std::holds_alternative<std::string>(it->second))
-		{
-			it->second = std::string(elem->GetText() ? elem->GetText() : "");
-		}
+		else if (typeStr == "string" && std::holds_alternative<std::string>(val))
+			val = elem->GetText() ? elem->GetText() : "";
 		else
-		{
 			continue;
-		}
 
 		if (m_script)
-			m_script->SetProperty(nameStr, it->second);
+			m_script->SetProperty(name, val);
 	}
 }
 
@@ -240,6 +221,7 @@ void OvCore::ECS::Components::Behaviour::OnInspector(OvUI::Internal::WidgetConta
 	if (!m_script)
 	{
 		p_root.CreateWidget<OvUI::Widgets::Texts::TextColored>("No scripting context", OvUI::Types::Color::White);
+		p_root.CreateWidget<OvUI::Widgets::Layout::Dummy>();
 	}
 	else if (m_script->IsValid())
 	{
@@ -248,60 +230,24 @@ void OvCore::ECS::Components::Behaviour::OnInspector(OvUI::Internal::WidgetConta
 
 		for (const auto& [fieldKey, fieldValue] : m_scriptProperties)
 		{
-			std::visit([&, key = fieldKey](auto&& v) {
-				using T = std::decay_t<decltype(v)>;
-
+			std::visit([&, key = fieldKey]<typename T>(const T&) {
+				auto getter = [this, key]() -> T {
+					if (auto live = m_script->GetProperty(key))
+						if (auto* val = std::get_if<T>(&*live))
+							return *val;
+					auto it = m_scriptProperties.find(key);
+					return it != m_scriptProperties.end() ? std::get<T>(it->second) : T{};
+				};
+				auto setter = [this, key](T newVal) {
+					m_scriptProperties[key] = newVal;
+					if (m_script) m_script->SetProperty(key, std::move(newVal));
+				};
 				if constexpr (std::is_same_v<T, bool>)
-				{
-					GUIDrawer::DrawBoolean(p_root, key,
-						[this, key]() -> bool {
-							if (m_script)
-								if (auto liveVal = m_script->GetProperty(key))
-									if (auto* b = std::get_if<bool>(&*liveVal))
-										return *b;
-							auto it = m_scriptProperties.find(key);
-							return it != m_scriptProperties.end() ? std::get<bool>(it->second) : false;
-						},
-						[this, key](bool newVal) {
-							m_scriptProperties[key] = newVal;
-							if (m_script) m_script->SetProperty(key, newVal);
-						}
-					);
-				}
+					GUIDrawer::DrawBoolean(p_root, key, getter, setter);
 				else if constexpr (std::is_same_v<T, double>)
-				{
-					GUIDrawer::DrawScalar<double>(p_root, key,
-						[this, key]() -> double {
-							if (m_script)
-								if (auto liveVal = m_script->GetProperty(key))
-									if (auto* d = std::get_if<double>(&*liveVal))
-										return *d;
-							auto it = m_scriptProperties.find(key);
-							return it != m_scriptProperties.end() ? std::get<double>(it->second) : 0.0;
-						},
-						[this, key](double newVal) {
-							m_scriptProperties[key] = newVal;
-							if (m_script) m_script->SetProperty(key, newVal);
-						}
-					);
-				}
-				else if constexpr (std::is_same_v<T, std::string>)
-				{
-					GUIDrawer::DrawString(p_root, key,
-						[this, key]() -> std::string {
-							if (m_script)
-								if (auto liveVal = m_script->GetProperty(key))
-									if (auto* s = std::get_if<std::string>(&*liveVal))
-										return *s;
-							auto it = m_scriptProperties.find(key);
-							return it != m_scriptProperties.end() ? std::get<std::string>(it->second) : "";
-						},
-						[this, key](std::string newVal) {
-							m_scriptProperties[key] = newVal;
-							if (m_script) m_script->SetProperty(key, std::move(newVal));
-						}
-					);
-				}
+					GUIDrawer::DrawScalar<double>(p_root, key, getter, setter);
+				else
+					GUIDrawer::DrawString(p_root, key, getter, setter);
 			}, fieldValue);
 		}
 	}

--- a/Sources/OvCore/src/OvCore/ECS/Components/Behaviour.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/Behaviour.cpp
@@ -15,6 +15,8 @@
 #include <OvDebug/Logger.h>
 
 #include <OvUI/Widgets/Texts/TextColored.h>
+#include <OvUI/Widgets/Layout/Dummy.h>
+#include <OvUI/Widgets/Visual/Separator.h>
 
 OvCore::ECS::Components::Behaviour::Behaviour(ECS::Actor& p_owner, const std::string& p_name) :
 	name(p_name), AComponent(p_owner)
@@ -242,6 +244,7 @@ void OvCore::ECS::Components::Behaviour::OnInspector(OvUI::Internal::WidgetConta
 	else if (m_script->IsValid())
 	{
 		p_root.CreateWidget<OvUI::Widgets::Texts::TextColored>("Ready", OvUI::Types::Color::Green);
+		p_root.CreateWidget<OvUI::Widgets::Texts::TextColored>("Script properties will appear below", OvUI::Types::Color::White);
 
 		for (const auto& [fieldKey, fieldValue] : m_scriptProperties)
 		{

--- a/Sources/OvCore/src/OvCore/ECS/Components/Behaviour.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/Behaviour.cpp
@@ -4,6 +4,7 @@
 * @licence: MIT
 */
 
+#include <limits>
 #include <utility>
 
 #include <tinyxml2.h>
@@ -16,7 +17,12 @@
 
 #include <OvDebug/Logger.h>
 
+#include <OvUI/Plugins/DataDispatcher.h>
+#include <OvUI/Widgets/Drags/DragSingleScalar.h>
+#include <OvUI/Widgets/InputFields/InputText.h>
 #include <OvUI/Widgets/Layout/Dummy.h>
+#include <OvUI/Widgets/Layout/Group.h>
+#include <OvUI/Widgets/Selection/CheckBox.h>
 #include <OvUI/Widgets/Texts/TextColored.h>
 
 OvCore::ECS::Components::Behaviour::Behaviour(ECS::Actor& p_owner, const std::string& p_name) :
@@ -47,18 +53,26 @@ void OvCore::ECS::Components::Behaviour::SetScript(std::unique_ptr<Scripting::Sc
 	if (!m_script || !m_script->IsValid())
 	{
 		m_scriptProperties.clear();
+		m_scriptDefaults.clear();
+		m_unlockedProperties.clear();
 		return;
 	}
 
-	// Collect fresh defaults from the script, then merge with any same-type user overrides.
-	auto old = std::exchange(m_scriptProperties, {});
+	m_scriptDefaults = m_script->GetDefaultProperties();
 
-	for (auto& [key, defaultVal] : m_script->GetDefaultProperties())
+	auto old = std::exchange(m_scriptProperties, {});
+	auto oldUnlocked = std::exchange(m_unlockedProperties, {});
+
+	for (const auto& [key, defaultVal] : m_scriptDefaults)
 	{
+		const bool wasUnlocked = oldUnlocked.contains(key);
 		auto it = old.find(key);
-		m_scriptProperties[key] = (it != old.end() && it->second.index() == defaultVal.index())
-			? std::move(it->second)
-			: std::move(defaultVal);
+		const bool canPreserve = wasUnlocked && it != old.end() && it->second.index() == defaultVal.index();
+
+		m_scriptProperties[key] = canPreserve ? std::move(it->second) : defaultVal;
+
+		if (wasUnlocked)
+			m_unlockedProperties.insert(key);
 	}
 
 	// Push user overrides back into the live script.
@@ -153,13 +167,15 @@ void OvCore::ECS::Components::Behaviour::OnTriggerExit(Components::CPhysicalObje
 
 void OvCore::ECS::Components::Behaviour::OnSerialize(tinyxml2::XMLDocument & p_doc, tinyxml2::XMLNode * p_node)
 {
-	if (m_scriptProperties.empty()) return;
+	if (m_unlockedProperties.empty()) return;
 
 	tinyxml2::XMLNode* propsNode = p_doc.NewElement("script_properties");
 	p_node->InsertEndChild(propsNode);
 
 	for (const auto& [fieldKey, fieldValue] : m_scriptProperties)
 	{
+		if (!m_unlockedProperties.contains(fieldKey)) continue;
+
 		tinyxml2::XMLElement* elem = p_doc.NewElement(fieldKey.c_str());
 
 		std::visit([elem]<typename T>(const T& v) {
@@ -209,6 +225,8 @@ void OvCore::ECS::Components::Behaviour::OnDeserialize(tinyxml2::XMLDocument & p
 		else
 			continue;
 
+		m_unlockedProperties.insert(name);
+
 		if (m_script)
 			m_script->SetProperty(name, val);
 	}
@@ -230,7 +248,9 @@ void OvCore::ECS::Components::Behaviour::OnInspector(OvUI::Internal::WidgetConta
 
 		for (const auto& [fieldKey, fieldValue] : m_scriptProperties)
 		{
-			std::visit([&, key = fieldKey]<typename T>(const T&) {
+			const bool isUnlocked = m_unlockedProperties.contains(fieldKey);
+
+			std::visit([&, key = fieldKey, unlocked = isUnlocked]<typename T>(const T&) {
 				auto getter = [this, key]() -> T {
 					if (auto live = m_script->GetProperty(key))
 						if (auto* val = std::get_if<T>(&*live))
@@ -242,12 +262,63 @@ void OvCore::ECS::Components::Behaviour::OnInspector(OvUI::Internal::WidgetConta
 					m_scriptProperties[key] = newVal;
 					if (m_script) m_script->SetProperty(key, std::move(newVal));
 				};
+
+				// Label row: [unlock checkbox] [field title], grouped together
+				auto& labelGroup = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
+				auto& unlockBox = labelGroup.CreateWidget<OvUI::Widgets::Selection::CheckBox>(unlocked);
+				unlockBox.lineBreak = false;
+				labelGroup.CreateWidget<OvUI::Widgets::Texts::TextColored>(key, GUIDrawer::TitleColor);
+
+				// Input widget on the row below
+				OvUI::Widgets::AWidget* inputPtr = nullptr;
 				if constexpr (std::is_same_v<T, bool>)
-					GUIDrawer::DrawBoolean(p_root, key, getter, setter);
+				{
+					auto& w = p_root.CreateWidget<OvUI::Widgets::Selection::CheckBox>();
+					auto& d = w.template AddPlugin<OvUI::Plugins::DataDispatcher<bool>>();
+					d.RegisterGatherer([getter]() { bool v = getter(); return reinterpret_cast<bool&>(v); });
+					d.RegisterProvider([setter](bool v) { setter(reinterpret_cast<bool&>(v)); });
+					inputPtr = &w;
+				}
 				else if constexpr (std::is_same_v<T, double>)
-					GUIDrawer::DrawScalar<double>(p_root, key, getter, setter);
+				{
+					auto& w = p_root.CreateWidget<OvUI::Widgets::Drags::DragSingleScalar<double>>(
+						GUIDrawer::GetDataType<double>(),
+						std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max(),
+						static_cast<double>(0), 1.f, "", GUIDrawer::GetFormat<double>()
+					);
+					auto& d = w.template AddPlugin<OvUI::Plugins::DataDispatcher<double>>();
+					d.RegisterGatherer(getter);
+					d.RegisterProvider(setter);
+					inputPtr = &w;
+				}
 				else
-					GUIDrawer::DrawString(p_root, key, getter, setter);
+				{
+					auto& w = p_root.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
+					auto& d = w.template AddPlugin<OvUI::Plugins::DataDispatcher<std::string>>();
+					d.RegisterGatherer(getter);
+					d.RegisterProvider(setter);
+					inputPtr = &w;
+				}
+
+				auto& inputWidget = *inputPtr;
+				inputWidget.disabled = !unlocked;
+
+				unlockBox.ValueChangedEvent += [this, key, &inputWidget](bool checked) {
+					if (checked)
+					{
+						m_unlockedProperties.insert(key);
+					}
+					else
+					{
+						m_unlockedProperties.erase(key);
+						if (auto it = m_scriptDefaults.find(key); it != m_scriptDefaults.end())
+						{
+							m_scriptProperties[key] = it->second;
+							if (m_script) m_script->SetProperty(key, it->second);
+						}
+					}
+					inputWidget.disabled = !checked;
+				};
 			}, fieldValue);
 		}
 	}

--- a/Sources/OvCore/src/OvCore/ECS/Components/Behaviour.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/Behaviour.cpp
@@ -4,9 +4,12 @@
 * @licence: MIT
 */
 
+#include <tinyxml2.h>
+
 #include <OvCore/ECS/Actor.h>
 #include <OvCore/ECS/Components/Behaviour.h>
 #include <OvCore/Global/ServiceLocator.h>
+#include <OvCore/Helpers/GUIDrawer.h>
 #include <OvCore/Scripting/ScriptEngine.h>
 
 #include <OvDebug/Logger.h>
@@ -37,6 +40,31 @@ std::string OvCore::ECS::Components::Behaviour::GetTypeName()
 void OvCore::ECS::Components::Behaviour::SetScript(std::unique_ptr<Scripting::Script> &&p_scriptContext)
 {
 	m_script = std::move(p_scriptContext);
+
+	if (!m_script || !m_script->IsValid())
+	{
+		m_scriptProperties.clear();
+		return;
+	}
+
+	// Collect fresh defaults from the script, then merge with any same-type user overrides.
+	auto defaults = m_script->GetDefaultProperties();
+	std::map<std::string, Scripting::ScriptPropertyValue> newProperties;
+
+	for (auto& [key, defaultVal] : defaults)
+	{
+		const auto it = m_scriptProperties.find(key);
+		if (it != m_scriptProperties.end() && it->second.index() == defaultVal.index())
+			newProperties[key] = it->second;
+		else
+			newProperties[key] = defaultVal;
+	}
+
+	m_scriptProperties = std::move(newProperties);
+
+	// Push user overrides back into the live script.
+	for (const auto& [key, val] : m_scriptProperties)
+		m_script->SetProperty(key, val);
 }
 
 OvTools::Utils::OptRef<OvCore::Scripting::Script> OvCore::ECS::Components::Behaviour::GetScript()
@@ -126,25 +154,153 @@ void OvCore::ECS::Components::Behaviour::OnTriggerExit(Components::CPhysicalObje
 
 void OvCore::ECS::Components::Behaviour::OnSerialize(tinyxml2::XMLDocument & p_doc, tinyxml2::XMLNode * p_node)
 {
+	if (m_scriptProperties.empty()) return;
+
+	tinyxml2::XMLNode* propsNode = p_doc.NewElement("script_properties");
+	p_node->InsertEndChild(propsNode);
+
+	for (const auto& [fieldKey, fieldValue] : m_scriptProperties)
+	{
+		tinyxml2::XMLElement* elem = p_doc.NewElement(fieldKey.c_str());
+
+		std::visit([elem](auto&& v) {
+			using T = std::decay_t<decltype(v)>;
+			if constexpr (std::is_same_v<T, bool>)
+			{
+				elem->SetAttribute("type", "bool");
+				elem->SetText(v);
+			}
+			else if constexpr (std::is_same_v<T, double>)
+			{
+				elem->SetAttribute("type", "number");
+				elem->SetText(v);
+			}
+			else if constexpr (std::is_same_v<T, std::string>)
+			{
+				elem->SetAttribute("type", "string");
+				elem->SetText(v.c_str());
+			}
+		}, fieldValue);
+
+		propsNode->InsertEndChild(elem);
+	}
 }
 
 void OvCore::ECS::Components::Behaviour::OnDeserialize(tinyxml2::XMLDocument & p_doc, tinyxml2::XMLNode * p_node)
 {
+	const tinyxml2::XMLElement* propsNode = p_node->FirstChildElement("script_properties");
+	if (!propsNode) return;
+
+	for (const tinyxml2::XMLElement* elem = propsNode->FirstChildElement(); elem; elem = elem->NextSiblingElement())
+	{
+		const char* name = elem->Name();
+		const char* type = elem->Attribute("type");
+		if (!name || !type) continue;
+
+		const std::string nameStr(name);
+		const std::string typeStr(type);
+
+		// Only apply the loaded value when the key exists in m_scriptProperties (populated by
+		// SetScript) AND the type matches, to guard against stale or type-changed fields.
+		auto it = m_scriptProperties.find(nameStr);
+		if (it == m_scriptProperties.end()) continue;
+
+		if (typeStr == "bool" && std::holds_alternative<bool>(it->second))
+		{
+			bool val = false;
+			elem->QueryBoolText(&val);
+			it->second = val;
+		}
+		else if (typeStr == "number" && std::holds_alternative<double>(it->second))
+		{
+			double val = 0.0;
+			elem->QueryDoubleText(&val);
+			it->second = val;
+		}
+		else if (typeStr == "string" && std::holds_alternative<std::string>(it->second))
+		{
+			it->second = std::string(elem->GetText() ? elem->GetText() : "");
+		}
+		else
+		{
+			continue;
+		}
+
+		if (m_script)
+			m_script->SetProperty(nameStr, it->second);
+	}
 }
 
 void OvCore::ECS::Components::Behaviour::OnInspector(OvUI::Internal::WidgetContainer & p_root)
 {
-	using namespace OvMaths;
 	using namespace OvCore::Helpers;
 
 	if (!m_script)
 	{
 		p_root.CreateWidget<OvUI::Widgets::Texts::TextColored>("No scripting context", OvUI::Types::Color::White);
 	}
-	else if (m_script && m_script->IsValid())
+	else if (m_script->IsValid())
 	{
 		p_root.CreateWidget<OvUI::Widgets::Texts::TextColored>("Ready", OvUI::Types::Color::Green);
-		p_root.CreateWidget<OvUI::Widgets::Texts::TextColored>("Your script will execute in play mode.", OvUI::Types::Color::White);
+
+		for (const auto& [fieldKey, fieldValue] : m_scriptProperties)
+		{
+			std::visit([&, key = fieldKey](auto&& v) {
+				using T = std::decay_t<decltype(v)>;
+
+				if constexpr (std::is_same_v<T, bool>)
+				{
+					GUIDrawer::DrawBoolean(p_root, key,
+						[this, key]() -> bool {
+							if (m_script)
+								if (auto liveVal = m_script->GetProperty(key))
+									if (auto* b = std::get_if<bool>(&*liveVal))
+										return *b;
+							auto it = m_scriptProperties.find(key);
+							return it != m_scriptProperties.end() ? std::get<bool>(it->second) : false;
+						},
+						[this, key](bool newVal) {
+							m_scriptProperties[key] = newVal;
+							if (m_script) m_script->SetProperty(key, newVal);
+						}
+					);
+				}
+				else if constexpr (std::is_same_v<T, double>)
+				{
+					GUIDrawer::DrawScalar<double>(p_root, key,
+						[this, key]() -> double {
+							if (m_script)
+								if (auto liveVal = m_script->GetProperty(key))
+									if (auto* d = std::get_if<double>(&*liveVal))
+										return *d;
+							auto it = m_scriptProperties.find(key);
+							return it != m_scriptProperties.end() ? std::get<double>(it->second) : 0.0;
+						},
+						[this, key](double newVal) {
+							m_scriptProperties[key] = newVal;
+							if (m_script) m_script->SetProperty(key, newVal);
+						}
+					);
+				}
+				else if constexpr (std::is_same_v<T, std::string>)
+				{
+					GUIDrawer::DrawString(p_root, key,
+						[this, key]() -> std::string {
+							if (m_script)
+								if (auto liveVal = m_script->GetProperty(key))
+									if (auto* s = std::get_if<std::string>(&*liveVal))
+										return *s;
+							auto it = m_scriptProperties.find(key);
+							return it != m_scriptProperties.end() ? std::get<std::string>(it->second) : "";
+						},
+						[this, key](std::string newVal) {
+							m_scriptProperties[key] = newVal;
+							if (m_script) m_script->SetProperty(key, std::move(newVal));
+						}
+					);
+				}
+			}, fieldValue);
+		}
 	}
 	else
 	{

--- a/Sources/OvCore/src/OvCore/Scripting/Lua/LuaScript.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/LuaScript.cpp
@@ -44,6 +44,7 @@ std::map<std::string, OvCore::Scripting::ScriptPropertyValue> OvCore::Scripting:
 	m_context.table->for_each([&](const sol::object& key, const sol::object& value) {
 		if (!key.is<std::string>()) return;
 		const std::string keyStr = key.as<std::string>();
+		if (keyStr.starts_with('_')) return;
 
 		switch (value.get_type())
 		{

--- a/Sources/OvCore/src/OvCore/Scripting/Lua/LuaScript.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/LuaScript.cpp
@@ -33,3 +33,52 @@ void OvCore::Scripting::LuaScript::SetOwner(OvCore::ECS::Actor& p_owner)
 {
 	(*m_context.table)["owner"] = &p_owner;
 }
+
+template<>
+std::map<std::string, OvCore::Scripting::ScriptPropertyValue> OvCore::Scripting::LuaScriptBase::GetDefaultProperties() const
+{
+	std::map<std::string, ScriptPropertyValue> properties;
+
+	if (!IsValid()) return properties;
+
+	m_context.table->for_each([&](const sol::object& key, const sol::object& value) {
+		if (!key.is<std::string>()) return;
+		const std::string keyStr = key.as<std::string>();
+
+		switch (value.get_type())
+		{
+			case sol::type::boolean: properties[keyStr] = value.as<bool>();        break;
+			case sol::type::number:  properties[keyStr] = value.as<double>();      break;
+			case sol::type::string:  properties[keyStr] = value.as<std::string>(); break;
+			default: break;
+		}
+	});
+
+	return properties;
+}
+
+template<>
+std::optional<OvCore::Scripting::ScriptPropertyValue> OvCore::Scripting::LuaScriptBase::GetProperty(const std::string& p_key) const
+{
+	if (!IsValid()) return std::nullopt;
+
+	const sol::object obj = (*m_context.table)[p_key];
+
+	switch (obj.get_type())
+	{
+		case sol::type::boolean: return obj.as<bool>();
+		case sol::type::number:  return obj.as<double>();
+		case sol::type::string:  return obj.as<std::string>();
+		default:                 return std::nullopt;
+	}
+}
+
+template<>
+void OvCore::Scripting::LuaScriptBase::SetProperty(const std::string& p_key, const OvCore::Scripting::ScriptPropertyValue& p_value)
+{
+	if (!IsValid()) return;
+
+	std::visit([&](auto&& v) {
+		(*m_context.table)[p_key] = v;
+	}, p_value);
+}

--- a/Sources/OvCore/src/OvCore/Scripting/Null/NullScript.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Null/NullScript.cpp
@@ -14,3 +14,12 @@ OvCore::Scripting::NullScript::~TScript() {}
 
 template<>
 bool OvCore::Scripting::NullScript::IsValid() const { return true; }
+
+template<>
+std::map<std::string, OvCore::Scripting::ScriptPropertyValue> OvCore::Scripting::NullScript::GetDefaultProperties() const { return {}; }
+
+template<>
+std::optional<OvCore::Scripting::ScriptPropertyValue> OvCore::Scripting::NullScript::GetProperty(const std::string&) const { return std::nullopt; }
+
+template<>
+void OvCore::Scripting::NullScript::SetProperty(const std::string&, const OvCore::Scripting::ScriptPropertyValue&) {}


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
This PR exposes all public (non `_` prefixed) members in a script's lua table.

Properties are "locked" by default, so that when the default value changes in Lua, it's not overridden by the value set in the inspector.

Example script used:
```lua
---@class oui : Behaviour
local oui =
{
    name = "",
    foo = 0,
    yes = false,
    _private = "You cannot see me!"
}

function oui:OnStart()
    Debug.Log("Hello " .. self.name .. "!")
end

function oui:OnUpdate(deltaTime)
end

return oui
```

## To-Do
- [x] Find a way to avoid serialization to override any future default value update in the script.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #419

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
<img width="466" height="268" alt="image" src="https://github.com/user-attachments/assets/bd1a8230-9bcd-4a25-a8c9-5ebfea56b29d" />


## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
