### PR TITLE
Fixed selection outline reverting to T-pose when clearing skinned mesh materials

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Rendering/OutlineRenderFeature.cpp
+++ b/Sources/OvEditor/src/OvEditor/Rendering/OutlineRenderFeature.cpp
@@ -19,6 +19,7 @@ namespace
 	constexpr uint32_t kStencilMask = 0xFF;
 	constexpr int32_t kStencilReference = 1;
 	constexpr std::string_view kOutlinePassName = "OUTLINE_PASS";
+	const std::string kSkinningFeatureName = std::string{ OvCore::Rendering::SkinningUtils::kFeatureName };
 
 	using MaterialList = OvCore::ECS::Components::CMaterialRenderer::MaterialList;
 
@@ -241,16 +242,16 @@ void OvEditor::Rendering::OutlineRenderFeature::DrawModelToStencil(
 
 	for (auto mesh : p_model.GetMeshes())
 	{
-		const auto* originalMaterial = FindMeshMaterial(p_materials, mesh->GetMaterialIndex());
-		const bool skinningEnabled = hasSkinning && originalMaterial &&
-			originalMaterial->SupportsFeature(std::string{ OvCore::Rendering::SkinningUtils::kFeatureName });
-
 		auto& targetMaterial = ResolveOutlineMaterial(
 			mesh->GetMaterialIndex(),
 			outlinePassName,
 			p_materials,
 			m_stencilFillMaterial
 		);
+		const bool skinningEnabled =
+			hasSkinning &&
+			mesh->HasSkinningData() &&
+			targetMaterial.SupportsFeature(kSkinningFeatureName);
 
 		auto stateMask = targetMaterial.GenerateStateMask();
 
@@ -288,16 +289,16 @@ void OvEditor::Rendering::OutlineRenderFeature::DrawModelOutline(
 
 	for (auto mesh : p_model.GetMeshes())
 	{
-		const auto* originalMaterial = FindMeshMaterial(p_materials, mesh->GetMaterialIndex());
-		const bool skinningEnabled = hasSkinning && originalMaterial &&
-			originalMaterial->SupportsFeature(std::string{ OvCore::Rendering::SkinningUtils::kFeatureName });
-
 		auto& targetMaterial = ResolveOutlineMaterial(
 			mesh->GetMaterialIndex(),
 			outlinePassName,
 			p_materials,
 			m_outlineMaterial
 		);
+		const bool skinningEnabled =
+			hasSkinning &&
+			mesh->HasSkinningData() &&
+			targetMaterial.SupportsFeature(kSkinningFeatureName);
 
 		// Set the outline color property if it exists
 		if (targetMaterial.GetProperty("_OutlineColor"))

--- a/Sources/OvEditor/src/OvEditor/Rendering/OutlineRenderFeature.cpp
+++ b/Sources/OvEditor/src/OvEditor/Rendering/OutlineRenderFeature.cpp
@@ -242,15 +242,19 @@ void OvEditor::Rendering::OutlineRenderFeature::DrawModelToStencil(
 
 	for (auto mesh : p_model.GetMeshes())
 	{
+		const auto* originalMaterial = FindMeshMaterial(p_materials, mesh->GetMaterialIndex());
 		auto& targetMaterial = ResolveOutlineMaterial(
 			mesh->GetMaterialIndex(),
 			outlinePassName,
 			p_materials,
 			m_stencilFillMaterial
 		);
+		const bool originalMaterialSupportsSkinning =
+			!originalMaterial || originalMaterial->SupportsFeature(kSkinningFeatureName);
 		const bool skinningEnabled =
 			hasSkinning &&
 			mesh->HasSkinningData() &&
+			originalMaterialSupportsSkinning &&
 			targetMaterial.SupportsFeature(kSkinningFeatureName);
 
 		auto stateMask = targetMaterial.GenerateStateMask();
@@ -289,15 +293,19 @@ void OvEditor::Rendering::OutlineRenderFeature::DrawModelOutline(
 
 	for (auto mesh : p_model.GetMeshes())
 	{
+		const auto* originalMaterial = FindMeshMaterial(p_materials, mesh->GetMaterialIndex());
 		auto& targetMaterial = ResolveOutlineMaterial(
 			mesh->GetMaterialIndex(),
 			outlinePassName,
 			p_materials,
 			m_outlineMaterial
 		);
+		const bool originalMaterialSupportsSkinning =
+			!originalMaterial || originalMaterial->SupportsFeature(kSkinningFeatureName);
 		const bool skinningEnabled =
 			hasSkinning &&
 			mesh->HasSkinningData() &&
+			originalMaterialSupportsSkinning &&
 			targetMaterial.SupportsFeature(kSkinningFeatureName);
 
 		// Set the outline color property if it exists


### PR DESCRIPTION
## Description
This PR fixes a bug where the Scene View selection outline for skinned meshes reverts to the T-pose after clearing a material slot in `CMaterialRenderer`.

Root cause:
- Outline skinning was enabled only when the original material existed and supported skinning.
- Clearing a material sets that slot to `nullptr`, which disabled skinning for outline rendering.

Fix:
- In `OutlineRenderFeature`, skinning is now decided from the resolved target material (regular material with `OUTLINE_PASS` or fallback outline material), not only the original material pointer.
- Added `mesh->HasSkinningData()` checks to keep skinning activation consistent and safe in both stencil and outline paths.

## Related Issue(s)
Fixes #671

## Review Guidance
1. Select an actor with an animated skinned mesh.
2. Verify the selection outline follows the animated pose.
3. Clear one material slot from the actor's `Material Renderer`.
4. Verify the outline still follows animation and no longer reverts to T-pose.

## Screenshots/GIFs
<img width="1919" height="1019" alt="1" src="https://github.com/user-attachments/assets/a5a3ffe2-25aa-46cc-bb5c-6536c150b5a5" />

## Checklist
- [x] My code follows the project's code style guidelines
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
