### PR TITLE
Various UI improvements

### DIFF
--- a/Sources/OvCore/include/OvCore/ECS/Actor.h
+++ b/Sources/OvCore/include/OvCore/ECS/Actor.h
@@ -290,6 +290,13 @@ namespace OvCore::ECS
 		bool RemoveBehaviour(const std::string& p_name);
 
 		/**
+		* Rename a behaviour, preserving its position in the ordering
+		* @param p_previousName
+		* @param p_newName
+		*/
+		bool RenameBehaviour(const std::string& p_previousName, const std::string& p_newName);
+
+		/**
 		* Try to get the given behaviour (Returns nullptr on failure)
 		* @param p_name
 		*/

--- a/Sources/OvCore/include/OvCore/ECS/Actor.h
+++ b/Sources/OvCore/include/OvCore/ECS/Actor.h
@@ -301,6 +301,11 @@ namespace OvCore::ECS
 		std::unordered_map<std::string, Components::Behaviour>& GetBehaviours();
 
 		/**
+		* Returns the ordered list of behaviour names (display/serialization order)
+		*/
+		std::vector<std::string>& GetBehavioursOrder();
+
+		/**
 		* Serialize all the components
 		*/
 		virtual void OnSerialize(tinyxml2::XMLDocument& p_doc, tinyxml2::XMLNode* p_actorsRoot) override;
@@ -356,6 +361,7 @@ namespace OvCore::ECS
 		/* Actors components */
 		std::vector<std::shared_ptr<Components::AComponent>> m_components;
 		std::unordered_map<std::string, Components::Behaviour> m_behaviours;
+		std::vector<std::string> m_behavioursOrder;
 
 	public:
 		Components::CTransform& transform;

--- a/Sources/OvCore/include/OvCore/ECS/Actor.inl
+++ b/Sources/OvCore/include/OvCore/ECS/Actor.inl
@@ -17,8 +17,8 @@ namespace OvCore::ECS
 
 		if (auto found = GetComponent<T>(); !found)
 		{
-			m_components.insert(m_components.begin(), std::make_shared<T>(*this, p_args...));
-			T& instance = *dynamic_cast<T*>(m_components.front().get());
+			m_components.push_back(std::make_shared<T>(*this, p_args...));
+			T& instance = *dynamic_cast<T*>(m_components.back().get());
 			ComponentAddedEvent.Invoke(instance);
 			if (m_playing && IsActive())
 			{

--- a/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
+++ b/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
@@ -52,11 +52,6 @@ namespace OvCore::Helpers
 		static const float _MIN_FLOAT;
 		static const float _MAX_FLOAT;
 
-		/**
-		* Draw a title with the title color
-		* @param p_root
-		* @param p_name
-		*/
 		static void CreateTitle(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name);
 	
 		template <typename T>

--- a/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
+++ b/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
@@ -23,6 +23,7 @@
 #include <OvUI/Widgets/Drags/DragSingleScalar.h>
 #include <OvUI/Widgets/Drags/DragMultipleScalars.h>
 #include <OvUI/Widgets/InputFields/InputText.h>
+#include <OvUI/Widgets/InputFields/AssetField.h>
 #include <OvUI/Widgets/Visual/Image.h>
 #include <OvUI/Types/Color.h>
 
@@ -167,12 +168,12 @@ namespace OvCore::Helpers
 		static void DrawQuat(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FQuaternion& p_data, float p_step = 1.f, float p_min = _MIN_FLOAT, float p_max = _MAX_FLOAT);
 		static void DrawString(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::string& p_data);
 		static void DrawColor(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvUI::Types::Color& p_color, bool p_hasAlpha = false);
-		static OvUI::Widgets::Texts::Text& DrawMesh(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Model*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
+		static OvUI::Widgets::InputFields::AssetField& DrawMesh(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Model*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
 		static OvUI::Widgets::Visual::Image& DrawTexture(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Texture*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
-		static OvUI::Widgets::Texts::Text& DrawShader(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Shader*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
-		static OvUI::Widgets::Texts::Text& DrawMaterial(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvCore::Resources::Material*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
-		static OvUI::Widgets::Texts::Text& DrawSound(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvAudio::Resources::Sound*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
-		static OvUI::Widgets::Texts::Text& DrawAsset(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::string& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
+		static OvUI::Widgets::InputFields::AssetField& DrawShader(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Shader*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
+		static OvUI::Widgets::InputFields::AssetField& DrawMaterial(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvCore::Resources::Material*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
+		static OvUI::Widgets::InputFields::AssetField& DrawSound(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvAudio::Resources::Sound*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
+		static OvUI::Widgets::InputFields::AssetField& DrawAsset(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::string& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
 
 		template <typename T>
 		static void DrawScalar(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::function<T(void)> p_gatherer, std::function<void(T)> p_provider, float p_step = 1.f, T p_min = std::numeric_limits<T>::min(), T p_max = std::numeric_limits<T>::max());

--- a/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
+++ b/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
@@ -143,6 +143,13 @@ namespace OvCore::Helpers
 		static void SetOpenProvider(OpenProviderCallback p_provider);
 
 		/**
+		* Open the asset at the given resource path using the registered open provider.
+		* Has no effect if no provider has been registered or the path is empty.
+		* @param p_path  Resource path (e.g. ":Textures/Default.png" or "Materials/m.ovmat")
+		*/
+		static void Open(const std::string& p_path);
+
+		/**
 		* Register the function that returns a texture ID for a given file type.
 		* Used to show asset type icons in asset fields.
 		* Call this once during editor startup.

--- a/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
+++ b/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
@@ -24,7 +24,6 @@
 #include <OvUI/Widgets/Drags/DragMultipleScalars.h>
 #include <OvUI/Widgets/InputFields/InputText.h>
 #include <OvUI/Widgets/InputFields/AssetField.h>
-#include <OvUI/Widgets/Visual/Image.h>
 #include <OvUI/Types/Color.h>
 
 namespace OvCore::Resources
@@ -179,7 +178,7 @@ namespace OvCore::Helpers
 		static void DrawString(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::string& p_data);
 		static void DrawColor(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvUI::Types::Color& p_color, bool p_hasAlpha = false);
 		static OvUI::Widgets::InputFields::AssetField& DrawMesh(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Model*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
-		static OvUI::Widgets::Visual::Image& DrawTexture(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Texture*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
+		static OvUI::Widgets::InputFields::AssetField& DrawTexture(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Texture*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
 		static OvUI::Widgets::InputFields::AssetField& DrawShader(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Shader*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
 		static OvUI::Widgets::InputFields::AssetField& DrawMaterial(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvCore::Resources::Material*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
 		static OvUI::Widgets::InputFields::AssetField& DrawSound(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvAudio::Resources::Sound*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);

--- a/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
+++ b/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
@@ -8,15 +8,11 @@
 
 #include <functional>
 #include <string>
-#include <unordered_set>
-#include <vector>
 
 #include <OvMaths/FVector2.h>
 #include <OvMaths/FVector3.h>
 #include <OvMaths/FVector4.h>
 #include <OvMaths/FQuaternion.h>
-
-#include <OvTools/Utils/PathParser.h>
 
 #include <OvUI/Internal/WidgetContainer.h>
 #include <OvUI/Widgets/Texts/Text.h>
@@ -46,131 +42,15 @@ namespace OvRendering::Resources
 namespace OvCore::Helpers
 {
 	/**
-	* Provide some helpers to draw UI elements
+	* Provides helpers to draw UI elements for common data types and asset resources.
 	*/
 	class GUIDrawer
 	{
 	public:
-		/**
-		* Represents a single item in the picker.
-		* The key uniquely identifies the item for deduplication when combining lists.
-		*/
-		struct PickerItem
-		{
-			std::string key;         // unique identifier used for deduplication
-			std::string displayName;
-			std::string tooltip;
-			uint32_t iconID = 0;
-			std::function<void()> onSelected;
-		};
-
-		/**
-		* An ordered, deduplication-aware collection of picker items.
-		* Items with the same key are silently dropped when added.
-		*/
-		class PickerItemList
-		{
-		public:
-			/**
-			* Add an item to the list.
-			* @returns true if added, false if an item with the same key was already present.
-			*/
-			bool Add(PickerItem p_item)
-			{
-				if (!m_keys.insert(p_item.key).second)
-					return false;
-				m_items.push_back(std::move(p_item));
-				return true;
-			}
-
-			const std::vector<PickerItem>& Items() const { return m_items; }
-			bool empty() const { return m_items.empty(); }
-			size_t size() const { return m_items.size(); }
-
-		private:
-			std::vector<PickerItem> m_items;
-			std::unordered_set<std::string> m_keys;
-		};
-
-		/**
-		* A callback that builds a PickerItemList for a given file type.
-		* Called internally by OpenAssetPicker — register once via SetFileItemBuilder.
-		*/
-		using FileItemBuilderCallback = std::function<PickerItemList(OvTools::Utils::PathParser::EFileType, std::function<void(std::string)>, bool, bool)>;
-
-		using OpenProviderCallback = std::function<void(const std::string&)>;
-
-		using PickerProviderCallback = std::function<void(PickerItemList, std::string)>;
-
-		using IconProviderCallback = std::function<uint32_t(OvTools::Utils::PathParser::EFileType)>;
-
 		static const OvUI::Types::Color TitleColor;
 
 		static const float _MIN_FLOAT;
 		static const float _MAX_FLOAT;
-
-		/**
-		* Defines the texture to use when there is no texture in a texture resource field
-		* @param p_emptyTexture
-		*/
-		static void ProvideEmptyTexture(OvRendering::Resources::Texture& p_emptyTexture);
-
-		/**
-		* Register the function that builds a PickerItemList for a given file type.
-		* This is called internally by OpenAssetPicker.
-		* Call this once during editor startup.
-		* @param p_builder
-		*/
-		static void SetFileItemBuilder(FileItemBuilderCallback p_builder);
-
-		/**
-		* Open the asset picker for the given file type.
-		* Builds the item list via the registered file item builder, derives the window title
-		* from the file type, and forwards everything to the registered picker provider.
-		* Has no effect if either callback has not been registered.
-		* @param p_fileType
-		* @param p_onSelect
-		* @param p_searchProjectFiles  Include project assets in the results
-		* @param p_searchEngineFiles   Include engine assets in the results
-		*/
-		static void OpenAssetPicker(
-			OvTools::Utils::PathParser::EFileType p_fileType,
-			std::function<void(std::string)> p_onSelect,
-			bool p_searchProjectFiles = true,
-			bool p_searchEngineFiles = true
-		);
-
-		static void SetOpenProvider(OpenProviderCallback p_provider);
-
-		/**
-		* Open the asset at the given resource path using the registered open provider.
-		* Has no effect if no provider has been registered or the path is empty.
-		* @param p_path  Resource path (e.g. ":Textures/Default.png" or "Materials/m.ovmat")
-		*/
-		static void Open(const std::string& p_path);
-
-		/**
-		* Register the function that returns a texture ID for a given file type.
-		* Used to show asset type icons in asset fields.
-		* Call this once during editor startup.
-		* @param p_provider
-		*/
-		static void SetIconProvider(IconProviderCallback p_provider);
-
-		/**
-		* Register the function that opens the picker window.
-		* Call this once during editor startup (typically in Editor::SetupUI).
-		* @param p_provider
-		*/
-		static void SetPickerProvider(PickerProviderCallback p_provider);
-
-		/**
-		* Open the picker with the given list of items.
-		* Has no effect if no provider has been registered.
-		* @param p_items
-		* @param p_title  Title displayed in the window's title bar
-		*/
-		static void OpenPicker(PickerItemList p_items, std::string p_title);
 
 		/**
 		* Draw a title with the title color

--- a/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
+++ b/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
@@ -101,6 +101,8 @@ namespace OvCore::Helpers
 
 		using PickerProviderCallback = std::function<void(PickerItemList, std::string)>;
 
+		using IconProviderCallback = std::function<uint32_t(OvTools::Utils::PathParser::EFileType)>;
+
 		static const OvUI::Types::Color TitleColor;
 
 		static const float _MIN_FLOAT;
@@ -136,6 +138,14 @@ namespace OvCore::Helpers
 			bool p_searchProjectFiles = true,
 			bool p_searchEngineFiles = true
 		);
+
+		/**
+		* Register the function that returns a texture ID for a given file type.
+		* Used to show asset type icons in asset fields.
+		* Call this once during editor startup.
+		* @param p_provider
+		*/
+		static void SetIconProvider(IconProviderCallback p_provider);
 
 		/**
 		* Register the function that opens the picker window.

--- a/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
+++ b/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
@@ -98,6 +98,8 @@ namespace OvCore::Helpers
 		*/
 		using FileItemBuilderCallback = std::function<PickerItemList(OvTools::Utils::PathParser::EFileType, std::function<void(std::string)>, bool, bool)>;
 
+		using OpenProviderCallback = std::function<void(const std::string&)>;
+
 		using PickerProviderCallback = std::function<void(PickerItemList, std::string)>;
 
 		using IconProviderCallback = std::function<uint32_t(OvTools::Utils::PathParser::EFileType)>;
@@ -137,6 +139,8 @@ namespace OvCore::Helpers
 			bool p_searchProjectFiles = true,
 			bool p_searchEngineFiles = true
 		);
+
+		static void SetOpenProvider(OpenProviderCallback p_provider);
 
 		/**
 		* Register the function that returns a texture ID for a given file type.

--- a/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
+++ b/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
@@ -185,6 +185,8 @@ namespace OvCore::Helpers
 		static OvUI::Widgets::InputFields::AssetField& DrawSound(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvAudio::Resources::Sound*& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
 		static OvUI::Widgets::InputFields::AssetField& DrawAsset(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::string& p_data, OvTools::Eventing::Event<>* p_updateNotifier = nullptr);
 
+		static OvUI::Widgets::InputFields::AssetField& DrawScene(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::function<std::string()> p_gatherer, std::function<void(std::string)> p_provider);
+
 		template <typename T>
 		static void DrawScalar(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::function<T(void)> p_gatherer, std::function<void(T)> p_provider, float p_step = 1.f, T p_min = std::numeric_limits<T>::min(), T p_max = std::numeric_limits<T>::max());
 		static void DrawBoolean(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::function<bool(void)> p_gatherer, std::function<void(bool)> p_provider);

--- a/Sources/OvCore/include/OvCore/Helpers/GUIHelpers.h
+++ b/Sources/OvCore/include/OvCore/Helpers/GUIHelpers.h
@@ -22,17 +22,12 @@ namespace OvRendering::Resources
 namespace OvCore::Helpers
 {
 	/**
-	* Provides asset-picking and asset-opening helpers shared across the editor.
-	* GUIDrawer uses these internally for its asset field widgets.
-	* The editor registers the concrete implementations once at startup.
+	* Asset picking and opening helpers shared across the editor.
+	* Implements a service locator pattern for UI operations.
 	*/
 	class GUIHelpers
 	{
 	public:
-		/**
-		* Represents a single item in the picker.
-		* The key uniquely identifies the item for deduplication when combining lists.
-		*/
 		struct PickerItem
 		{
 			std::string key;
@@ -42,17 +37,9 @@ namespace OvCore::Helpers
 			std::function<void()> onSelected;
 		};
 
-		/**
-		* An ordered, deduplication-aware collection of picker items.
-		* Items with the same key are silently dropped when added.
-		*/
 		class PickerItemList
 		{
 		public:
-			/**
-			* Add an item to the list.
-			* @returns true if added, false if an item with the same key was already present.
-			*/
 			bool Add(PickerItem p_item)
 			{
 				if (!m_keys.insert(p_item.key).second)
@@ -70,46 +57,16 @@ namespace OvCore::Helpers
 			std::unordered_set<std::string> m_keys;
 		};
 
-		/**
-		* A callback that builds a PickerItemList for a given file type.
-		* Register once via SetFileItemBuilder.
-		*/
 		using FileItemBuilderCallback = std::function<PickerItemList(OvTools::Utils::PathParser::EFileType, std::function<void(std::string)>, bool, bool)>;
-
 		using OpenProviderCallback = std::function<void(const std::string&)>;
-
 		using PickerProviderCallback = std::function<void(PickerItemList, std::string)>;
-
 		using IconProviderCallback = std::function<uint32_t(OvTools::Utils::PathParser::EFileType)>;
 
-		/**
-		* Provide the texture used when no texture resource is assigned to a texture field.
-		* @param p_emptyTexture
-		*/
 		static void ProvideEmptyTexture(OvRendering::Resources::Texture& p_emptyTexture);
-
-		/**
-		* Returns the empty texture set via ProvideEmptyTexture, or nullptr if none was provided.
-		*/
 		static OvRendering::Resources::Texture* GetEmptyTexture();
 
-		/**
-		* Register the function that builds a PickerItemList for a given file type.
-		* Call once during editor startup.
-		* @param p_builder
-		*/
 		static void SetFileItemBuilder(FileItemBuilderCallback p_builder);
 
-		/**
-		* Open the asset picker for the given file type.
-		* Builds the item list via the registered file item builder, derives the window title
-		* from the file type, and forwards everything to the registered picker provider.
-		* Has no effect if either callback has not been registered.
-		* @param p_fileType
-		* @param p_onSelect
-		* @param p_searchProjectFiles  Include project assets in the results
-		* @param p_searchEngineFiles   Include engine assets in the results
-		*/
 		static void OpenAssetPicker(
 			OvTools::Utils::PathParser::EFileType p_fileType,
 			std::function<void(std::string)> p_onSelect,
@@ -117,48 +74,13 @@ namespace OvCore::Helpers
 			bool p_searchEngineFiles = true
 		);
 
-		/**
-		* Register the function that opens an asset at a given resource path.
-		* Call once during editor startup.
-		* @param p_provider
-		*/
 		static void SetOpenProvider(OpenProviderCallback p_provider);
-
-		/**
-		* Open the asset at the given resource path using the registered open provider.
-		* Has no effect if no provider has been registered or the path is empty.
-		* @param p_path  Resource path (e.g. ":Textures/Default.png" or "Materials/m.ovmat")
-		*/
 		static void Open(const std::string& p_path);
 
-		/**
-		* Register the function that returns a texture ID for a given file type.
-		* Used to show asset type icons in asset fields.
-		* Call once during editor startup.
-		* @param p_provider
-		*/
 		static void SetIconProvider(IconProviderCallback p_provider);
-
-		/**
-		* Returns the icon texture ID for the given file type.
-		* Returns 0 if no icon provider has been registered.
-		* @param p_fileType
-		*/
 		static uint32_t GetIconForFileType(OvTools::Utils::PathParser::EFileType p_fileType);
 
-		/**
-		* Register the function that opens the picker window.
-		* Call once during editor startup (typically in Editor::SetupUI).
-		* @param p_provider
-		*/
 		static void SetPickerProvider(PickerProviderCallback p_provider);
-
-		/**
-		* Open the picker with the given list of items.
-		* Has no effect if no provider has been registered.
-		* @param p_items
-		* @param p_title  Title displayed in the window's title bar
-		*/
 		static void OpenPicker(PickerItemList p_items, std::string p_title);
 	};
 }

--- a/Sources/OvCore/include/OvCore/Helpers/GUIHelpers.h
+++ b/Sources/OvCore/include/OvCore/Helpers/GUIHelpers.h
@@ -1,0 +1,164 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <OvTools/Utils/PathParser.h>
+
+namespace OvRendering::Resources
+{
+	class Texture;
+}
+
+namespace OvCore::Helpers
+{
+	/**
+	* Provides asset-picking and asset-opening helpers shared across the editor.
+	* GUIDrawer uses these internally for its asset field widgets.
+	* The editor registers the concrete implementations once at startup.
+	*/
+	class GUIHelpers
+	{
+	public:
+		/**
+		* Represents a single item in the picker.
+		* The key uniquely identifies the item for deduplication when combining lists.
+		*/
+		struct PickerItem
+		{
+			std::string key;
+			std::string displayName;
+			std::string tooltip;
+			uint32_t iconID = 0;
+			std::function<void()> onSelected;
+		};
+
+		/**
+		* An ordered, deduplication-aware collection of picker items.
+		* Items with the same key are silently dropped when added.
+		*/
+		class PickerItemList
+		{
+		public:
+			/**
+			* Add an item to the list.
+			* @returns true if added, false if an item with the same key was already present.
+			*/
+			bool Add(PickerItem p_item)
+			{
+				if (!m_keys.insert(p_item.key).second)
+					return false;
+				m_items.push_back(std::move(p_item));
+				return true;
+			}
+
+			const std::vector<PickerItem>& Items() const { return m_items; }
+			bool empty() const { return m_items.empty(); }
+			size_t size() const { return m_items.size(); }
+
+		private:
+			std::vector<PickerItem> m_items;
+			std::unordered_set<std::string> m_keys;
+		};
+
+		/**
+		* A callback that builds a PickerItemList for a given file type.
+		* Register once via SetFileItemBuilder.
+		*/
+		using FileItemBuilderCallback = std::function<PickerItemList(OvTools::Utils::PathParser::EFileType, std::function<void(std::string)>, bool, bool)>;
+
+		using OpenProviderCallback = std::function<void(const std::string&)>;
+
+		using PickerProviderCallback = std::function<void(PickerItemList, std::string)>;
+
+		using IconProviderCallback = std::function<uint32_t(OvTools::Utils::PathParser::EFileType)>;
+
+		/**
+		* Provide the texture used when no texture resource is assigned to a texture field.
+		* @param p_emptyTexture
+		*/
+		static void ProvideEmptyTexture(OvRendering::Resources::Texture& p_emptyTexture);
+
+		/**
+		* Returns the empty texture set via ProvideEmptyTexture, or nullptr if none was provided.
+		*/
+		static OvRendering::Resources::Texture* GetEmptyTexture();
+
+		/**
+		* Register the function that builds a PickerItemList for a given file type.
+		* Call once during editor startup.
+		* @param p_builder
+		*/
+		static void SetFileItemBuilder(FileItemBuilderCallback p_builder);
+
+		/**
+		* Open the asset picker for the given file type.
+		* Builds the item list via the registered file item builder, derives the window title
+		* from the file type, and forwards everything to the registered picker provider.
+		* Has no effect if either callback has not been registered.
+		* @param p_fileType
+		* @param p_onSelect
+		* @param p_searchProjectFiles  Include project assets in the results
+		* @param p_searchEngineFiles   Include engine assets in the results
+		*/
+		static void OpenAssetPicker(
+			OvTools::Utils::PathParser::EFileType p_fileType,
+			std::function<void(std::string)> p_onSelect,
+			bool p_searchProjectFiles = true,
+			bool p_searchEngineFiles = true
+		);
+
+		/**
+		* Register the function that opens an asset at a given resource path.
+		* Call once during editor startup.
+		* @param p_provider
+		*/
+		static void SetOpenProvider(OpenProviderCallback p_provider);
+
+		/**
+		* Open the asset at the given resource path using the registered open provider.
+		* Has no effect if no provider has been registered or the path is empty.
+		* @param p_path  Resource path (e.g. ":Textures/Default.png" or "Materials/m.ovmat")
+		*/
+		static void Open(const std::string& p_path);
+
+		/**
+		* Register the function that returns a texture ID for a given file type.
+		* Used to show asset type icons in asset fields.
+		* Call once during editor startup.
+		* @param p_provider
+		*/
+		static void SetIconProvider(IconProviderCallback p_provider);
+
+		/**
+		* Returns the icon texture ID for the given file type.
+		* Returns 0 if no icon provider has been registered.
+		* @param p_fileType
+		*/
+		static uint32_t GetIconForFileType(OvTools::Utils::PathParser::EFileType p_fileType);
+
+		/**
+		* Register the function that opens the picker window.
+		* Call once during editor startup (typically in Editor::SetupUI).
+		* @param p_provider
+		*/
+		static void SetPickerProvider(PickerProviderCallback p_provider);
+
+		/**
+		* Open the picker with the given list of items.
+		* Has no effect if no provider has been registered.
+		* @param p_items
+		* @param p_title  Title displayed in the window's title bar
+		*/
+		static void OpenPicker(PickerItemList p_items, std::string p_title);
+	};
+}

--- a/Sources/OvCore/src/OvCore/ECS/Actor.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Actor.cpp
@@ -384,6 +384,33 @@ bool OvCore::ECS::Actor::RemoveBehaviour(const std::string & p_name)
 	}
 }
 
+bool OvCore::ECS::Actor::RenameBehaviour(const std::string& p_previousName, const std::string& p_newName)
+{
+	auto orderIt = std::find(m_behavioursOrder.begin(), m_behavioursOrder.end(), p_previousName);
+	if (orderIt == m_behavioursOrder.end())
+		return false;
+
+	Components::Behaviour* found = GetBehaviour(p_previousName);
+	if (!found)
+		return false;
+
+	BehaviourRemovedEvent.Invoke(*found);
+	m_behaviours.erase(p_previousName);
+
+	*orderIt = p_newName;
+
+	m_behaviours.try_emplace(p_newName, *this, p_newName);
+	Components::Behaviour& newInstance = m_behaviours.at(p_newName);
+	BehaviourAddedEvent.Invoke(newInstance);
+	if (m_playing && IsActive())
+	{
+		newInstance.OnAwake();
+		newInstance.OnEnable();
+		newInstance.OnStart();
+	}
+	return true;
+}
+
 OvCore::ECS::Components::Behaviour* OvCore::ECS::Actor::GetBehaviour(const std::string& p_name)
 {
 	if (auto result = m_behaviours.find(p_name); result != m_behaviours.end())

--- a/Sources/OvCore/src/OvCore/ECS/Actor.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Actor.cpp
@@ -335,6 +335,7 @@ std::vector<std::shared_ptr<OvCore::ECS::Components::AComponent>>& OvCore::ECS::
 OvCore::ECS::Components::Behaviour & OvCore::ECS::Actor::AddBehaviour(const std::string & p_name)
 {
 	m_behaviours.try_emplace(p_name, *this, p_name);
+	m_behavioursOrder.push_back(p_name);
 	Components::Behaviour& newInstance = m_behaviours.at(p_name);
 	BehaviourAddedEvent.Invoke(newInstance);
 	if (m_playing && IsActive())
@@ -371,7 +372,11 @@ bool OvCore::ECS::Actor::RemoveBehaviour(const std::string & p_name)
 	if (found)
 	{
 		BehaviourRemovedEvent.Invoke(*found);
-		return m_behaviours.erase(p_name);
+		m_behaviours.erase(p_name);
+		auto it = std::find(m_behavioursOrder.begin(), m_behavioursOrder.end(), p_name);
+		if (it != m_behavioursOrder.end())
+			m_behavioursOrder.erase(it);
+		return true;
 	}
 	else
 	{
@@ -390,6 +395,11 @@ OvCore::ECS::Components::Behaviour* OvCore::ECS::Actor::GetBehaviour(const std::
 std::unordered_map<std::string, OvCore::ECS::Components::Behaviour>& OvCore::ECS::Actor::GetBehaviours()
 {
 	return m_behaviours;
+}
+
+std::vector<std::string>& OvCore::ECS::Actor::GetBehavioursOrder()
+{
+	return m_behavioursOrder;
 }
 
 void OvCore::ECS::Actor::OnSerialize(tinyxml2::XMLDocument & p_doc, tinyxml2::XMLNode * p_actorsRoot)
@@ -426,21 +436,25 @@ void OvCore::ECS::Actor::OnSerialize(tinyxml2::XMLDocument & p_doc, tinyxml2::XM
 	tinyxml2::XMLNode* behavioursNode = p_doc.NewElement("behaviours");
 	actorNode->InsertEndChild(behavioursNode);
 
-	for (auto& behaviour : m_behaviours)
+	for (auto& name : m_behavioursOrder)
 	{
+		auto it = m_behaviours.find(name);
+		if (it == m_behaviours.end()) continue;
+		auto& behaviour = it->second;
+
 		/* Current behaviour root */
 		tinyxml2::XMLNode* behaviourNode = p_doc.NewElement("behaviour");
 		behavioursNode->InsertEndChild(behaviourNode);
 
 		/* Behaviour type */
-		OvCore::Helpers::Serializer::SerializeString(p_doc, behaviourNode, "type", behaviour.first);
+		OvCore::Helpers::Serializer::SerializeString(p_doc, behaviourNode, "type", name);
 
 		/* Data node (Will be passed to the behaviour) */
 		tinyxml2::XMLElement* data = p_doc.NewElement("data");
 		behaviourNode->InsertEndChild(data);
 
 		/* Data serialization of the behaviour */
-		behaviour.second.OnSerialize(p_doc, data);
+		behaviour.OnSerialize(p_doc, data);
 	}
 }
 

--- a/Sources/OvCore/src/OvCore/ECS/Components/CMaterialRenderer.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/CMaterialRenderer.cpp
@@ -145,7 +145,7 @@ std::array<OvUI::Widgets::AWidget*, 2> CustomMaterialDrawer(OvUI::Internal::Widg
 	const size_t before = p_root.GetWidgets().size();
 	OvCore::Helpers::GUIDrawer::DrawMaterial(p_root, p_name, p_data, nullptr);
 	auto& widgets = p_root.GetWidgets();
-	// DrawMaterial adds exactly 2 widgets: [before]=TextColored title, [before+1]=Group rightSide
+	// DrawMaterial adds exactly 2 widgets: [before]=TextColored title, [before+1]=AssetField
 	return { widgets[before].first, widgets[before + 1].first };
 }
 

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -244,40 +244,44 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawMesh(OvU
 	return DrawResourceWidget<OvRendering::Resources::Model, OvCore::ResourceManagement::ModelManager>(p_root, p_name, p_data, OvTools::Utils::PathParser::EFileType::MODEL, p_updateNotifier);
 }
 
-OvUI::Widgets::Visual::Image& OvCore::Helpers::GUIDrawer::DrawTexture(OvUI::Internal::WidgetContainer & p_root, const std::string & p_name, OvRendering::Resources::Texture *& p_data, OvTools::Eventing::Event<>* p_updateNotifier)
+OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawTexture(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Texture*& p_data, OvTools::Eventing::Event<>* p_updateNotifier)
 {
 	CreateTitle(p_root, p_name);
 
-	auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
-	rightSide.horizontal = true;
-	rightSide.stretchWidget = 0;
+	auto getPreviewID = [&]() -> uint32_t
+	{
+		if (p_data) return p_data->GetTexture().GetID();
+		return __EMPTY_TEXTURE ? __EMPTY_TEXTURE->GetTexture().GetID() : 0;
+	};
 
-	auto& widget = rightSide.CreateWidget<OvUI::Widgets::Visual::Image>(p_data ? p_data->GetTexture().GetID() : (__EMPTY_TEXTURE ? __EMPTY_TEXTURE->GetTexture().GetID() : 0), OvMaths::FVector2{75, 75});
+	auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(p_data ? p_data->path : std::string{});
+	if (__ICON_PROVIDER)
+		widget.iconTextureID = __ICON_PROVIDER(OvTools::Utils::PathParser::EFileType::TEXTURE);
+	widget.previewTextureID = getPreviewID();
 
-	widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent += [&widget, &p_data, p_updateNotifier](auto p_receivedData)
+	widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent +=
+		[&widget, &p_data, p_updateNotifier, getPreviewID](auto p_receivedData)
 	{
 		if (OvTools::Utils::PathParser::GetFileType(p_receivedData.first) == OvTools::Utils::PathParser::EFileType::TEXTURE)
 		{
 			if (auto resource = OVSERVICE(OvCore::ResourceManagement::TextureManager).GetResource(p_receivedData.first); resource)
 			{
 				p_data = resource;
-				widget.textureID.id = resource->GetTexture().GetID();
+				widget.content = p_receivedData.first;
+				widget.previewTextureID = resource->GetTexture().GetID();
 				if (p_updateNotifier)
 					p_updateNotifier->Invoke();
 			}
 		}
 	};
 
-	widget.lineBreak = false;
-
-	auto& selectButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::ButtonSmall>("...");
-	selectButton.lineBreak = false;
-	AddSelectButton(selectButton.ClickedEvent, OvTools::Utils::PathParser::EFileType::TEXTURE, [&widget, &p_data, p_updateNotifier](const std::string& p_path)
+	AddSelectButton(widget.ClickedEvent, OvTools::Utils::PathParser::EFileType::TEXTURE, [&widget, &p_data, p_updateNotifier, getPreviewID](const std::string& p_path)
 	{
 		if (p_path.empty())
 		{
 			p_data = nullptr;
-			widget.textureID.id = (__EMPTY_TEXTURE ? __EMPTY_TEXTURE->GetTexture().GetID() : 0);
+			widget.content.clear();
+			widget.previewTextureID = getPreviewID();
 			if (p_updateNotifier)
 				p_updateNotifier->Invoke();
 			return;
@@ -285,7 +289,8 @@ OvUI::Widgets::Visual::Image& OvCore::Helpers::GUIDrawer::DrawTexture(OvUI::Inte
 		if (auto resource = OVSERVICE(OvCore::ResourceManagement::TextureManager).GetResource(p_path); resource)
 		{
 			p_data = resource;
-			widget.textureID.id = resource->GetTexture().GetID();
+			widget.content = p_path;
+			widget.previewTextureID = resource->GetTexture().GetID();
 			if (p_updateNotifier)
 				p_updateNotifier->Invoke();
 		}

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -196,7 +196,7 @@ namespace
 	{
 		OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);
 
-		std::string displayedText = (p_data ? p_data->path : std::string("Empty"));
+		const std::string displayedText = p_data ? p_data->path : std::string{};
 		auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(displayedText);
 		if (__ICON_PROVIDER)
 			widget.iconTextureID = __ICON_PROVIDER(p_fileType);
@@ -221,7 +221,7 @@ namespace
 			if (p_path.empty())
 			{
 				p_data = nullptr;
-				widget.content = "Empty";
+				widget.content.clear();
 				if (p_updateNotifier)
 					p_updateNotifier->Invoke();
 				return;
@@ -313,7 +313,7 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawAsset(Ov
 {
 	CreateTitle(p_root, p_name);
 
-	const std::string displayedText = (p_data.empty() ? std::string("Empty") : p_data);
+	const std::string displayedText = p_data;
 	auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(displayedText);
 
 	widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent += [&widget, &p_data, p_updateNotifier](auto p_receivedData)
@@ -327,10 +327,43 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawAsset(Ov
 	AddSelectButton(widget.ClickedEvent, OvTools::Utils::PathParser::EFileType::UNKNOWN, [&widget, &p_data, p_updateNotifier](const std::string& p_path)
 	{
 		p_data = p_path;
-		widget.content = p_path.empty() ? "Empty" : p_path;
+		widget.content = p_path;
 		if (p_updateNotifier)
 			p_updateNotifier->Invoke();
 	});
+
+	return widget;
+}
+
+OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawScene(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::function<std::string()> p_gatherer, std::function<void(std::string)> p_provider)
+{
+	CreateTitle(p_root, p_name);
+
+	auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(p_gatherer());
+	if (__ICON_PROVIDER)
+		widget.iconTextureID = __ICON_PROVIDER(OvTools::Utils::PathParser::EFileType::SCENE);
+
+	auto& dispatcher = widget.AddPlugin<OvUI::Plugins::DataDispatcher<std::string>>();
+	dispatcher.RegisterGatherer(p_gatherer);
+
+	widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent +=
+		[&widget, &dispatcher, p_provider](auto p_receivedData)
+	{
+		if (OvTools::Utils::PathParser::GetFileType(p_receivedData.first) == OvTools::Utils::PathParser::EFileType::SCENE)
+		{
+			widget.content = p_receivedData.first;
+			p_provider(p_receivedData.first);
+		}
+	};
+
+	widget.ClickedEvent += [&widget, p_provider]()
+	{
+		OpenAssetPicker(OvTools::Utils::PathParser::EFileType::SCENE, [&widget, p_provider](const std::string& p_path)
+		{
+			widget.content = p_path;
+			p_provider(p_path);
+		}, true, false);
+	};
 
 	return widget;
 }

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -348,11 +348,10 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawScene(Ov
 	if (__ICON_PROVIDER)
 		widget.iconTextureID = __ICON_PROVIDER(OvTools::Utils::PathParser::EFileType::SCENE);
 
-	auto& dispatcher = widget.AddPlugin<OvUI::Plugins::DataDispatcher<std::string>>();
-	dispatcher.RegisterGatherer(p_gatherer);
+	widget.AddPlugin<OvUI::Plugins::DataDispatcher<std::string>>().RegisterGatherer(p_gatherer);
 
 	widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent +=
-		[&widget, &dispatcher, p_provider](auto p_receivedData)
+		[&widget, p_provider](auto p_receivedData)
 	{
 		if (OvTools::Utils::PathParser::GetFileType(p_receivedData.first) == OvTools::Utils::PathParser::EFileType::SCENE)
 		{
@@ -361,12 +360,17 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawScene(Ov
 		}
 	};
 
-	widget.ClickedEvent += [&widget, p_provider]()
+	auto token = std::make_shared<bool>(true);
+	widget.ClickedEvent += [&widget, p_provider, token]()
 	{
-		OpenAssetPicker(OvTools::Utils::PathParser::EFileType::SCENE, [&widget, p_provider](const std::string& p_path)
+		std::weak_ptr<bool> weak = token;
+		OpenAssetPicker(OvTools::Utils::PathParser::EFileType::SCENE, [&widget, p_provider, weak](const std::string& p_path)
 		{
-			widget.content = p_path;
-			p_provider(p_path);
+			if (!weak.expired())
+			{
+				widget.content = p_path;
+				p_provider(p_path);
+			}
 		}, true, false);
 	};
 

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -107,6 +107,12 @@ void OvCore::Helpers::GUIDrawer::SetOpenProvider(OpenProviderCallback p_provider
 	__OPEN_PROVIDER = std::move(p_provider);
 }
 
+void OvCore::Helpers::GUIDrawer::Open(const std::string& p_path)
+{
+	if (__OPEN_PROVIDER && !p_path.empty())
+		__OPEN_PROVIDER(p_path);
+}
+
 void OvCore::Helpers::GUIDrawer::OpenPicker(PickerItemList p_items, std::string p_title)
 {
 	if (__PICKER_PROVIDER)

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -287,6 +287,8 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawAsset(Ov
 			p_updateNotifier->Invoke();
 	});
 
+	widget.DoubleClickedEvent += [widgetPtr] { GUIHelpers::Open(widgetPtr->content); };
+
 	return widget;
 }
 
@@ -325,6 +327,8 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawScene(Ov
 			}
 		}, true, false);
 	};
+
+	widget.DoubleClickedEvent += [widgetPtr] { GUIHelpers::Open(widgetPtr->content); };
 
 	return widget;
 }

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -100,6 +100,10 @@ void OvCore::Helpers::GUIDrawer::DrawColor(OvUI::Internal::WidgetContainer & p_r
 
 namespace
 {
+	/**
+	* Helper to attach an asset picker to a widget's click event.
+	* The picker will be available only if the callback is still alive when invoked.
+	*/
 	void AddSelectButton(
 		OvTools::Eventing::Event<>& p_clickedEvent,
 		OvTools::Utils::PathParser::EFileType p_fileType,
@@ -116,6 +120,10 @@ namespace
 		};
 	}
 
+	/**
+	* Generic asset field widget for resources with drag-drop and file selection support.
+	* Handles resource loading via the service locator and optional change notifications.
+	*/
 	template<typename TResource, typename TResourceManager>
 	OvUI::Widgets::InputFields::AssetField& DrawResourceWidget(
 		OvUI::Internal::WidgetContainer& p_root,
@@ -130,27 +138,30 @@ namespace
 		auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(displayedText);
 		widget.iconTextureID = OvCore::Helpers::GUIHelpers::GetIconForFileType(p_fileType);
 
+		// Create a shared widget reference for safe access in captured lambdas
+		auto widgetPtr = std::shared_ptr<OvUI::Widgets::InputFields::AssetField>(&widget, [](void*) {});
+
 		widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent +=
-			[&widget, &p_data, p_updateNotifier, p_fileType](auto p_receivedData)
+			[widgetPtr, &p_data, p_updateNotifier, p_fileType](auto p_receivedData)
 		{
 			if (OvTools::Utils::PathParser::GetFileType(p_receivedData.first) == p_fileType)
 			{
 				if (auto resource = OVSERVICE(TResourceManager).GetResource(p_receivedData.first); resource)
 				{
 					p_data = resource;
-					widget.content = p_receivedData.first;
+					widgetPtr->content = p_receivedData.first;
 					if (p_updateNotifier)
 						p_updateNotifier->Invoke();
 				}
 			}
 		};
 
-		AddSelectButton(widget.ClickedEvent, p_fileType, [&widget, &p_data, p_updateNotifier](const std::string& p_path)
+		AddSelectButton(widget.ClickedEvent, p_fileType, [widgetPtr, &p_data, p_updateNotifier](const std::string& p_path)
 		{
 			if (p_path.empty())
 			{
 				p_data = nullptr;
-				widget.content.clear();
+				widgetPtr->content.clear();
 				if (p_updateNotifier)
 					p_updateNotifier->Invoke();
 				return;
@@ -158,13 +169,13 @@ namespace
 			if (auto resource = OVSERVICE(TResourceManager).GetResource(p_path); resource)
 			{
 				p_data = resource;
-				widget.content = p_path;
+				widgetPtr->content = p_path;
 				if (p_updateNotifier)
 					p_updateNotifier->Invoke();
 			}
 		});
 
-		widget.DoubleClickedEvent += [&widget] { OvCore::Helpers::GUIHelpers::Open(widget.content); };
+		widget.DoubleClickedEvent += [widgetPtr] { OvCore::Helpers::GUIHelpers::Open(widgetPtr->content); };
 
 		return widget;
 	}
@@ -182,37 +193,40 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawTexture(
 	auto getPreviewID = [&]() -> uint32_t
 	{
 		if (p_data) return p_data->GetTexture().GetID();
-		auto* empty = OvCore::Helpers::GUIHelpers::GetEmptyTexture();
+		auto* empty = GUIHelpers::GetEmptyTexture();
 		return empty ? empty->GetTexture().GetID() : 0;
 	};
 
 	auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(p_data ? p_data->path : std::string{});
-	widget.iconTextureID = OvCore::Helpers::GUIHelpers::GetIconForFileType(OvTools::Utils::PathParser::EFileType::TEXTURE);
+	widget.iconTextureID = GUIHelpers::GetIconForFileType(OvTools::Utils::PathParser::EFileType::TEXTURE);
 	widget.previewTextureID = getPreviewID();
 
+	// Create a shared widget reference for safe access in captured lambdas
+	auto widgetPtr = std::shared_ptr<OvUI::Widgets::InputFields::AssetField>(&widget, [](void*) {});
+
 	widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent +=
-		[&widget, &p_data, p_updateNotifier, getPreviewID](auto p_receivedData)
+		[widgetPtr, &p_data, p_updateNotifier, getPreviewID](auto p_receivedData)
 	{
 		if (OvTools::Utils::PathParser::GetFileType(p_receivedData.first) == OvTools::Utils::PathParser::EFileType::TEXTURE)
 		{
 			if (auto resource = OVSERVICE(OvCore::ResourceManagement::TextureManager).GetResource(p_receivedData.first); resource)
 			{
 				p_data = resource;
-				widget.content = p_receivedData.first;
-				widget.previewTextureID = resource->GetTexture().GetID();
+				widgetPtr->content = p_receivedData.first;
+				widgetPtr->previewTextureID = resource->GetTexture().GetID();
 				if (p_updateNotifier)
 					p_updateNotifier->Invoke();
 			}
 		}
 	};
 
-	AddSelectButton(widget.ClickedEvent, OvTools::Utils::PathParser::EFileType::TEXTURE, [&widget, &p_data, p_updateNotifier, getPreviewID](const std::string& p_path)
+	AddSelectButton(widget.ClickedEvent, OvTools::Utils::PathParser::EFileType::TEXTURE, [widgetPtr, &p_data, p_updateNotifier, getPreviewID](const std::string& p_path)
 	{
 		if (p_path.empty())
 		{
 			p_data = nullptr;
-			widget.content.clear();
-			widget.previewTextureID = getPreviewID();
+			widgetPtr->content.clear();
+			widgetPtr->previewTextureID = getPreviewID();
 			if (p_updateNotifier)
 				p_updateNotifier->Invoke();
 			return;
@@ -220,14 +234,14 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawTexture(
 		if (auto resource = OVSERVICE(OvCore::ResourceManagement::TextureManager).GetResource(p_path); resource)
 		{
 			p_data = resource;
-			widget.content = p_path;
-			widget.previewTextureID = resource->GetTexture().GetID();
+			widgetPtr->content = p_path;
+			widgetPtr->previewTextureID = resource->GetTexture().GetID();
 			if (p_updateNotifier)
 				p_updateNotifier->Invoke();
 		}
 	});
 
-	widget.DoubleClickedEvent += [&widget] { OvCore::Helpers::GUIHelpers::Open(widget.content); };
+	widget.DoubleClickedEvent += [widgetPtr] { GUIHelpers::Open(widgetPtr->content); };
 
 	return widget;
 }
@@ -254,18 +268,21 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawAsset(Ov
 	const std::string displayedText = p_data;
 	auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(displayedText);
 
-	widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent += [&widget, &p_data, p_updateNotifier](auto p_receivedData)
+	// Create a shared widget reference for safe access in captured lambdas
+	auto widgetPtr = std::shared_ptr<OvUI::Widgets::InputFields::AssetField>(&widget, [](void*) {});
+
+	widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent += [widgetPtr, &p_data, p_updateNotifier](auto p_receivedData)
 	{
 		p_data = p_receivedData.first;
-		widget.content = p_receivedData.first;
+		widgetPtr->content = p_receivedData.first;
 		if (p_updateNotifier)
 			p_updateNotifier->Invoke();
 	};
 
-	AddSelectButton(widget.ClickedEvent, OvTools::Utils::PathParser::EFileType::UNKNOWN, [&widget, &p_data, p_updateNotifier](const std::string& p_path)
+	AddSelectButton(widget.ClickedEvent, OvTools::Utils::PathParser::EFileType::UNKNOWN, [widgetPtr, &p_data, p_updateNotifier](const std::string& p_path)
 	{
 		p_data = p_path;
-		widget.content = p_path;
+		widgetPtr->content = p_path;
 		if (p_updateNotifier)
 			p_updateNotifier->Invoke();
 	});
@@ -278,29 +295,32 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawScene(Ov
 	CreateTitle(p_root, p_name);
 
 	auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(p_gatherer());
-	widget.iconTextureID = OvCore::Helpers::GUIHelpers::GetIconForFileType(OvTools::Utils::PathParser::EFileType::SCENE);
+	widget.iconTextureID = GUIHelpers::GetIconForFileType(OvTools::Utils::PathParser::EFileType::SCENE);
+
+	// Create a shared widget reference for safe access in captured lambdas
+	auto widgetPtr = std::shared_ptr<OvUI::Widgets::InputFields::AssetField>(&widget, [](void*) {});
 
 	widget.AddPlugin<OvUI::Plugins::DataDispatcher<std::string>>().RegisterGatherer(p_gatherer);
 
 	widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent +=
-		[&widget, p_provider](auto p_receivedData)
+		[widgetPtr, p_provider](auto p_receivedData)
 	{
 		if (OvTools::Utils::PathParser::GetFileType(p_receivedData.first) == OvTools::Utils::PathParser::EFileType::SCENE)
 		{
-			widget.content = p_receivedData.first;
+			widgetPtr->content = p_receivedData.first;
 			p_provider(p_receivedData.first);
 		}
 	};
 
 	auto token = std::make_shared<bool>(true);
-	widget.ClickedEvent += [&widget, p_provider, token]()
+	widget.ClickedEvent += [widgetPtr, p_provider, token]()
 	{
 		std::weak_ptr<bool> weak = token;
-		OvCore::Helpers::GUIHelpers::OpenAssetPicker(OvTools::Utils::PathParser::EFileType::SCENE, [&widget, p_provider, weak](const std::string& p_path)
+		GUIHelpers::OpenAssetPicker(OvTools::Utils::PathParser::EFileType::SCENE, [widgetPtr, p_provider, weak](const std::string& p_path)
 		{
 			if (!weak.expired())
 			{
-				widget.content = p_path;
+				widgetPtr->content = p_path;
 				p_provider(p_path);
 			}
 		}, true, false);

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -40,6 +40,7 @@ namespace
 	OvRendering::Resources::Texture* __EMPTY_TEXTURE = nullptr;
 	OvCore::Helpers::GUIDrawer::FileItemBuilderCallback __FILE_ITEM_BUILDER;
 	OvCore::Helpers::GUIDrawer::PickerProviderCallback __PICKER_PROVIDER;
+	OvCore::Helpers::GUIDrawer::IconProviderCallback __ICON_PROVIDER;
 
 	std::string TitleFromFileType(OvTools::Utils::PathParser::EFileType p_type)
 	{
@@ -93,6 +94,11 @@ void OvCore::Helpers::GUIDrawer::OpenAssetPicker(
 void OvCore::Helpers::GUIDrawer::SetPickerProvider(PickerProviderCallback p_provider)
 {
 	__PICKER_PROVIDER = std::move(p_provider);
+}
+
+void OvCore::Helpers::GUIDrawer::SetIconProvider(IconProviderCallback p_provider)
+{
+	__ICON_PROVIDER = std::move(p_provider);
 }
 
 void OvCore::Helpers::GUIDrawer::OpenPicker(PickerItemList p_items, std::string p_title)
@@ -192,6 +198,8 @@ namespace
 
 		std::string displayedText = (p_data ? p_data->path : std::string("Empty"));
 		auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(displayedText);
+		if (__ICON_PROVIDER)
+			widget.iconTextureID = __ICON_PROVIDER(p_fileType);
 
 		widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent +=
 			[&widget, &p_data, p_updateNotifier, p_fileType](auto p_receivedData)

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -13,6 +13,7 @@
 #include <OvUI/Widgets/Drags/DragSingleScalar.h>
 #include <OvUI/Widgets/Drags/DragMultipleScalars.h>
 #include <OvUI/Widgets/InputFields/InputText.h>
+#include <OvUI/Widgets/InputFields/AssetField.h>
 #include <OvUI/Widgets/Selection/ColorEdit.h>
 #include <OvUI/Widgets/Layout/Group.h>
 #include <OvUI/Widgets/Layout/Columns.h>
@@ -29,7 +30,6 @@
 #include <OvCore/ResourceManagement/SoundManager.h>
 
 #include "OvCore/Helpers/GUIDrawer.h"
-#include "OvUI/Widgets/Buttons/AButton.h"
 
 const OvUI::Types::Color OvCore::Helpers::GUIDrawer::TitleColor = { 0.85f, 0.65f, 0.0f };
 const float OvCore::Helpers::GUIDrawer::_MIN_FLOAT = -999999999.f;
@@ -165,12 +165,12 @@ void OvCore::Helpers::GUIDrawer::DrawColor(OvUI::Internal::WidgetContainer & p_r
 namespace
 {
 	void AddSelectButton(
-		OvUI::Widgets::Buttons::AButton& p_button,
+		OvTools::Eventing::Event<>& p_clickedEvent,
 		OvTools::Utils::PathParser::EFileType p_fileType,
 		std::function<void(const std::string&)> p_onSelect)
 	{
 		auto token = std::make_shared<bool>(true);
-		p_button.ClickedEvent += [p_fileType, p_onSelect = std::move(p_onSelect), token = std::move(token)]
+		p_clickedEvent += [p_fileType, p_onSelect = std::move(p_onSelect), token = std::move(token)]
 		{
 			std::weak_ptr<bool> weak = token;
 			OvCore::Helpers::GUIDrawer::OpenAssetPicker(p_fileType, [p_onSelect, weak](const std::string& p_path)
@@ -181,7 +181,7 @@ namespace
 	}
 
 	template<typename TResource, typename TResourceManager>
-	OvUI::Widgets::Texts::Text& DrawResourceWidget(
+	OvUI::Widgets::InputFields::AssetField& DrawResourceWidget(
 		OvUI::Internal::WidgetContainer& p_root,
 		const std::string& p_name,
 		TResource*& p_data,
@@ -191,11 +191,7 @@ namespace
 		OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);
 
 		std::string displayedText = (p_data ? p_data->path : std::string("Empty"));
-		auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
-		rightSide.horizontal = true;
-		rightSide.stretchWidget = 0;
-
-		auto& widget = rightSide.CreateWidget<OvUI::Widgets::Texts::Text>(displayedText);
+		auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(displayedText);
 
 		widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent +=
 			[&widget, &p_data, p_updateNotifier, p_fileType](auto p_receivedData)
@@ -212,11 +208,7 @@ namespace
 			}
 		};
 
-		widget.lineBreak = false;
-
-		auto& selectButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::ButtonSmall>("...");
-		selectButton.lineBreak = false;
-		AddSelectButton(selectButton, p_fileType, [&widget, &p_data, p_updateNotifier](const std::string& p_path)
+		AddSelectButton(widget.ClickedEvent, p_fileType, [&widget, &p_data, p_updateNotifier](const std::string& p_path)
 		{
 			if (p_path.empty())
 			{
@@ -239,7 +231,7 @@ namespace
 	}
 }
 
-OvUI::Widgets::Texts::Text& OvCore::Helpers::GUIDrawer::DrawMesh(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Model*& p_data, OvTools::Eventing::Event<>* p_updateNotifier)
+OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawMesh(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Model*& p_data, OvTools::Eventing::Event<>* p_updateNotifier)
 {
 	return DrawResourceWidget<OvRendering::Resources::Model, OvCore::ResourceManagement::ModelManager>(p_root, p_name, p_data, OvTools::Utils::PathParser::EFileType::MODEL, p_updateNotifier);
 }
@@ -248,7 +240,6 @@ OvUI::Widgets::Visual::Image& OvCore::Helpers::GUIDrawer::DrawTexture(OvUI::Inte
 {
 	CreateTitle(p_root, p_name);
 
-	std::string displayedText = (p_data ? p_data->path : std::string("Empty"));
 	auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
 	rightSide.horizontal = true;
 	rightSide.stretchWidget = 0;
@@ -273,7 +264,7 @@ OvUI::Widgets::Visual::Image& OvCore::Helpers::GUIDrawer::DrawTexture(OvUI::Inte
 
 	auto& selectButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::ButtonSmall>("...");
 	selectButton.lineBreak = false;
-	AddSelectButton(selectButton, OvTools::Utils::PathParser::EFileType::TEXTURE, [&widget, &p_data, p_updateNotifier](const std::string& p_path)
+	AddSelectButton(selectButton.ClickedEvent, OvTools::Utils::PathParser::EFileType::TEXTURE, [&widget, &p_data, p_updateNotifier](const std::string& p_path)
 	{
 		if (p_path.empty())
 		{
@@ -295,31 +286,27 @@ OvUI::Widgets::Visual::Image& OvCore::Helpers::GUIDrawer::DrawTexture(OvUI::Inte
 	return widget;
 }
 
-OvUI::Widgets::Texts::Text& OvCore::Helpers::GUIDrawer::DrawShader(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Shader*& p_data, OvTools::Eventing::Event<>* p_updateNotifier)
+OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawShader(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvRendering::Resources::Shader*& p_data, OvTools::Eventing::Event<>* p_updateNotifier)
 {
 	return DrawResourceWidget<OvRendering::Resources::Shader, OvCore::ResourceManagement::ShaderManager>(p_root, p_name, p_data, OvTools::Utils::PathParser::EFileType::SHADER, p_updateNotifier);
 }
 
-OvUI::Widgets::Texts::Text& OvCore::Helpers::GUIDrawer::DrawMaterial(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvCore::Resources::Material*& p_data, OvTools::Eventing::Event<>* p_updateNotifier)
+OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawMaterial(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvCore::Resources::Material*& p_data, OvTools::Eventing::Event<>* p_updateNotifier)
 {
 	return DrawResourceWidget<OvCore::Resources::Material, OvCore::ResourceManagement::MaterialManager>(p_root, p_name, p_data, OvTools::Utils::PathParser::EFileType::MATERIAL, p_updateNotifier);
 }
 
-OvUI::Widgets::Texts::Text& OvCore::Helpers::GUIDrawer::DrawSound(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvAudio::Resources::Sound*& p_data, OvTools::Eventing::Event<>* p_updateNotifier)
+OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawSound(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvAudio::Resources::Sound*& p_data, OvTools::Eventing::Event<>* p_updateNotifier)
 {
 	return DrawResourceWidget<OvAudio::Resources::Sound, OvCore::ResourceManagement::SoundManager>(p_root, p_name, p_data, OvTools::Utils::PathParser::EFileType::SOUND, p_updateNotifier);
 }
 
-OvUI::Widgets::Texts::Text& OvCore::Helpers::GUIDrawer::DrawAsset(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::string& p_data, OvTools::Eventing::Event<>* p_updateNotifier)
+OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawAsset(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::string& p_data, OvTools::Eventing::Event<>* p_updateNotifier)
 {
 	CreateTitle(p_root, p_name);
 
 	const std::string displayedText = (p_data.empty() ? std::string("Empty") : p_data);
-	auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
-	rightSide.horizontal = true;
-	rightSide.stretchWidget = 0;
-
-	auto& widget = rightSide.CreateWidget<OvUI::Widgets::Texts::Text>(displayedText);
+	auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(displayedText);
 
 	widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent += [&widget, &p_data, p_updateNotifier](auto p_receivedData)
 	{
@@ -329,11 +316,7 @@ OvUI::Widgets::Texts::Text& OvCore::Helpers::GUIDrawer::DrawAsset(OvUI::Internal
 			p_updateNotifier->Invoke();
 	};
 
-	widget.lineBreak = false;
-
-	auto& selectButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::ButtonSmall>("...");
-	selectButton.lineBreak = false;
-	AddSelectButton(selectButton, OvTools::Utils::PathParser::EFileType::UNKNOWN, [&widget, &p_data, p_updateNotifier](const std::string& p_path)
+	AddSelectButton(widget.ClickedEvent, OvTools::Utils::PathParser::EFileType::UNKNOWN, [&widget, &p_data, p_updateNotifier](const std::string& p_path)
 	{
 		p_data = p_path;
 		widget.content = p_path.empty() ? "Empty" : p_path;

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -9,6 +9,8 @@
 
 #include <OvTools/Utils/PathParser.h>
 
+#include <OvCore/Helpers/GUIHelpers.h>
+
 #include <OvUI/Widgets/Texts/TextColored.h>
 #include <OvUI/Widgets/Drags/DragSingleScalar.h>
 #include <OvUI/Widgets/Drags/DragMultipleScalars.h>
@@ -34,90 +36,6 @@
 const OvUI::Types::Color OvCore::Helpers::GUIDrawer::TitleColor = { 0.85f, 0.65f, 0.0f };
 const float OvCore::Helpers::GUIDrawer::_MIN_FLOAT = -999999999.f;
 const float OvCore::Helpers::GUIDrawer::_MAX_FLOAT = +999999999.f;
-
-namespace
-{
-	OvRendering::Resources::Texture* __EMPTY_TEXTURE = nullptr;
-	OvCore::Helpers::GUIDrawer::FileItemBuilderCallback __FILE_ITEM_BUILDER;
-	OvCore::Helpers::GUIDrawer::PickerProviderCallback __PICKER_PROVIDER;
-	OvCore::Helpers::GUIDrawer::IconProviderCallback __ICON_PROVIDER;
-	OvCore::Helpers::GUIDrawer::OpenProviderCallback __OPEN_PROVIDER;
-
-	std::string TitleFromFileType(OvTools::Utils::PathParser::EFileType p_type)
-	{
-		using EFileType = OvTools::Utils::PathParser::EFileType;
-		switch (p_type)
-		{
-		case EFileType::MODEL:    return "Pick Model";
-		case EFileType::TEXTURE:  return "Pick Texture";
-		case EFileType::SHADER:   return "Pick Shader";
-		case EFileType::MATERIAL: return "Pick Material";
-		case EFileType::SOUND:    return "Pick Sound";
-		case EFileType::SCRIPT:   return "Pick Script";
-		default:                  return "Pick Asset";
-		}
-	}
-}
-
-void OvCore::Helpers::GUIDrawer::ProvideEmptyTexture(OvRendering::Resources::Texture& p_emptyTexture)
-{
-	__EMPTY_TEXTURE = &p_emptyTexture;
-}
-
-void OvCore::Helpers::GUIDrawer::SetFileItemBuilder(FileItemBuilderCallback p_builder)
-{
-	__FILE_ITEM_BUILDER = std::move(p_builder);
-}
-
-void OvCore::Helpers::GUIDrawer::OpenAssetPicker(
-	OvTools::Utils::PathParser::EFileType p_fileType,
-	std::function<void(std::string)> p_onSelect,
-	bool p_searchProjectFiles,
-	bool p_searchEngineFiles
-)
-{
-	if (!__FILE_ITEM_BUILDER || !__PICKER_PROVIDER)
-		return;
-
-	// Keep a copy so we can attach it to the None item before moving.
-	auto onSelectCopy = p_onSelect;
-	auto assetItems = __FILE_ITEM_BUILDER(p_fileType, std::move(p_onSelect), p_searchProjectFiles, p_searchEngineFiles);
-
-	// Build the final list with "None" at the top.
-	PickerItemList items;
-	items.Add({ "__none__", "None", "Clear the current selection", 0, [onSelectCopy] { onSelectCopy(""); } });
-	for (const auto& item : assetItems.Items())
-		items.Add(item);
-
-	__PICKER_PROVIDER(std::move(items), TitleFromFileType(p_fileType));
-}
-
-void OvCore::Helpers::GUIDrawer::SetPickerProvider(PickerProviderCallback p_provider)
-{
-	__PICKER_PROVIDER = std::move(p_provider);
-}
-
-void OvCore::Helpers::GUIDrawer::SetIconProvider(IconProviderCallback p_provider)
-{
-	__ICON_PROVIDER = std::move(p_provider);
-}
-
-void OvCore::Helpers::GUIDrawer::SetOpenProvider(OpenProviderCallback p_provider)
-{
-	__OPEN_PROVIDER = std::move(p_provider);
-}
-
-void OvCore::Helpers::GUIDrawer::Open(const std::string& p_path)
-{
-	if (__OPEN_PROVIDER && !p_path.empty())
-		__OPEN_PROVIDER(p_path);
-}
-
-void OvCore::Helpers::GUIDrawer::OpenPicker(PickerItemList p_items, std::string p_title)
-{
-	if (__PICKER_PROVIDER)
-		__PICKER_PROVIDER(std::move(p_items), std::move(p_title));
-}
 
 void OvCore::Helpers::GUIDrawer::CreateTitle(OvUI::Internal::WidgetContainer& p_root, const std::string & p_name)
 {
@@ -191,7 +109,7 @@ namespace
 		p_clickedEvent += [p_fileType, p_onSelect = std::move(p_onSelect), token = std::move(token)]
 		{
 			std::weak_ptr<bool> weak = token;
-			OvCore::Helpers::GUIDrawer::OpenAssetPicker(p_fileType, [p_onSelect, weak](const std::string& p_path)
+			OvCore::Helpers::GUIHelpers::OpenAssetPicker(p_fileType, [p_onSelect, weak](const std::string& p_path)
 			{
 				if (!weak.expired()) p_onSelect(p_path);
 			}, true, true);
@@ -210,8 +128,7 @@ namespace
 
 		const std::string displayedText = p_data ? p_data->path : std::string{};
 		auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(displayedText);
-		if (__ICON_PROVIDER)
-			widget.iconTextureID = __ICON_PROVIDER(p_fileType);
+		widget.iconTextureID = OvCore::Helpers::GUIHelpers::GetIconForFileType(p_fileType);
 
 		widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent +=
 			[&widget, &p_data, p_updateNotifier, p_fileType](auto p_receivedData)
@@ -247,8 +164,7 @@ namespace
 			}
 		});
 
-		if (__OPEN_PROVIDER)
-			widget.DoubleClickedEvent += [&widget] { __OPEN_PROVIDER(widget.content); };
+		widget.DoubleClickedEvent += [&widget] { OvCore::Helpers::GUIHelpers::Open(widget.content); };
 
 		return widget;
 	}
@@ -266,12 +182,12 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawTexture(
 	auto getPreviewID = [&]() -> uint32_t
 	{
 		if (p_data) return p_data->GetTexture().GetID();
-		return __EMPTY_TEXTURE ? __EMPTY_TEXTURE->GetTexture().GetID() : 0;
+		auto* empty = OvCore::Helpers::GUIHelpers::GetEmptyTexture();
+		return empty ? empty->GetTexture().GetID() : 0;
 	};
 
 	auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(p_data ? p_data->path : std::string{});
-	if (__ICON_PROVIDER)
-		widget.iconTextureID = __ICON_PROVIDER(OvTools::Utils::PathParser::EFileType::TEXTURE);
+	widget.iconTextureID = OvCore::Helpers::GUIHelpers::GetIconForFileType(OvTools::Utils::PathParser::EFileType::TEXTURE);
 	widget.previewTextureID = getPreviewID();
 
 	widget.AddPlugin<OvUI::Plugins::DDTarget<std::pair<std::string, OvUI::Widgets::Layout::Group*>>>("File").DataReceivedEvent +=
@@ -311,8 +227,7 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawTexture(
 		}
 	});
 
-	if (__OPEN_PROVIDER)
-		widget.DoubleClickedEvent += [&widget] { __OPEN_PROVIDER(widget.content); };
+	widget.DoubleClickedEvent += [&widget] { OvCore::Helpers::GUIHelpers::Open(widget.content); };
 
 	return widget;
 }
@@ -363,8 +278,7 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawScene(Ov
 	CreateTitle(p_root, p_name);
 
 	auto& widget = p_root.CreateWidget<OvUI::Widgets::InputFields::AssetField>(p_gatherer());
-	if (__ICON_PROVIDER)
-		widget.iconTextureID = __ICON_PROVIDER(OvTools::Utils::PathParser::EFileType::SCENE);
+	widget.iconTextureID = OvCore::Helpers::GUIHelpers::GetIconForFileType(OvTools::Utils::PathParser::EFileType::SCENE);
 
 	widget.AddPlugin<OvUI::Plugins::DataDispatcher<std::string>>().RegisterGatherer(p_gatherer);
 
@@ -382,7 +296,7 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawScene(Ov
 	widget.ClickedEvent += [&widget, p_provider, token]()
 	{
 		std::weak_ptr<bool> weak = token;
-		OpenAssetPicker(OvTools::Utils::PathParser::EFileType::SCENE, [&widget, p_provider, weak](const std::string& p_path)
+		OvCore::Helpers::GUIHelpers::OpenAssetPicker(OvTools::Utils::PathParser::EFileType::SCENE, [&widget, p_provider, weak](const std::string& p_path)
 		{
 			if (!weak.expired())
 			{

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -41,6 +41,7 @@ namespace
 	OvCore::Helpers::GUIDrawer::FileItemBuilderCallback __FILE_ITEM_BUILDER;
 	OvCore::Helpers::GUIDrawer::PickerProviderCallback __PICKER_PROVIDER;
 	OvCore::Helpers::GUIDrawer::IconProviderCallback __ICON_PROVIDER;
+	OvCore::Helpers::GUIDrawer::OpenProviderCallback __OPEN_PROVIDER;
 
 	std::string TitleFromFileType(OvTools::Utils::PathParser::EFileType p_type)
 	{
@@ -99,6 +100,11 @@ void OvCore::Helpers::GUIDrawer::SetPickerProvider(PickerProviderCallback p_prov
 void OvCore::Helpers::GUIDrawer::SetIconProvider(IconProviderCallback p_provider)
 {
 	__ICON_PROVIDER = std::move(p_provider);
+}
+
+void OvCore::Helpers::GUIDrawer::SetOpenProvider(OpenProviderCallback p_provider)
+{
+	__OPEN_PROVIDER = std::move(p_provider);
 }
 
 void OvCore::Helpers::GUIDrawer::OpenPicker(PickerItemList p_items, std::string p_title)
@@ -235,6 +241,9 @@ namespace
 			}
 		});
 
+		if (__OPEN_PROVIDER)
+			widget.DoubleClickedEvent += [&widget] { __OPEN_PROVIDER(widget.content); };
+
 		return widget;
 	}
 }
@@ -295,6 +304,9 @@ OvUI::Widgets::InputFields::AssetField& OvCore::Helpers::GUIDrawer::DrawTexture(
 				p_updateNotifier->Invoke();
 		}
 	});
+
+	if (__OPEN_PROVIDER)
+		widget.DoubleClickedEvent += [&widget] { __OPEN_PROVIDER(widget.content); };
 
 	return widget;
 }

--- a/Sources/OvCore/src/OvCore/Helpers/GUIHelpers.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIHelpers.cpp
@@ -1,0 +1,101 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <OvRendering/Resources/Texture.h>
+
+#include "OvCore/Helpers/GUIHelpers.h"
+
+namespace
+{
+	OvRendering::Resources::Texture* __EMPTY_TEXTURE = nullptr;
+	OvCore::Helpers::GUIHelpers::FileItemBuilderCallback __FILE_ITEM_BUILDER;
+	OvCore::Helpers::GUIHelpers::PickerProviderCallback __PICKER_PROVIDER;
+	OvCore::Helpers::GUIHelpers::IconProviderCallback __ICON_PROVIDER;
+	OvCore::Helpers::GUIHelpers::OpenProviderCallback __OPEN_PROVIDER;
+
+	std::string TitleFromFileType(OvTools::Utils::PathParser::EFileType p_type)
+	{
+		using EFileType = OvTools::Utils::PathParser::EFileType;
+		switch (p_type)
+		{
+		case EFileType::MODEL:    return "Pick Model";
+		case EFileType::TEXTURE:  return "Pick Texture";
+		case EFileType::SHADER:   return "Pick Shader";
+		case EFileType::MATERIAL: return "Pick Material";
+		case EFileType::SOUND:    return "Pick Sound";
+		case EFileType::SCRIPT:   return "Pick Script";
+		default:                  return "Pick Asset";
+		}
+	}
+}
+
+void OvCore::Helpers::GUIHelpers::ProvideEmptyTexture(OvRendering::Resources::Texture& p_emptyTexture)
+{
+	__EMPTY_TEXTURE = &p_emptyTexture;
+}
+
+OvRendering::Resources::Texture* OvCore::Helpers::GUIHelpers::GetEmptyTexture()
+{
+	return __EMPTY_TEXTURE;
+}
+
+void OvCore::Helpers::GUIHelpers::SetFileItemBuilder(FileItemBuilderCallback p_builder)
+{
+	__FILE_ITEM_BUILDER = std::move(p_builder);
+}
+
+void OvCore::Helpers::GUIHelpers::OpenAssetPicker(
+	OvTools::Utils::PathParser::EFileType p_fileType,
+	std::function<void(std::string)> p_onSelect,
+	bool p_searchProjectFiles,
+	bool p_searchEngineFiles
+)
+{
+	if (!__FILE_ITEM_BUILDER || !__PICKER_PROVIDER)
+		return;
+
+	auto onSelectCopy = p_onSelect;
+	auto assetItems = __FILE_ITEM_BUILDER(p_fileType, std::move(p_onSelect), p_searchProjectFiles, p_searchEngineFiles);
+
+	PickerItemList items;
+	items.Add({ "__none__", "None", "Clear the current selection", 0, [onSelectCopy] { onSelectCopy(""); } });
+	for (const auto& item : assetItems.Items())
+		items.Add(item);
+
+	__PICKER_PROVIDER(std::move(items), TitleFromFileType(p_fileType));
+}
+
+void OvCore::Helpers::GUIHelpers::SetOpenProvider(OpenProviderCallback p_provider)
+{
+	__OPEN_PROVIDER = std::move(p_provider);
+}
+
+void OvCore::Helpers::GUIHelpers::Open(const std::string& p_path)
+{
+	if (__OPEN_PROVIDER && !p_path.empty())
+		__OPEN_PROVIDER(p_path);
+}
+
+void OvCore::Helpers::GUIHelpers::SetIconProvider(IconProviderCallback p_provider)
+{
+	__ICON_PROVIDER = std::move(p_provider);
+}
+
+uint32_t OvCore::Helpers::GUIHelpers::GetIconForFileType(OvTools::Utils::PathParser::EFileType p_fileType)
+{
+	return __ICON_PROVIDER ? __ICON_PROVIDER(p_fileType) : 0;
+}
+
+void OvCore::Helpers::GUIHelpers::SetPickerProvider(PickerProviderCallback p_provider)
+{
+	__PICKER_PROVIDER = std::move(p_provider);
+}
+
+void OvCore::Helpers::GUIHelpers::OpenPicker(PickerItemList p_items, std::string p_title)
+{
+	if (__PICKER_PROVIDER)
+		__PICKER_PROVIDER(std::move(p_items), std::move(p_title));
+}

--- a/Sources/OvCore/src/OvCore/Helpers/GUIHelpers.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIHelpers.cpp
@@ -1,8 +1,8 @@
 /**
-* @project: Overload
-* @author: Overload Tech.
-* @licence: MIT
-*/
+ * @project: Overload
+ * @author: Overload Tech.
+ * @licence: MIT
+ */
 
 #include <OvRendering/Resources/Texture.h>
 
@@ -27,6 +27,7 @@ namespace
 		case EFileType::MATERIAL: return "Pick Material";
 		case EFileType::SOUND:    return "Pick Sound";
 		case EFileType::SCRIPT:   return "Pick Script";
+		case EFileType::SCENE:    return "Pick Scene";
 		default:                  return "Pick Asset";
 		}
 	}
@@ -57,11 +58,10 @@ void OvCore::Helpers::GUIHelpers::OpenAssetPicker(
 	if (!__FILE_ITEM_BUILDER || !__PICKER_PROVIDER)
 		return;
 
-	auto onSelectCopy = p_onSelect;
-	auto assetItems = __FILE_ITEM_BUILDER(p_fileType, std::move(p_onSelect), p_searchProjectFiles, p_searchEngineFiles);
+	auto assetItems = __FILE_ITEM_BUILDER(p_fileType, p_onSelect, p_searchProjectFiles, p_searchEngineFiles);
 
 	PickerItemList items;
-	items.Add({ "__none__", "None", "Clear the current selection", 0, [onSelectCopy] { onSelectCopy(""); } });
+	items.Add({ "__none__", "None", "Clear the current selection", 0, [p_onSelect] { p_onSelect(""); } });
 	for (const auto& item : assetItems.Items())
 		items.Add(item);
 

--- a/Sources/OvEditor/include/OvEditor/Helpers/PickerHelpers.h
+++ b/Sources/OvEditor/include/OvEditor/Helpers/PickerHelpers.h
@@ -9,7 +9,7 @@
 #include <functional>
 #include <string>
 
-#include <OvCore/Helpers/GUIDrawer.h>
+#include <OvCore/Helpers/GUIHelpers.h>
 #include <OvTools/Utils/PathParser.h>
 
 namespace OvEditor::Helpers::PickerHelpers
@@ -26,7 +26,7 @@ namespace OvEditor::Helpers::PickerHelpers
 	* @param p_searchEngine     Include engine assets
 	*/
 	void AddFileItems(
-		OvCore::Helpers::GUIDrawer::PickerItemList& p_list,
+		OvCore::Helpers::GUIHelpers::PickerItemList& p_list,
 		OvTools::Utils::PathParser::EFileType p_fileType,
 		std::function<void(std::string)> p_onSelected,
 		bool p_searchProject = true,

--- a/Sources/OvEditor/include/OvEditor/Panels/AssetProperties.h
+++ b/Sources/OvEditor/include/OvEditor/Panels/AssetProperties.h
@@ -14,6 +14,7 @@
 #include <OvUI/Widgets/Texts/Text.h>
 #include <OvUI/Panels/PanelWindow.h>
 #include <OvUI/Widgets/Layout/Group.h>
+#include <OvUI/Widgets/InputFields/AssetField.h>
 #include <OvUI/Widgets/Layout/Columns.h>
 #include <OvUI/Widgets/Buttons/Button.h>
 
@@ -78,7 +79,7 @@ namespace OvEditor::Panels
         OvUI::Widgets::AWidget* m_headerLineBreak = nullptr;
 		OvUI::Widgets::Layout::Columns<2>* m_settingsColumns = nullptr;
 		OvUI::Widgets::Layout::Columns<2>* m_infoColumns = nullptr;
-        OvUI::Widgets::Texts::Text* m_assetSelector = nullptr;
+        OvUI::Widgets::InputFields::AssetField* m_assetSelector = nullptr;
 		std::unique_ptr<OvTools::Filesystem::IniFile> m_metadata;
 	};
 }

--- a/Sources/OvEditor/include/OvEditor/Panels/Inspector.h
+++ b/Sources/OvEditor/include/OvEditor/Panels/Inspector.h
@@ -66,8 +66,8 @@ namespace OvEditor::Panels
 		void _PopulateActorComponents();
 		void _PopulateActorBehaviours();
 		void _DrawAddSection();
-		void _DrawComponent(OvCore::ECS::Components::AComponent& p_component);
-		void _DrawBehaviour(OvCore::ECS::Components::Behaviour& p_behaviour);
+		void _DrawComponent(OvCore::ECS::Components::AComponent& p_component, int p_index, int p_total);
+		void _DrawBehaviour(OvCore::ECS::Components::Behaviour& p_behaviour, int p_index, int p_total);
 
 	private:
 		OvTools::Utils::OptRef<OvCore::ECS::Actor> m_targetActor = std::nullopt;

--- a/Sources/OvEditor/include/OvEditor/Panels/ItemPicker.h
+++ b/Sources/OvEditor/include/OvEditor/Panels/ItemPicker.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include <OvCore/Helpers/GUIDrawer.h>
+#include <OvCore/Helpers/GUIHelpers.h>
 #include <OvUI/Panels/PanelWindow.h>
 
 namespace OvUI::Widgets
@@ -45,7 +45,7 @@ namespace OvEditor::Panels
 		* @param p_items
 		* @param p_title  Title displayed in the window's title bar
 		*/
-		void Open(OvCore::Helpers::GUIDrawer::PickerItemList p_items, std::string p_title);
+		void Open(OvCore::Helpers::GUIHelpers::PickerItemList p_items, std::string p_title);
 
 	private:
 		void _Draw_Impl() override;
@@ -60,7 +60,7 @@ namespace OvEditor::Panels
 		float m_anchorY = 0.f;  // bottom-left Y when m_usePivotAnchor is true
 
 	private:
-		OvCore::Helpers::GUIDrawer::PickerItemList m_items;
+		OvCore::Helpers::GUIHelpers::PickerItemList m_items;
 
 		OvUI::Widgets::InputFields::InputText* m_searchField = nullptr;
 		OvUI::Widgets::Layout::Group* m_listGroup = nullptr;

--- a/Sources/OvEditor/include/OvEditor/Panels/MaterialEditor.h
+++ b/Sources/OvEditor/include/OvEditor/Panels/MaterialEditor.h
@@ -9,6 +9,7 @@
 #include <OvRendering/Resources/Shader.h>
 #include <OvUI/Panels/PanelWindow.h>
 #include <OvUI/Widgets/Texts/Text.h>
+#include <OvUI/Widgets/InputFields/AssetField.h>
 #include <OvUI/Widgets/Buttons/AButton.h>
 #include <OvUI/Widgets/Layout/Group.h>
 #include <OvUI/Widgets/Layout/Columns.h>
@@ -83,8 +84,8 @@ namespace OvEditor::Panels
 		OvCore::Resources::Material* m_target = nullptr;
 		OvRendering::Resources::Shader* m_shader = nullptr;
 
-		OvUI::Widgets::Texts::Text* m_targetMaterialText = nullptr;
-		OvUI::Widgets::Texts::Text* m_shaderText = nullptr;
+		OvUI::Widgets::InputFields::AssetField* m_targetMaterialText = nullptr;
+		OvUI::Widgets::InputFields::AssetField* m_shaderText = nullptr;
 
 		OvUI::Widgets::Buttons::AButton* m_editShaderButton = nullptr;
 		OvUI::Widgets::Buttons::AButton* m_compileShaderButton = nullptr;

--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -8,6 +8,13 @@
 
 #include <OvCore/Helpers/GUIDrawer.h>
 
+#include <OvCore/ResourceManagement/ModelManager.h>
+#include <OvCore/ResourceManagement/TextureManager.h>
+#include <OvCore/ResourceManagement/MaterialManager.h>
+
+#include <OvTools/Utils/SystemCalls.h>
+#include <OvTools/Utils/PathParser.h>
+
 #include <OvEditor/Core/Editor.h>
 #include <OvEditor/Panels/AssetBrowser.h>
 #include <OvEditor/Panels/ItemPicker.h>
@@ -67,6 +74,50 @@ void OvEditor::Core::Editor::SetupUI()
 		[this](OvTools::Utils::PathParser::EFileType p_fileType) -> uint32_t {
 			auto* texture = m_context.editorResources->GetTexture(OvTools::Utils::PathParser::FileTypeToString(p_fileType));
 			return texture ? texture->GetTexture().GetID() : 0;
+		}
+	);
+
+	OvCore::Helpers::GUIDrawer::SetOpenProvider(
+		[this](const std::string& p_path)
+		{
+			using EFileType = OvTools::Utils::PathParser::EFileType;
+			const auto fileType = OvTools::Utils::PathParser::GetFileType(p_path);
+
+			auto openInAssetView = [&](auto* p_resource)
+			{
+				if (!p_resource) return;
+				auto& assetView = EDITOR_PANEL(AssetView, "Asset View");
+				assetView.SetResource(AssetView::ViewableResource{ p_resource });
+				assetView.Open();
+				assetView.Focus();
+			};
+
+			if (fileType == EFileType::TEXTURE)
+			{
+				openInAssetView(OVSERVICE(TextureManager).GetResource(p_path, false));
+			}
+			else if (fileType == EFileType::MODEL)
+			{
+				openInAssetView(OVSERVICE(ModelManager).GetResource(p_path, false));
+			}
+			else if (fileType == EFileType::MATERIAL)
+			{
+				auto* material = OVSERVICE(MaterialManager).GetResource(p_path, false);
+				openInAssetView(material);
+				if (material)
+				{
+					auto& materialEditor = EDITOR_PANEL(MaterialEditor, "Material Editor");
+					EDITOR_EXEC(DelayAction([material, &materialEditor]() {
+						materialEditor.SetTarget(*material);
+						materialEditor.Open();
+						materialEditor.Focus();
+					}));
+				}
+			}
+			else if (fileType == EFileType::SHADER || fileType == EFileType::SHADER_PART)
+			{
+				OvTools::Utils::SystemCalls::OpenFile(EDITOR_EXEC(GetRealPath(p_path)));
+			}
 		}
 	);
 

--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -83,6 +83,7 @@ void OvEditor::Core::Editor::SetupUI()
 		{
 			using EFileType = OvTools::Utils::PathParser::EFileType;
 			const auto fileType = OvTools::Utils::PathParser::GetFileType(p_path);
+			const auto path = OvTools::Utils::PathParser::MakeNonWindowsStyle(p_path);
 
 			auto openInAssetView = [&](auto* p_resource)
 			{
@@ -95,15 +96,15 @@ void OvEditor::Core::Editor::SetupUI()
 
 			if (fileType == EFileType::TEXTURE)
 			{
-				openInAssetView(OVSERVICE(TextureManager).GetResource(p_path));
+				openInAssetView(OVSERVICE(TextureManager).GetResource(path));
 			}
 			else if (fileType == EFileType::MODEL)
 			{
-				openInAssetView(OVSERVICE(ModelManager).GetResource(p_path));
+				openInAssetView(OVSERVICE(ModelManager).GetResource(path));
 			}
 			else if (fileType == EFileType::MATERIAL)
 			{
-				auto* material = OVSERVICE(MaterialManager).GetResource(p_path);
+				auto* material = OVSERVICE(MaterialManager).GetResource(path);
 				openInAssetView(material);
 				if (material)
 				{
@@ -117,12 +118,12 @@ void OvEditor::Core::Editor::SetupUI()
 			}
 			else if (fileType == EFileType::SCENE)
 			{
-				EDITOR_EXEC(LoadSceneFromDisk(p_path));
+				EDITOR_EXEC(LoadSceneFromDisk(path));
 			}
 			else
 			{
 				// SHADER, SHADER_PART, SCRIPT, SOUND, FONT, UNKNOWN → open with OS default
-				OvTools::Utils::SystemCalls::OpenFile(EDITOR_EXEC(GetRealPath(p_path)));
+				OvTools::Utils::SystemCalls::OpenFile(EDITOR_EXEC(GetRealPath(path)));
 			}
 		}
 	);

--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -7,6 +7,7 @@
 #include <tracy/Tracy.hpp>
 
 #include <OvCore/Helpers/GUIDrawer.h>
+#include <OvCore/Helpers/GUIHelpers.h>
 
 #include <OvCore/ResourceManagement/ModelManager.h>
 #include <OvCore/ResourceManagement/TextureManager.h>
@@ -64,20 +65,20 @@ void OvEditor::Core::Editor::SetupUI()
 	settings.collapsable = true;
 	settings.dockable = true;
 
-	OvCore::Helpers::GUIDrawer::SetPickerProvider(
-		[this](OvCore::Helpers::GUIDrawer::PickerItemList p_items, std::string p_title) {
+	OvCore::Helpers::GUIHelpers::SetPickerProvider(
+		[this](OvCore::Helpers::GUIHelpers::PickerItemList p_items, std::string p_title) {
 			m_itemPicker->Open(std::move(p_items), std::move(p_title));
 		}
 	);
 
-	OvCore::Helpers::GUIDrawer::SetIconProvider(
+	OvCore::Helpers::GUIHelpers::SetIconProvider(
 		[this](OvTools::Utils::PathParser::EFileType p_fileType) -> uint32_t {
 			auto* texture = m_context.editorResources->GetTexture(OvTools::Utils::PathParser::FileTypeToString(p_fileType));
 			return texture ? texture->GetTexture().GetID() : 0;
 		}
 	);
 
-	OvCore::Helpers::GUIDrawer::SetOpenProvider(
+	OvCore::Helpers::GUIHelpers::SetOpenProvider(
 		[this](const std::string& p_path)
 		{
 			using EFileType = OvTools::Utils::PathParser::EFileType;

--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -91,6 +91,13 @@ void OvEditor::Core::Editor::SetupUI()
 			m_itemPicker->Open(std::move(p_items), std::move(p_title));
 		}
 	);
+
+	OvCore::Helpers::GUIDrawer::SetIconProvider(
+		[this](OvTools::Utils::PathParser::EFileType p_fileType) -> uint32_t {
+			auto* texture = m_context.editorResources->GetTexture(OvTools::Utils::PathParser::FileTypeToString(p_fileType));
+			return texture ? texture->GetTexture().GetID() : 0;
+		}
+	);
 }
 
 void OvEditor::Core::Editor::PreUpdate()

--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -115,8 +115,13 @@ void OvEditor::Core::Editor::SetupUI()
 					}));
 				}
 			}
-			else if (fileType == EFileType::SHADER || fileType == EFileType::SHADER_PART)
+			else if (fileType == EFileType::SCENE)
 			{
+				EDITOR_EXEC(LoadSceneFromDisk(p_path));
+			}
+			else
+			{
+				// SHADER, SHADER_PART, SCRIPT, SOUND, FONT, UNKNOWN → open with OS default
 				OvTools::Utils::SystemCalls::OpenFile(EDITOR_EXEC(GetRealPath(p_path)));
 			}
 		}

--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -57,6 +57,19 @@ void OvEditor::Core::Editor::SetupUI()
 	settings.collapsable = true;
 	settings.dockable = true;
 
+	OvCore::Helpers::GUIDrawer::SetPickerProvider(
+		[this](OvCore::Helpers::GUIDrawer::PickerItemList p_items, std::string p_title) {
+			m_itemPicker->Open(std::move(p_items), std::move(p_title));
+		}
+	);
+
+	OvCore::Helpers::GUIDrawer::SetIconProvider(
+		[this](OvTools::Utils::PathParser::EFileType p_fileType) -> uint32_t {
+			auto* texture = m_context.editorResources->GetTexture(OvTools::Utils::PathParser::FileTypeToString(p_fileType));
+			return texture ? texture->GetTexture().GetID() : 0;
+		}
+	);
+
 	m_panelsManager.CreatePanel<Panels::MenuBar>("Menu Bar");
 	m_panelsManager.CreatePanel<Panels::AssetBrowser>("Asset Browser", true, settings);
 	m_panelsManager.CreatePanel<Panels::HardwareInfo>("Hardware Info", false, settings);
@@ -85,19 +98,6 @@ void OvEditor::Core::Editor::SetupUI()
 	);
 
 	m_canvas.AddPanel(*m_itemPicker);
-
-	OvCore::Helpers::GUIDrawer::SetPickerProvider(
-		[this](OvCore::Helpers::GUIDrawer::PickerItemList p_items, std::string p_title) {
-			m_itemPicker->Open(std::move(p_items), std::move(p_title));
-		}
-	);
-
-	OvCore::Helpers::GUIDrawer::SetIconProvider(
-		[this](OvTools::Utils::PathParser::EFileType p_fileType) -> uint32_t {
-			auto* texture = m_context.editorResources->GetTexture(OvTools::Utils::PathParser::FileTypeToString(p_fileType));
-			return texture ? texture->GetTexture().GetID() : 0;
-		}
-	);
 }
 
 void OvEditor::Core::Editor::PreUpdate()

--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -94,15 +94,15 @@ void OvEditor::Core::Editor::SetupUI()
 
 			if (fileType == EFileType::TEXTURE)
 			{
-				openInAssetView(OVSERVICE(TextureManager).GetResource(p_path, false));
+				openInAssetView(OVSERVICE(TextureManager).GetResource(p_path));
 			}
 			else if (fileType == EFileType::MODEL)
 			{
-				openInAssetView(OVSERVICE(ModelManager).GetResource(p_path, false));
+				openInAssetView(OVSERVICE(ModelManager).GetResource(p_path));
 			}
 			else if (fileType == EFileType::MATERIAL)
 			{
-				auto* material = OVSERVICE(MaterialManager).GetResource(p_path, false);
+				auto* material = OVSERVICE(MaterialManager).GetResource(p_path);
 				openInAssetView(material);
 				if (material)
 				{

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -20,6 +20,7 @@
 #include <OvCore/ECS/Components/CPhysicalSphere.h>
 
 #include <OvCore/Helpers/GUIDrawer.h>
+#include <OvCore/Helpers/GUIHelpers.h>
 
 #include <OvEditor/Core/EditorActions.h>
 #include <OvEditor/Core/GizmoBehaviour.h>
@@ -47,9 +48,9 @@ OvEditor::Core::EditorActions::EditorActions(Context& p_context, PanelsManager& 
 {
 	OvCore::Global::ServiceLocator::Provide<OvEditor::Core::EditorActions>(*this);
 
-	OvCore::Helpers::GUIDrawer::SetFileItemBuilder(
+	OvCore::Helpers::GUIHelpers::SetFileItemBuilder(
 		[](OvTools::Utils::PathParser::EFileType p_type, std::function<void(std::string)> p_callback, bool p_searchProject, bool p_searchEngine) {
-			OvCore::Helpers::GUIDrawer::PickerItemList items;
+			OvCore::Helpers::GUIHelpers::PickerItemList items;
 			OvEditor::Helpers::PickerHelpers::AddFileItems(items, p_type, std::move(p_callback), p_searchProject, p_searchEngine);
 			return items;
 		}

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -1162,10 +1162,10 @@ void OvEditor::Core::EditorActions::PropagateFileRename(std::string p_previousNa
 		{
 			for (auto actor : currentScene->GetActors())
 			{
-				if (actor->RemoveBehaviour(prev) && next != "?")
-				{
-					actor->AddBehaviour(next);
-				}
+				if (next != "?")
+					actor->RenameBehaviour(prev, next);
+				else
+					actor->RemoveBehaviour(prev);
 			}
 		}
 

--- a/Sources/OvEditor/src/OvEditor/Core/EditorResources.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorResources.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 
 #include <OvCore/Helpers/GUIDrawer.h>
+#include <OvCore/Helpers/GUIHelpers.h>
 #include <OvDebug/Assertion.h>
 #include <OvEditor/Core/EditorResources.h>
 #include <OvRendering/Settings/ETextureFilteringMode.h>
@@ -161,7 +162,7 @@ OvEditor::Core::EditorResources::EditorResources(const std::string& p_editorAsse
 	ValidateResources(m_shaders);
 
 	// Register the empty texture for the GUIDrawer to use it when a texture is missing
-	OvCore::Helpers::GUIDrawer::ProvideEmptyTexture(*m_textures["Empty_Texture"]);
+	OvCore::Helpers::GUIHelpers::ProvideEmptyTexture(*m_textures["Empty_Texture"]);
 }
 
 OvEditor::Core::EditorResources::~EditorResources()

--- a/Sources/OvEditor/src/OvEditor/Helpers/PickerHelpers.cpp
+++ b/Sources/OvEditor/src/OvEditor/Helpers/PickerHelpers.cpp
@@ -15,7 +15,7 @@ using namespace OvTools::Utils;
 namespace
 {
 	void CollectFromDirectory(
-		OvCore::Helpers::GUIDrawer::PickerItemList& p_list,
+		OvCore::Helpers::GUIHelpers::PickerItemList& p_list,
 		const std::filesystem::path& p_directory,
 		bool p_isEngine,
 		PathParser::EFileType p_fileType,
@@ -57,7 +57,7 @@ namespace
 }
 
 void OvEditor::Helpers::PickerHelpers::AddFileItems(
-	OvCore::Helpers::GUIDrawer::PickerItemList& p_list,
+	OvCore::Helpers::GUIHelpers::PickerItemList& p_list,
 	PathParser::EFileType p_fileType,
 	std::function<void(std::string)> p_onSelected,
 	bool p_searchProject,

--- a/Sources/OvEditor/src/OvEditor/Helpers/PickerHelpers.cpp
+++ b/Sources/OvEditor/src/OvEditor/Helpers/PickerHelpers.cpp
@@ -42,12 +42,13 @@ namespace
 
 			const std::string resourcePath = EDITOR_EXEC(GetResourcePath(path, p_isEngine));
 			const std::string filename = PathParser::GetElementName(resourcePath);
+			const std::string friendlyPath = PathParser::GetFriendlyPath(resourcePath);
 			const uint32_t iconID = EDITOR_CONTEXT(editorResources)->GetFileIcon(path)->GetTexture().GetID();
 
 			p_list.Add({
 				resourcePath,
 				filename,
-				resourcePath,
+				friendlyPath,
 				iconID,
 				[onSelected = p_onSelected, resourcePath] { onSelected(resourcePath); }
 			});

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -13,6 +13,7 @@
 #include <tinyxml2.h>
 
 #include <OvCore/Helpers/GUIDrawer.h>
+#include <OvCore/Helpers/GUIHelpers.h>
 #include <OvCore/Global/ServiceLocator.h>
 #include <OvCore/ResourceManagement/ModelManager.h>
 #include <OvCore/ResourceManagement/TextureManager.h>
@@ -310,7 +311,7 @@ namespace
 
 			ItemAddedEvent.Invoke(finalPath);
 
-			OvCore::Helpers::GUIDrawer::Open(EDITOR_EXEC(GetResourcePath(finalPath.string())));
+			OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(finalPath.string())));
 
 			Close();
 		}
@@ -591,7 +592,7 @@ namespace
 			auto& previewAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Preview");
 
 			previewAction.ClickedEvent += [this] {
-				OvCore::Helpers::GUIDrawer::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
+				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
 			};
 
 			FileContextualMenu::CreateList();
@@ -764,7 +765,7 @@ namespace
 
 			editAction.ClickedEvent += [this]
 			{
-				OvCore::Helpers::GUIDrawer::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
+				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
 			};
 
 			auto& reload = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Reload");
@@ -1186,14 +1187,14 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 		if (fileType == OvTools::Utils::PathParser::EFileType::MODEL)
 		{
 			clickableText.DoubleClickedEvent += [&contextMenu, p_isEngineItem] {
-				OvCore::Helpers::GUIDrawer::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
+				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
 			};
 		}
 
 		if (fileType == OvTools::Utils::PathParser::EFileType::MATERIAL)
 		{
 			clickableText.DoubleClickedEvent += [&contextMenu, p_isEngineItem] {
-				OvCore::Helpers::GUIDrawer::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
+				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
 			};
 		}
 
@@ -1203,7 +1204,7 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 			texturePreview.SetPath(resourceFormatPath);
 
 			clickableText.DoubleClickedEvent += [&contextMenu, p_isEngineItem] {
-				OvCore::Helpers::GUIDrawer::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
+				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
 			};
 		}
 

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -525,7 +525,7 @@ namespace
 			auto& editAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Open");
 
 			editAction.ClickedEvent += [this] {
-				OvTools::Utils::SystemCalls::OpenFile(filePath.string());
+				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
 			};
 
 			auto& openInCodeEditor = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Open in code editor");
@@ -747,7 +747,7 @@ namespace
 
 			editAction.ClickedEvent += [this]
 			{
-				EDITOR_EXEC(LoadSceneFromDisk(EDITOR_EXEC(GetResourcePath(filePath.string()))));
+				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
 			};
 
 			FileContextualMenu::CreateList();
@@ -1174,44 +1174,16 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 			EDITOR_EXEC(DelayAction(std::bind(&AssetBrowser::ConsiderItem, this, p_root, std::filesystem::directory_entry{ newItem }, p_isEngineItem, false), 0));
 		};
 
-		if (fileType == OvTools::Utils::PathParser::EFileType::SOUND ||
-			fileType == OvTools::Utils::PathParser::EFileType::SCRIPT ||
-			fileType == OvTools::Utils::PathParser::EFileType::SHADER ||
-			fileType == OvTools::Utils::PathParser::EFileType::SHADER_PART)
-		{
-			clickableText.DoubleClickedEvent += [&contextMenu] {
-				OvTools::Utils::SystemCalls::OpenFile(contextMenu.filePath.string());
-			};
-		}
-
-		if (fileType == OvTools::Utils::PathParser::EFileType::MODEL)
-		{
-			clickableText.DoubleClickedEvent += [&contextMenu, p_isEngineItem] {
-				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
-			};
-		}
-
-		if (fileType == OvTools::Utils::PathParser::EFileType::MATERIAL)
-		{
-			clickableText.DoubleClickedEvent += [&contextMenu, p_isEngineItem] {
-				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
-			};
-		}
-
 		if (fileType == OvTools::Utils::PathParser::EFileType::TEXTURE)
 		{
 			auto& texturePreview = clickableText.AddPlugin<TexturePreview>();
 			texturePreview.SetPath(resourceFormatPath);
-
-			clickableText.DoubleClickedEvent += [&contextMenu, p_isEngineItem] {
-				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
-			};
 		}
 
-		if (fileType == OvTools::Utils::PathParser::EFileType::SCENE)
+		if (fileType != OvTools::Utils::PathParser::EFileType::UNKNOWN)
 		{
-			clickableText.DoubleClickedEvent += [&contextMenu] {
-				EDITOR_EXEC(LoadSceneFromDisk(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string()))));
+			clickableText.DoubleClickedEvent += [&contextMenu, p_isEngineItem] {
+				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
 			};
 		}
 	}

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -969,7 +969,7 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 			treeNode.Open();
 		}
 
-		auto& ddSource = treeNode.AddPlugin<OvUI::Plugins::DDSource<std::pair<std::string, Layout::Group*>>>("Folder", resourceFormatPath, std::make_pair(resourceFormatPath, &itemGroup));
+		auto& ddSource = treeNode.AddPlugin<OvUI::Plugins::DDSource<std::pair<std::string, Layout::Group*>>>("Folder", OvTools::Utils::PathParser::GetFriendlyPath(resourceFormatPath), std::make_pair(resourceFormatPath, &itemGroup));
 		
 		if (!p_root)
 		{
@@ -1097,7 +1097,7 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 					const auto elementName = p_newPath.filename();
 					const auto data = std::filesystem::path{ ddSource.data.first }.parent_path() / elementName;
 					ddSource.data.first = data.string();
-					ddSource.tooltip = data.string();
+					ddSource.tooltip = OvTools::Utils::PathParser::GetFriendlyPath(data.string());
 					treeNode.name = elementName.string();
 					treeNode.Open();
 					treeNode.RemoveAllWidgets();
@@ -1162,7 +1162,7 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 
 		auto& ddSource = clickableText.AddPlugin<OvUI::Plugins::DDSource<std::pair<std::string, Layout::Group*>>>(
 			"File",
-			resourceFormatPath,
+			OvTools::Utils::PathParser::GetFriendlyPath(resourceFormatPath),
 			std::make_pair(resourceFormatPath, &itemGroup)
 		);
 
@@ -1177,7 +1177,7 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 					RenameAsset(p_prev, p_newPath);
 					const auto elementName = p_newPath.filename();
 					ddSource.data.first = (std::filesystem::path{ ddSource.data.first }.parent_path() / elementName).string();
-					ddSource.tooltip = ddSource.data.first;
+					ddSource.tooltip = OvTools::Utils::PathParser::GetFriendlyPath(ddSource.data.first);
 
 					EDITOR_EXEC(PropagateFileRename(p_prev.string(), p_newPath.string()));
 

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <tinyxml2.h>
 
+#include <OvCore/Helpers/GUIDrawer.h>
 #include <OvCore/Global/ServiceLocator.h>
 #include <OvCore/ResourceManagement/ModelManager.h>
 #include <OvCore/ResourceManagement/TextureManager.h>
@@ -23,7 +24,6 @@
 #include <OvEditor/Core/EditorResources.h>
 #include <OvEditor/Panels/AssetBrowser.h>
 #include <OvEditor/Panels/AssetProperties.h>
-#include <OvEditor/Panels/AssetView.h>
 #include <OvEditor/Panels/MaterialEditor.h>
 #include <OvEditor/Settings/EditorSettings.h>
 
@@ -50,30 +50,6 @@ using namespace OvUI::Widgets;
 namespace
 {
 	constexpr std::string_view kAllowedFilenameChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-_=+ 0123456789()[]";
-
-	template<typename ResourceManager>
-	auto& GetResource(const std::string& p_path, bool p_isEngineResource)
-	{
-		auto resource = OvCore::Global::ServiceLocator::Get<ResourceManager>()[EDITOR_EXEC(GetResourcePath(p_path, p_isEngineResource))];
-		OVASSERT(resource, "Resource not found");
-		return *resource;
-	}
-
-	void OpenInAssetView(auto& p_resource)
-	{
-		auto& assetView = EDITOR_PANEL(OvEditor::Panels::AssetView, "Asset View");
-		assetView.SetResource(OvEditor::Panels::AssetView::ViewableResource{ &p_resource });
-		assetView.Open();
-		assetView.Focus();
-	}
-
-	void OpenInMaterialEditor(auto& p_resource)
-	{
-		auto& materialEditor = EDITOR_PANEL(OvEditor::Panels::MaterialEditor, "Material Editor");
-		materialEditor.SetTarget(p_resource);
-		materialEditor.Open();
-		materialEditor.Focus();
-	}
 
 	std::filesystem::path GetAssociatedMetaFile(const std::filesystem::path& p_assetPath)
 	{
@@ -334,12 +310,7 @@ namespace
 
 			ItemAddedEvent.Invoke(finalPath);
 
-			if (auto instance = EDITOR_CONTEXT(materialManager)[EDITOR_EXEC(GetResourcePath(finalPath.string()))])
-			{
-				auto& materialEditor = EDITOR_PANEL(OvEditor::Panels::MaterialEditor, "Material Editor");
-				OpenInMaterialEditor(*instance);
-				OpenInAssetView(*instance);
-			}
+			OvCore::Helpers::GUIDrawer::Open(EDITOR_EXEC(GetResourcePath(finalPath.string())));
 
 			Close();
 		}
@@ -610,7 +581,6 @@ namespace
 		OvTools::Eventing::Event<std::filesystem::path> DuplicateEvent;
 	};
 
-	template<typename Resource, typename ResourceLoader>
 	class PreviewableContextualMenu : public FileContextualMenu
 	{
 	public:
@@ -621,7 +591,7 @@ namespace
 			auto& previewAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Preview");
 
 			previewAction.ClickedEvent += [this] {
-				OpenInAssetView(GetResource<ResourceLoader>(filePath.string(), m_protected));
+				OvCore::Helpers::GUIDrawer::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
 			};
 
 			FileContextualMenu::CreateList();
@@ -670,7 +640,7 @@ namespace
 		ShaderPartContextualMenu(const std::string& p_filePath, bool p_protected = false) : FileContextualMenu(p_filePath, p_protected) {}
 	};
 
-	class ModelContextualMenu : public PreviewableContextualMenu<OvRendering::Resources::Model, OvCore::ResourceManagement::ModelManager>
+	class ModelContextualMenu : public PreviewableContextualMenu
 	{
 	public:
 		ModelContextualMenu(const std::string& p_filePath, bool p_protected = false) : PreviewableContextualMenu(p_filePath, p_protected) {}
@@ -740,7 +710,7 @@ namespace
 		}
 	};
 
-	class TextureContextualMenu : public PreviewableContextualMenu<OvRendering::Resources::Texture, OvCore::ResourceManagement::TextureManager>
+	class TextureContextualMenu : public PreviewableContextualMenu
 	{
 	public:
 		TextureContextualMenu(const std::string& p_filePath, bool p_protected = false) : PreviewableContextualMenu(p_filePath, p_protected) {}
@@ -783,7 +753,7 @@ namespace
 		}
 	};
 
-	class MaterialContextualMenu : public PreviewableContextualMenu<OvCore::Resources::Material, OvCore::ResourceManagement::MaterialManager>
+	class MaterialContextualMenu : public PreviewableContextualMenu
 	{
 	public:
 		MaterialContextualMenu(const std::string& p_filePath, bool p_protected = false) : PreviewableContextualMenu(p_filePath, p_protected) {}
@@ -794,13 +764,7 @@ namespace
 
 			editAction.ClickedEvent += [this]
 			{
-				auto material = OVSERVICE(OvCore::ResourceManagement::MaterialManager)[EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected))];
-
-				if (material)
-				{
-					OpenInAssetView(*material);
-					EDITOR_EXEC(DelayAction([material]() { OpenInMaterialEditor(*material); }));
-				}
+				OvCore::Helpers::GUIDrawer::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
 			};
 
 			auto& reload = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Reload");
@@ -1222,17 +1186,14 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 		if (fileType == OvTools::Utils::PathParser::EFileType::MODEL)
 		{
 			clickableText.DoubleClickedEvent += [&contextMenu, p_isEngineItem] {
-				auto& res = GetResource<OvCore::ResourceManagement::ModelManager>(contextMenu.filePath.string(), p_isEngineItem);
-				OpenInAssetView(res);
+				OvCore::Helpers::GUIDrawer::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
 			};
 		}
 
 		if (fileType == OvTools::Utils::PathParser::EFileType::MATERIAL)
 		{
 			clickableText.DoubleClickedEvent += [&contextMenu, p_isEngineItem] {
-				auto& res = GetResource<OvCore::ResourceManagement::MaterialManager>(contextMenu.filePath.string(), p_isEngineItem);
-				OpenInAssetView(res);
-				EDITOR_EXEC(DelayAction([&res]() { OpenInMaterialEditor(res); }));
+				OvCore::Helpers::GUIDrawer::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
 			};
 		}
 
@@ -1242,8 +1203,7 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 			texturePreview.SetPath(resourceFormatPath);
 
 			clickableText.DoubleClickedEvent += [&contextMenu, p_isEngineItem] {
-				auto& res = GetResource<OvCore::ResourceManagement::TextureManager>(contextMenu.filePath.string(), p_isEngineItem);
-				OpenInAssetView(res);
+				OvCore::Helpers::GUIDrawer::Open(EDITOR_EXEC(GetResourcePath(contextMenu.filePath.string(), p_isEngineItem)));
 			};
 		}
 

--- a/Sources/OvEditor/src/OvEditor/Panels/Inspector.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Inspector.cpp
@@ -237,8 +237,6 @@ void OvEditor::Panels::Inspector::_PopulateActorBehaviours()
 void OvEditor::Panels::Inspector::_DrawAddSection()
 {
 	auto& addButton = m_content->CreateWidget<Buttons::Button>("Add Component...", OvMaths::FVector2{ -1.f, 0 });
-	addButton.idleBackgroundColor = OvUI::Types::Color{ 0.7f, 0.5f, 0.f };
-	addButton.textColor = OvUI::Types::Color::White;
 
 	addButton.ClickedEvent += [this] {
 		if (!m_targetActor.has_value())

--- a/Sources/OvEditor/src/OvEditor/Panels/Inspector.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Inspector.cpp
@@ -317,6 +317,7 @@ void OvEditor::Panels::Inspector::_DrawComponent(AComponent& p_component)
 		p_component.owner.RemoveComponent(p_component);
 	};
 	auto& columns = header.CreateWidget<Layout::Columns<2>>();
+	columns.SetID("comp_" + p_component.GetName());
 	columns.widths[0] = 200;
 	p_component.OnInspector(columns);
 }
@@ -330,6 +331,7 @@ void OvEditor::Panels::Inspector::_DrawBehaviour(Behaviour& p_behaviour)
 	};
 
 	auto& columns = header.CreateWidget<Layout::Columns<2>>();
+	columns.SetID("bhv_" + p_behaviour.name);
 	columns.widths[0] = 200;
 	p_behaviour.OnInspector(columns);
 }

--- a/Sources/OvEditor/src/OvEditor/Panels/Inspector.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Inspector.cpp
@@ -211,26 +211,24 @@ void OvEditor::Panels::Inspector::_PopulateActorInfo()
 
 void OvEditor::Panels::Inspector::_PopulateActorComponents()
 {
-	for (auto component : m_targetActor->GetComponents() | std::views::reverse)
+	auto& components = m_targetActor->GetComponents();
+	const int total = static_cast<int>(components.size());
+	for (int i = 0; i < total; ++i)
 	{
-		_DrawComponent(*component);
+		_DrawComponent(*components[i], i, total);
 	}
 }
 
 void OvEditor::Panels::Inspector::_PopulateActorBehaviours()
 {
-	std::map<std::string, std::reference_wrapper<Behaviour>> behaviours;
-
-	// Sorts the behaviours alphabetically
-	for (auto& behaviour : m_targetActor->GetBehaviours() | std::views::values)
+	auto& order = m_targetActor->GetBehavioursOrder();
+	auto& behaviours = m_targetActor->GetBehaviours();
+	const int total = static_cast<int>(order.size());
+	for (int i = 0; i < total; ++i)
 	{
-		behaviours.emplace(behaviour.name, std::ref(behaviour));
-	}
-
-	// Iterate through the sorted behaviours
-	for (auto& behaviour : behaviours | std::views::values)
-	{
-		_DrawBehaviour(behaviour.get());
+		auto it = behaviours.find(order[i]);
+		if (it != behaviours.end())
+			_DrawBehaviour(it->second, i, total);
 	}
 }
 
@@ -307,25 +305,89 @@ void OvEditor::Panels::Inspector::_DrawAddSection()
 	};
 }
 
-void OvEditor::Panels::Inspector::_DrawComponent(AComponent& p_component)
+void OvEditor::Panels::Inspector::_DrawComponent(AComponent& p_component, int p_index, int p_total)
 {
 	auto& header = m_content->CreateWidget<Layout::GroupCollapsable>(p_component.GetName());
-	header.closable = !dynamic_cast<CTransform*>(&p_component);
+	const bool isTransform = dynamic_cast<CTransform*>(&p_component) != nullptr;
+	header.closable = !isTransform;
 	header.CloseEvent += [this, &header, &p_component] { 
 		p_component.owner.RemoveComponent(p_component);
 	};
+
+	if (!isTransform)
+	{
+		header.reorderable = true;
+		// CTransform is always at index 0; non-Transform components start at index 1
+		header.canMoveUp = (p_index > 1);
+		header.canMoveDown = (p_index < p_total - 1);
+
+		header.MoveUpEvent += [this, &p_component]
+		{
+			auto& components = p_component.owner.GetComponents();
+			auto it = std::find_if(components.begin(), components.end(),
+				[&](const auto& c) { return c.get() == &p_component; });
+			if (it != components.begin())
+			{
+				auto prev = std::prev(it);
+				if (!dynamic_cast<CTransform*>(prev->get()))
+					std::iter_swap(it, prev);
+			}
+			EDITOR_EXEC(DelayAction([this] { Refresh(); }));
+		};
+
+		header.MoveDownEvent += [this, &p_component]
+		{
+			auto& components = p_component.owner.GetComponents();
+			auto it = std::find_if(components.begin(), components.end(),
+				[&](const auto& c) { return c.get() == &p_component; });
+			if (it != components.end())
+			{
+				auto next = std::next(it);
+				if (next != components.end())
+					std::iter_swap(it, next);
+			}
+			EDITOR_EXEC(DelayAction([this] { Refresh(); }));
+		};
+	}
+
 	auto& columns = header.CreateWidget<Layout::Columns<2>>();
 	columns.SetID("comp_" + p_component.GetName());
 	columns.widths[0] = 200;
 	p_component.OnInspector(columns);
 }
 
-void OvEditor::Panels::Inspector::_DrawBehaviour(Behaviour& p_behaviour)
+void OvEditor::Panels::Inspector::_DrawBehaviour(Behaviour& p_behaviour, int p_index, int p_total)
 {
 	auto& header = m_content->CreateWidget<Layout::GroupCollapsable>(std::filesystem::path(p_behaviour.name).replace_extension().string());
 	header.closable = true;
 	header.CloseEvent += [&p_behaviour] {
 		p_behaviour.owner.RemoveBehaviour(p_behaviour);
+	};
+
+	header.reorderable = true;
+	header.canMoveUp = (p_index > 0);
+	header.canMoveDown = (p_index < p_total - 1);
+
+	header.MoveUpEvent += [this, &p_behaviour]
+	{
+		auto& order = p_behaviour.owner.GetBehavioursOrder();
+		auto it = std::find(order.begin(), order.end(), p_behaviour.name);
+		if (it != order.begin())
+			std::iter_swap(it, std::prev(it));
+		EDITOR_EXEC(DelayAction([this] { Refresh(); }));
+	};
+
+	header.MoveDownEvent += [this, &p_behaviour]
+	{
+		auto& order = p_behaviour.owner.GetBehavioursOrder();
+		auto it = std::find(order.begin(), order.end(), p_behaviour.name);
+		if (it != order.end())
+		{
+			auto next = std::next(it);
+			if (next != order.end())
+				std::iter_swap(it, next);
+		}
+		EDITOR_EXEC(DelayAction([this] { Refresh(); }));
 	};
 
 	auto& columns = header.CreateWidget<Layout::Columns<2>>();

--- a/Sources/OvEditor/src/OvEditor/Panels/Inspector.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Inspector.cpp
@@ -235,7 +235,6 @@ void OvEditor::Panels::Inspector::_PopulateActorBehaviours()
 void OvEditor::Panels::Inspector::_DrawAddSection()
 {
 	auto& addButton = m_content->CreateWidget<Buttons::Button>("Add Component...", OvMaths::FVector2{ -1.f, 0 });
-
 	addButton.ClickedEvent += [this] {
 		if (!m_targetActor.has_value())
 			return;
@@ -317,37 +316,23 @@ void OvEditor::Panels::Inspector::_DrawComponent(AComponent& p_component, int p_
 	if (!isTransform)
 	{
 		header.reorderable = true;
-		// CTransform is always at index 0; non-Transform components start at index 1
 		header.canMoveUp = (p_index > 1);
 		header.canMoveDown = (p_index < p_total - 1);
 
-		header.MoveUpEvent += [this, &p_component]
-		{
-			auto& components = p_component.owner.GetComponents();
-			auto it = std::find_if(components.begin(), components.end(),
-				[&](const auto& c) { return c.get() == &p_component; });
-			if (it != components.begin())
-			{
-				auto prev = std::prev(it);
-				if (!dynamic_cast<CTransform*>(prev->get()))
-					std::iter_swap(it, prev);
-			}
-			EDITOR_EXEC(DelayAction([this] { Refresh(); }));
-		};
-
-		header.MoveDownEvent += [this, &p_component]
-		{
-			auto& components = p_component.owner.GetComponents();
-			auto it = std::find_if(components.begin(), components.end(),
-				[&](const auto& c) { return c.get() == &p_component; });
-			if (it != components.end())
-			{
-				auto next = std::next(it);
-				if (next != components.end())
+		auto move = [this, &p_component](bool up) {
+			auto& comps = p_component.owner.GetComponents();
+			auto it = std::find_if(comps.begin(), comps.end(), [&](const auto& c) { return c.get() == &p_component; });
+			if (up) {
+				if (it != comps.begin() && !dynamic_cast<CTransform*>(std::prev(it)->get()))
+					std::iter_swap(it, std::prev(it));
+			} else {
+				if (auto next = std::next(it); next != comps.end())
 					std::iter_swap(it, next);
 			}
 			EDITOR_EXEC(DelayAction([this] { Refresh(); }));
 		};
+		header.MoveUpEvent += [move] { move(true); };
+		header.MoveDownEvent += [move] { move(false); };
 	}
 
 	auto& columns = header.CreateWidget<Layout::Columns<2>>();
@@ -368,27 +353,20 @@ void OvEditor::Panels::Inspector::_DrawBehaviour(Behaviour& p_behaviour, int p_i
 	header.canMoveUp = (p_index > 0);
 	header.canMoveDown = (p_index < p_total - 1);
 
-	header.MoveUpEvent += [this, &p_behaviour]
-	{
+	auto move = [this, &p_behaviour](bool up) {
 		auto& order = p_behaviour.owner.GetBehavioursOrder();
 		auto it = std::find(order.begin(), order.end(), p_behaviour.name);
-		if (it != order.begin())
-			std::iter_swap(it, std::prev(it));
-		EDITOR_EXEC(DelayAction([this] { Refresh(); }));
-	};
-
-	header.MoveDownEvent += [this, &p_behaviour]
-	{
-		auto& order = p_behaviour.owner.GetBehavioursOrder();
-		auto it = std::find(order.begin(), order.end(), p_behaviour.name);
-		if (it != order.end())
-		{
-			auto next = std::next(it);
-			if (next != order.end())
+		if (up) {
+			if (it != order.begin())
+				std::iter_swap(it, std::prev(it));
+		} else {
+			if (auto next = std::next(it); next != order.end())
 				std::iter_swap(it, next);
 		}
 		EDITOR_EXEC(DelayAction([this] { Refresh(); }));
 	};
+	header.MoveUpEvent += [move] { move(true); };
+	header.MoveDownEvent += [move] { move(false); };
 
 	auto& columns = header.CreateWidget<Layout::Columns<2>>();
 	columns.SetID("bhv_" + p_behaviour.name);

--- a/Sources/OvEditor/src/OvEditor/Panels/Inspector.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Inspector.cpp
@@ -25,6 +25,7 @@
 #include <OvCore/ECS/Components/CSpotLight.h>
 #include <OvCore/ECS/Components/CTransform.h>
 #include <OvCore/Helpers/GUIDrawer.h>
+#include <OvCore/Helpers/GUIHelpers.h>
 #include <OvEditor/Core/EditorActions.h>
 #include <OvEditor/Core/EditorResources.h>
 #include <OvEditor/Helpers/PickerHelpers.h>
@@ -241,7 +242,7 @@ void OvEditor::Panels::Inspector::_DrawAddSection()
 
 		const uint32_t componentIconID = EDITOR_CONTEXT(editorResources)->GetTexture("Component")->GetTexture().GetID();
 
-		OvCore::Helpers::GUIDrawer::PickerItemList items;
+		OvCore::Helpers::GUIHelpers::PickerItemList items;
 
 		for (const auto& info : componentRegistry)
 		{
@@ -300,7 +301,7 @@ void OvEditor::Panels::Inspector::_DrawAddSection()
 			true, false
 		);
 
-		OvCore::Helpers::GUIDrawer::OpenPicker(std::move(items), "Add Component");
+		OvCore::Helpers::GUIHelpers::OpenPicker(std::move(items), "Add Component");
 	};
 }
 

--- a/Sources/OvEditor/src/OvEditor/Panels/ItemPicker.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/ItemPicker.cpp
@@ -86,7 +86,7 @@ void ItemPicker::_Draw_Impl()
 	}
 }
 
-void ItemPicker::Open(OvCore::Helpers::GUIDrawer::PickerItemList p_items, std::string p_title)
+void ItemPicker::Open(OvCore::Helpers::GUIHelpers::PickerItemList p_items, std::string p_title)
 {
 	name = std::move(p_title);
 	m_items = std::move(p_items);

--- a/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -182,7 +182,7 @@ OvCore::Resources::Material * OvEditor::Panels::MaterialEditor::GetTarget() cons
 void OvEditor::Panels::MaterialEditor::RemoveTarget()
 {
 	m_target = nullptr;
-	m_targetMaterialText->content = "Empty";
+	m_targetMaterialText->content.clear();
 	OnMaterialDropped();
 }
 
@@ -214,7 +214,8 @@ void OvEditor::Panels::MaterialEditor::OnMaterialDropped()
 	if (m_settings->enabled)
 	{
 		GenerateMaterialSettingsContent();
-		m_shaderText->content = m_target->GetShader() ? m_target->GetShader()->path : "Empty";
+		const auto shader = m_target->GetShader();
+		m_shaderText->content = shader ? shader->path : std::string{};
 		m_shader = m_target->GetShader();
 	}
 	else

--- a/Sources/OvEditor/src/OvEditor/Panels/ProjectSettings.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/ProjectSettings.cpp
@@ -88,6 +88,6 @@ OvEditor::Panels::ProjectSettings::ProjectSettings(const std::string & p_title, 
 		auto& columns = gameRoot.CreateWidget<Layout::Columns<2>>();
 		columns.widths[0] = 125;
 
-		GUIDrawer::DrawDDString(columns, "Start scene", GenerateGatherer<std::string>("start_scene"), GenerateProvider<std::string>("start_scene"), "File");
+		GUIDrawer::DrawScene(columns, "Start scene", GenerateGatherer<std::string>("start_scene"), GenerateProvider<std::string>("start_scene"));
 	}
 }

--- a/Sources/OvTools/include/OvTools/Utils/PathParser.h
+++ b/Sources/OvTools/include/OvTools/Utils/PathParser.h
@@ -49,6 +49,14 @@ namespace OvTools::Utils
 		static std::string MakeNonWindowsStyle(const std::string& p_path);
 
 		/**
+		* Returns a human-friendly representation of a resource path.
+		* Backslashes are normalized to forward slashes.
+		* Engine paths (starting with ':') are displayed as {ENGINE}/rest/of/path.
+		* @param p_path
+		*/
+		static std::string GetFriendlyPath(const std::string& p_path);
+
+		/**
 		* Returns the containing folder of the file or folder identified by the given path
 		* @param p_path
 		*/

--- a/Sources/OvTools/src/OvTools/Utils/PathParser.cpp
+++ b/Sources/OvTools/src/OvTools/Utils/PathParser.cpp
@@ -30,6 +30,16 @@ std::string OvTools::Utils::PathParser::MakeNonWindowsStyle(const std::string & 
 	return result;
 }
 
+std::string OvTools::Utils::PathParser::GetFriendlyPath(const std::string& p_path)
+{
+	const std::string normalized = MakeNonWindowsStyle(p_path);
+
+	if (!normalized.empty() && normalized[0] == ':')
+		return "{ENGINE}/" + normalized.substr(1);
+
+	return normalized;
+}
+
 std::string OvTools::Utils::PathParser::GetContainingFolder(const std::string & p_path)
 {
 	std::string result;

--- a/Sources/OvUI/include/OvUI/Widgets/AWidget.h
+++ b/Sources/OvUI/include/OvUI/Widgets/AWidget.h
@@ -42,6 +42,14 @@ namespace OvUI::Widgets
 		void LinkTo(const AWidget& p_widget);
 
 		/**
+		* Override the auto-generated widget ID with a custom stable identifier.
+		* Useful to preserve ImGui state (e.g. table column widths) across widget
+		* rebuilds that would otherwise receive a new monotonic ID.
+		* @param p_id  Arbitrary unique string (will be prefixed with "##")
+		*/
+		void SetID(const std::string& p_id) { m_widgetID = "##" + p_id; }
+
+		/**
 		* Mark the widget as destroyed. It will be removed from the owner panel
 		* by the garbage collector
 		*/

--- a/Sources/OvUI/include/OvUI/Widgets/InputFields/AssetField.h
+++ b/Sources/OvUI/include/OvUI/Widgets/InputFields/AssetField.h
@@ -38,5 +38,6 @@ namespace OvUI::Widgets::InputFields
 		float previewSize = 64.0f;
 
 		OvTools::Eventing::Event<> ClickedEvent;
+		OvTools::Eventing::Event<> DoubleClickedEvent;
 	};
 }

--- a/Sources/OvUI/include/OvUI/Widgets/InputFields/AssetField.h
+++ b/Sources/OvUI/include/OvUI/Widgets/InputFields/AssetField.h
@@ -32,6 +32,11 @@ namespace OvUI::Widgets::InputFields
 	public:
 		std::string content;
 		uint32_t iconTextureID = 0;
+
+		/** When non-zero, a framed preview image is drawn above the input row. */
+		uint32_t previewTextureID = 0;
+		float previewSize = 64.0f;
+
 		OvTools::Eventing::Event<> ClickedEvent;
 	};
 }

--- a/Sources/OvUI/include/OvUI/Widgets/InputFields/AssetField.h
+++ b/Sources/OvUI/include/OvUI/Widgets/InputFields/AssetField.h
@@ -1,0 +1,36 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <string>
+
+#include <OvTools/Eventing/Event.h>
+#include <OvUI/Widgets/DataWidget.h>
+
+namespace OvUI::Widgets::InputFields
+{
+	/**
+	* Read-only input field that displays an asset path and includes an attached "..." picker button.
+	* Behaves like a text input (framed, drag-and-drop target) while the button opens the asset picker.
+	*/
+	class AssetField : public DataWidget<std::string>
+	{
+	public:
+		/**
+		* Constructor
+		* @param p_content  Initial content (asset path or empty string)
+		*/
+		AssetField(const std::string& p_content = "");
+
+	protected:
+		void _Draw_Impl() override;
+
+	public:
+		std::string content;
+		OvTools::Eventing::Event<> ClickedEvent;
+	};
+}

--- a/Sources/OvUI/include/OvUI/Widgets/InputFields/AssetField.h
+++ b/Sources/OvUI/include/OvUI/Widgets/InputFields/AssetField.h
@@ -31,6 +31,7 @@ namespace OvUI::Widgets::InputFields
 
 	public:
 		std::string content;
+		uint32_t iconTextureID = 0;
 		OvTools::Eventing::Event<> ClickedEvent;
 	};
 }

--- a/Sources/OvUI/include/OvUI/Widgets/Layout/Columns.h
+++ b/Sources/OvUI/include/OvUI/Widgets/Layout/Columns.h
@@ -69,6 +69,25 @@ namespace OvUI::Widgets::Layout
 					{
 						if (counter == 0)
 						{
+							// Skip the row entirely if all its widgets are disabled
+							bool allDisabled = true;
+							auto lookahead = it;
+							for (size_t k = 0; k < _Size && lookahead != p_end; ++k, ++lookahead)
+							{
+								if (lookahead->first->enabled)
+								{
+									allDisabled = false;
+									break;
+								}
+							}
+
+							if (allDisabled)
+							{
+								for (size_t k = 1; k < _Size && std::next(it) != p_end; ++k)
+									++it;
+								continue;
+							}
+
 							ImGui::TableNextRow();
 						}
 

--- a/Sources/OvUI/include/OvUI/Widgets/Layout/GroupCollapsable.h
+++ b/Sources/OvUI/include/OvUI/Widgets/Layout/GroupCollapsable.h
@@ -34,7 +34,12 @@ namespace OvUI::Widgets::Layout
 		bool closable = false;
 		bool opened = true;
 		bool collapsed = false;
+		bool reorderable = false;
+		bool canMoveUp = true;
+		bool canMoveDown = true;
 		OvTools::Eventing::Event<> CloseEvent;
 		OvTools::Eventing::Event<> OpenEvent;
+		OvTools::Eventing::Event<> MoveUpEvent;
+		OvTools::Eventing::Event<> MoveDownEvent;
 	};
 }

--- a/Sources/OvUI/include/OvUI/Widgets/Layout/GroupCollapsable.h
+++ b/Sources/OvUI/include/OvUI/Widgets/Layout/GroupCollapsable.h
@@ -33,7 +33,6 @@ namespace OvUI::Widgets::Layout
 		std::string name;
 		bool closable = false;
 		bool opened = true;
-		bool collapsed = false;
 		bool reorderable = false;
 		bool canMoveUp = true;
 		bool canMoveDown = true;

--- a/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
@@ -4,7 +4,6 @@
 * @licence: MIT
 */
 
-#include <algorithm>
 #include <filesystem>
 #include <string>
 
@@ -60,6 +59,27 @@ void OvUI::Widgets::InputFields::AssetField::_Draw_Impl()
 
 	if (clicked)
 		ClickedEvent.Invoke();
+
+	if (previewTextureID != 0)
+	{
+		// Tighten the gap between the field row and preview to match frame inner padding.
+		const float gap = ImGui::GetStyle().FramePadding.y;
+		ImGui::SetCursorPosY(ImGui::GetCursorPosY() - ImGui::GetStyle().ItemSpacing.y + gap);
+
+		ImVec2 imgMin = ImGui::GetCursorScreenPos();
+		ImGui::Image(
+			(ImTextureID)(uintptr_t)previewTextureID,
+			ImVec2(previewSize, previewSize),
+			ImVec2(0.f, 1.f), ImVec2(1.f, 0.f)
+		);
+		ImGui::GetWindowDrawList()->AddRect(
+			imgMin,
+			ImVec2(imgMin.x + previewSize, imgMin.y + previewSize),
+			ImGui::GetColorU32(ImGuiCol_Border)
+		);
+		if (ImGui::IsItemClicked())
+			ClickedEvent.Invoke();
+	}
 
 	ImGui::EndGroup();
 }

--- a/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
@@ -16,6 +16,7 @@ OvUI::Widgets::InputFields::AssetField::AssetField(const std::string& p_content)
 void OvUI::Widgets::InputFields::AssetField::_Draw_Impl()
 {
 	const float buttonSize = ImGui::GetFrameHeight();
+	const float innerSize = buttonSize - 2.0f * ImGui::GetStyle().FramePadding.x;
 
 	ImGui::BeginGroup();
 
@@ -29,7 +30,21 @@ void OvUI::Widgets::InputFields::AssetField::_Draw_Impl()
 
 	ImGui::SameLine(0, 0);
 
-	if (ImGui::Button(("..." + m_widgetID).c_str(), ImVec2(buttonSize, buttonSize)))
+	bool clicked;
+	if (iconTextureID != 0)
+	{
+		clicked = ImGui::ImageButton(
+			("icon" + m_widgetID).c_str(),
+			(ImTextureID)(uintptr_t)iconTextureID,
+			ImVec2(innerSize, innerSize)
+		);
+	}
+	else
+	{
+		clicked = ImGui::Button(("..." + m_widgetID).c_str(), ImVec2(buttonSize, buttonSize));
+	}
+
+	if (clicked)
 		ClickedEvent.Invoke();
 
 	ImGui::EndGroup();

--- a/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
@@ -39,6 +39,9 @@ void OvUI::Widgets::InputFields::AssetField::_Draw_Impl()
 	if (!tooltip.empty() && ImGui::IsItemHovered(ImGuiHoveredFlags_ForTooltip))
 		ImGui::SetTooltip("%s", tooltip.c_str());
 
+	if (!content.empty() && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled) && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
+		DoubleClickedEvent.Invoke();
+
 	ImGui::SameLine(0, 0);
 
 	bool clicked;

--- a/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
@@ -4,6 +4,9 @@
 * @licence: MIT
 */
 
+#include <algorithm>
+#include <string>
+
 #include <imgui.h>
 
 #include <OvUI/Widgets/InputFields/AssetField.h>
@@ -18,15 +21,38 @@ void OvUI::Widgets::InputFields::AssetField::_Draw_Impl()
 	const float buttonSize = ImGui::GetFrameHeight();
 	const float innerSize = buttonSize - 2.0f * ImGui::GetStyle().FramePadding.x;
 
+	// Normalize to forward slashes
+	std::string normalized = content;
+	std::replace(normalized.begin(), normalized.end(), '\\', '/');
+
+	// Extract filename for display
+	std::string displayName = normalized;
+	const auto lastSlash = normalized.rfind('/');
+	if (lastSlash != std::string::npos)
+		displayName = normalized.substr(lastSlash + 1);
+
+	// Build tooltip: replace leading ':' with {engine}/ or prepend {project}/
+	std::string tooltip;
+	if (!content.empty() && content != "Empty")
+	{
+		if (content[0] == ':')
+			tooltip = "{engine}/" + normalized.substr(1);
+		else
+			tooltip = "{project}/" + normalized;
+	}
+
 	ImGui::BeginGroup();
 
 	ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - buttonSize);
 
 	char buf[512] = {};
-	content.copy(buf, sizeof(buf) - 1);
+	displayName.copy(buf, sizeof(buf) - 1);
 	ImGui::BeginDisabled();
 	ImGui::InputText((m_widgetID + "i").c_str(), buf, sizeof(buf), ImGuiInputTextFlags_ReadOnly);
 	ImGui::EndDisabled();
+
+	if (!tooltip.empty() && ImGui::IsItemHovered(ImGuiHoveredFlags_ForTooltip))
+		ImGui::SetTooltip("%s", tooltip.c_str());
 
 	ImGui::SameLine(0, 0);
 

--- a/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
@@ -6,7 +6,7 @@
 
 #include <imgui.h>
 
-#include "OvUI/Widgets/InputFields/AssetField.h"
+#include <OvUI/Widgets/InputFields/AssetField.h>
 
 OvUI::Widgets::InputFields::AssetField::AssetField(const std::string& p_content)
 	: DataWidget<std::string>(content), content(p_content)
@@ -23,7 +23,9 @@ void OvUI::Widgets::InputFields::AssetField::_Draw_Impl()
 
 	char buf[512] = {};
 	strncpy(buf, content.c_str(), sizeof(buf) - 1);
+	ImGui::BeginDisabled();
 	ImGui::InputText((m_widgetID + "i").c_str(), buf, sizeof(buf), ImGuiInputTextFlags_ReadOnly);
+	ImGui::EndDisabled();
 
 	ImGui::SameLine(0, 0);
 

--- a/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
@@ -1,0 +1,34 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <imgui.h>
+
+#include "OvUI/Widgets/InputFields/AssetField.h"
+
+OvUI::Widgets::InputFields::AssetField::AssetField(const std::string& p_content)
+	: DataWidget<std::string>(content), content(p_content)
+{
+}
+
+void OvUI::Widgets::InputFields::AssetField::_Draw_Impl()
+{
+	const float buttonSize = ImGui::GetFrameHeight();
+
+	ImGui::BeginGroup();
+
+	ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - buttonSize);
+
+	char buf[512] = {};
+	strncpy(buf, content.c_str(), sizeof(buf) - 1);
+	ImGui::InputText((m_widgetID + "i").c_str(), buf, sizeof(buf), ImGuiInputTextFlags_ReadOnly);
+
+	ImGui::SameLine(0, 0);
+
+	if (ImGui::Button(("..." + m_widgetID).c_str(), ImVec2(buttonSize, buttonSize)))
+		ClickedEvent.Invoke();
+
+	ImGui::EndGroup();
+}

--- a/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
@@ -5,10 +5,12 @@
 */
 
 #include <algorithm>
+#include <filesystem>
 #include <string>
 
 #include <imgui.h>
 
+#include <OvTools/Utils/PathParser.h>
 #include <OvUI/Widgets/InputFields/AssetField.h>
 
 OvUI::Widgets::InputFields::AssetField::AssetField(const std::string& p_content)
@@ -21,25 +23,16 @@ void OvUI::Widgets::InputFields::AssetField::_Draw_Impl()
 	const float buttonSize = ImGui::GetFrameHeight();
 	const float innerSize = buttonSize - 2.0f * ImGui::GetStyle().FramePadding.x;
 
-	// Normalize to forward slashes
-	std::string normalized = content;
-	std::replace(normalized.begin(), normalized.end(), '\\', '/');
+	std::filesystem::path assetPath{
+		OvTools::Utils::PathParser::MakeNonWindowsStyle(content)
+	};
 
-	// Extract filename for display
-	std::string displayName = normalized;
-	const auto lastSlash = normalized.rfind('/');
-	if (lastSlash != std::string::npos)
-		displayName = normalized.substr(lastSlash + 1);
+	std::string displayName = assetPath.empty() ? "None" : assetPath.stem();
 
-	// Build tooltip: replace leading ':' with {engine}/ or prepend {project}/
-	std::string tooltip;
-	if (!content.empty() && content != "Empty")
-	{
-		if (content[0] == ':')
-			tooltip = "{engine}/" + normalized.substr(1);
-		else
-			tooltip = "{project}/" + normalized;
-	}
+	std::string tooltip =
+		content.starts_with(':') ?
+		"{ENGINE}/" + assetPath.string().substr(1) :
+		assetPath.string();
 
 	ImGui::BeginGroup();
 

--- a/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
@@ -23,16 +23,9 @@ void OvUI::Widgets::InputFields::AssetField::_Draw_Impl()
 	const float buttonSize = ImGui::GetFrameHeight();
 	const float innerSize = buttonSize - 2.0f * ImGui::GetStyle().FramePadding.x;
 
-	std::filesystem::path assetPath{
-		OvTools::Utils::PathParser::MakeNonWindowsStyle(content)
-	};
-
-	std::string displayName = assetPath.empty() ? "None" : assetPath.stem();
-
-	std::string tooltip =
-		content.starts_with(':') ?
-		"{ENGINE}/" + assetPath.string().substr(1) :
-		assetPath.string();
+	const std::string friendly = OvTools::Utils::PathParser::GetFriendlyPath(content);
+	const std::string displayName = friendly.empty() ? "None" : std::filesystem::path(friendly).stem().string();
+	const std::string tooltip = friendly;
 
 	ImGui::BeginGroup();
 

--- a/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
@@ -48,7 +48,9 @@ void OvUI::Widgets::InputFields::AssetField::_Draw_Impl()
 		clicked = ImGui::ImageButton(
 			("icon" + m_widgetID).c_str(),
 			(ImTextureID)(uintptr_t)iconTextureID,
-			ImVec2(innerSize, innerSize)
+			ImVec2(innerSize, innerSize),
+			ImVec2(0.f, 1.f),
+			ImVec2(1.f, 0.f)
 		);
 	}
 	else

--- a/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/InputFields/AssetField.cpp
@@ -23,7 +23,7 @@ void OvUI::Widgets::InputFields::AssetField::_Draw_Impl()
 	ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - buttonSize);
 
 	char buf[512] = {};
-	strncpy(buf, content.c_str(), sizeof(buf) - 1);
+	content.copy(buf, sizeof(buf) - 1);
 	ImGui::BeginDisabled();
 	ImGui::InputText((m_widgetID + "i").c_str(), buf, sizeof(buf), ImGuiInputTextFlags_ReadOnly);
 	ImGui::EndDisabled();

--- a/Sources/OvUI/src/OvUI/Widgets/Layout/GroupCollapsable.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/Layout/GroupCollapsable.cpp
@@ -20,7 +20,41 @@ void OvUI::Widgets::Layout::GroupCollapsable::_Draw_Impl()
 
 	ImGui::SetNextItemOpen(!collapsed);
 
-	if (ImGui::CollapsingHeader(name.c_str(), closable ? &opened : nullptr))
+	bool isOpen = ImGui::CollapsingHeader(name.c_str(), closable ? &opened : nullptr);
+
+	if (reorderable)
+	{
+		const ImVec2 headerMin = ImGui::GetItemRectMin();
+		const ImVec2 headerMax = ImGui::GetItemRectMax();
+		const float bSize = headerMax.y - headerMin.y;
+		const float rightEdge = closable ? (headerMax.x - bSize) : headerMax.x;
+		const ImVec2 savedCursor = ImGui::GetCursorPos();
+
+		// Keep original vertical padding so arrow buttons fill the header height exactly
+		const float padY = ImGui::GetStyle().FramePadding.y;
+		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2{0, padY});
+		ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0, 0, 0, 0});
+		ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImGui::GetStyleColorVec4(ImGuiCol_HeaderHovered));
+		ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImGui::GetStyleColorVec4(ImGuiCol_HeaderActive));
+
+		ImGui::SetCursorScreenPos({rightEdge - bSize * 2.0f, headerMin.y});
+		if (!canMoveUp) ImGui::BeginDisabled();
+		if (ImGui::ArrowButton(("##mu" + m_widgetID).c_str(), ImGuiDir_Up))
+			MoveUpEvent.Invoke();
+		if (!canMoveUp) ImGui::EndDisabled();
+
+		ImGui::SetCursorScreenPos({rightEdge - bSize, headerMin.y});
+		if (!canMoveDown) ImGui::BeginDisabled();
+		if (ImGui::ArrowButton(("##md" + m_widgetID).c_str(), ImGuiDir_Down))
+			MoveDownEvent.Invoke();
+		if (!canMoveDown) ImGui::EndDisabled();
+
+		ImGui::PopStyleColor(3);
+		ImGui::PopStyleVar();
+		ImGui::SetCursorPos(savedCursor);
+	}
+
+	if (isOpen)
 		Group::_Draw_Impl();
 
 	collapsed = !ImGui::TreeNodeUpdateNextOpen(ImGui::GetID(name.c_str()), ImGuiTreeNodeFlags_None);

--- a/Sources/OvUI/src/OvUI/Widgets/Layout/GroupCollapsable.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/Layout/GroupCollapsable.cpp
@@ -18,9 +18,7 @@ void OvUI::Widgets::Layout::GroupCollapsable::_Draw_Impl()
 {
 	bool previouslyOpened = opened;
 
-	ImGui::SetNextItemOpen(!collapsed);
-
-	bool isOpen = ImGui::CollapsingHeader(name.c_str(), closable ? &opened : nullptr);
+	bool isOpen = ImGui::CollapsingHeader(name.c_str(), closable ? &opened : nullptr, ImGuiTreeNodeFlags_DefaultOpen);
 
 	if (reorderable)
 	{
@@ -56,8 +54,6 @@ void OvUI::Widgets::Layout::GroupCollapsable::_Draw_Impl()
 
 	if (isOpen)
 		Group::_Draw_Impl();
-
-	collapsed = !ImGui::TreeNodeUpdateNextOpen(ImGui::GetID(name.c_str()), ImGuiTreeNodeFlags_None);
 
 	if (opened != previouslyOpened)
 	{


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
- Inspector elements now keep the same column size consistently based on component type
- Changed "Add Component..." button style to default
- Table rows with only disabled widgets are now properly skipped
- Introduced `AssetField`
- Now using asset icons instead of "..."
- No more "Empty" string in asset fields
- Textures now also use `AssetField`, which also supports previews (so technically any asset type can display a preview)
- Components & behaviours can now be moved up and down in the inspector (re-ordered)

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #(issue number)

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

<img width="457" height="133" alt="image" src="https://github.com/user-attachments/assets/7195bef5-bcc1-40da-864b-d5dac3441799" />

_"Add Component..." button doesn't visually yell anymore_

<img width="460" height="99" alt="image" src="https://github.com/user-attachments/assets/99309048-cd6b-41fa-9cea-75869b1ac298" />

_Introduced `AssetField`, for a nicer looking input field for assets_

<img width="438" height="424" alt="image" src="https://github.com/user-attachments/assets/f21bc84a-8c97-4d5a-a4fb-4dcd3051f0d1" />

_`AssetField` is also used by the textures_

<img width="456" height="580" alt="image" src="https://github.com/user-attachments/assets/165d8ada-b559-4c63-92e7-3a6a6b96dfa1" />

_Components can now be re-ordered (moved up and down)_

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
