### PR TITLE
Fix asset browser "Open" action to use OS default app again

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -525,7 +525,7 @@ namespace
 			auto& editAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Open");
 
 			editAction.ClickedEvent += [this] {
-				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
+				OvTools::Utils::SystemCalls::OpenFile(filePath.string());
 			};
 
 			auto& openInCodeEditor = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Open in code editor");


### PR DESCRIPTION
## Description
Restores the previous behavior of the Asset Browser "Open" contextual action.

After #686, "Open" for previewable assets (like textures/models) started going through the internal preview flow.
This change makes "Open" use the OS default application again, while keeping "Preview" unchanged for in-editor preview.

Scope is intentionally minimal:
- 1-line change in `AssetBrowser.cpp`
- no refactor
- no API changes
- no behavior change outside the "Open" contextual action

## Related Issue(s)
Fixes #693

## Review Guidance
Please focus on `FileContextualMenu::CreateList()` in `Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp`.

Changed behavior:
- "Open" now calls `OvTools::Utils::SystemCalls::OpenFile(filePath.string())`
- "Preview" still uses internal `GUIHelpers::Open(...)`

Expected result:
- Right-click texture/model -> "Open" launches default external software
- "Preview" still opens the in-editor preview flow

## Screenshots/GIFs
N/A (behavioral fix, no UI layout change)

## Checklist
- [x] My code follows the project's code style guidelines
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
