### PR TITLE
Fix self-drop behavior in hierarchy and asset browser drag-and-drop

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -966,6 +966,12 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 				const std::filesystem::path correctPath = m_pathUpdate.find(&treeNode) != m_pathUpdate.end() ? m_pathUpdate.at(&treeNode) : std::filesystem::path(path);
 				const std::filesystem::path newPath = correctPath / folderName;
 
+				std::error_code equivalenceError;
+				if (std::filesystem::equivalent(folderReceivedPath, correctPath, equivalenceError))
+				{
+					return;
+				}
+
 				if (!std::filesystem::exists(newPath))
 				{
 					const bool isEngineFolder = !p_data.first.empty() && p_data.first[0] == ':';							// Copy dd folder from Engine resources

--- a/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -350,6 +350,11 @@ void OvEditor::Panels::Hierarchy::AddActorByInstance(OvCore::ECS::Actor & p_acto
 	textSelectable.AddPlugin<OvUI::Plugins::DDSource<std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*>>>("Actor", "Attach to...", std::make_pair(&p_actor, &textSelectable));
 	textSelectable.AddPlugin<OvUI::Plugins::DDTarget<std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*>>>("Actor").DataReceivedEvent += [&p_actor, &textSelectable](std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*> p_element)
 	{
+		if (&p_actor == p_element.first)
+		{
+			return;
+		}
+
 		if (p_actor.IsDescendantOf(p_element.first))
 		{
 			OVLOG_WARNING("Cannot attach \"" + p_element.first->GetName() + "\" to \"" + p_actor.GetName() + "\" because it is a descendant of the latter.");

--- a/Sources/OvUI/include/OvUI/Plugins/DDTarget.h
+++ b/Sources/OvUI/include/OvUI/Plugins/DDTarget.h
@@ -37,13 +37,26 @@ namespace OvUI::Plugins
 		*/
 		virtual void Execute(EPluginExecutionContext p_context) override
 		{
-			const bool result =
-				p_context == EPluginExecutionContext::WIDGET ?
-				ImGui::BeginDragDropTarget() :
-				ImGui::BeginDragDropTargetCustom(
+			bool result = false;
+
+			if (p_context == EPluginExecutionContext::WIDGET)
+			{
+				const ImGuiID itemID = ImGui::GetItemID();
+				const ImGuiID targetSeed = itemID != 0 ? itemID : ImGui::GetID(this);
+				const ImGuiID targetID = ImHashStr(identifier.c_str(), 0, targetSeed);
+
+				result = ImGui::BeginDragDropTargetCustom(
+					ImRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax()),
+					targetID
+				);
+			}
+			else
+			{
+				result = ImGui::BeginDragDropTargetCustom(
 					ImGui::GetCurrentWindow()->WorkRect,
 					ImGui::GetID(identifier.c_str())
 				);
+			}
 
 			if (result)
 			{


### PR DESCRIPTION
## Description
This PR fixes drag-and-drop self-target behavior in editor panels.

Changes:
- Updated `DDTarget` widget execution path to use a dedicated target ID (based on item ID + payload identifier), so a drag source can correctly target its own widget drop zone.
- Added a hierarchy guard to treat actor self-drop as a no-op (instead of reattaching to root through the window target).
- Added an asset browser guard to treat folder self-drop as a no-op.

The goal is to keep existing behavior unchanged for valid drag-and-drop actions while preventing unintended reparent/move operations in self-drop scenarios.

## Related Issue(s)
Fixes #480

## Review Guidance
Please validate the following cases in the editor:
1. Drag an actor onto itself in Hierarchy: it should do nothing.
2. Drag an actor onto another actor in Hierarchy: parenting should still work.
3. Drag an actor onto empty Hierarchy area: detach to root behavior should remain unchanged.
4. Drag a folder onto itself in Asset Browser: it should do nothing.
5. Drag folders/files to other valid targets: existing behavior should remain unchanged.

## Screenshots/GIFs
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
