### PR TITLE
Fix hierarchy child gray-out when parent actor is disabled

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -363,7 +363,7 @@ void OvEditor::Panels::Hierarchy::AddActorByInstance(OvCore::ECS::Actor & p_acto
 	OvCore::ECS::Actor* targetPtr = &p_actor;
 	dispatcher.RegisterGatherer([targetPtr, &textSelectable]
 	{
-		const bool isActive = targetPtr->IsSelfActive();
+		const bool isActive = targetPtr->IsActive();
 		textSelectable.overrideLabelColor = !isActive;
 		if (!isActive)
 			textSelectable.labelColor = {0.5f, 0.5f, 0.5f, 1.0f};


### PR DESCRIPTION
## Description
This PR fixes the hierarchy visual state for child actors when their parent is disabled.

In `Hierarchy::AddActorByInstance`, the active-state check used for label coloring now relies on hierarchical activity:
- replaced `IsSelfActive()` with `IsActive()`

This ensures children are grayed out when any parent in their hierarchy is disabled, matching expected editor behavior.

## Related Issue(s)
Fixes #697

## Review Guidance
Please validate in the Editor Hierarchy panel:
1. Create a parent actor with at least one child actor.
2. Disable the parent actor.
3. Confirm that both the parent and its children are grayed out.
4. Re-enable the parent and confirm children return to normal color.

Scope is intentionally minimal: one functional line change in hierarchy label state evaluation.

## Screenshots/GIFs
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
