### PR TITLE
Prevent crash when dragging a folder into its own child

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -130,27 +130,8 @@ namespace
 
 	bool IsPathSameOrDescendant(const std::filesystem::path& p_path, const std::filesystem::path& p_ancestor)
 	{
-		const std::filesystem::path ancestor = p_ancestor.lexically_normal();
-		std::filesystem::path current = p_path.lexically_normal();
-
-		while (!current.empty())
-		{
-			if (current == ancestor)
-			{
-				return true;
-			}
-
-			const std::filesystem::path parent = current.parent_path();
-
-			if (parent == current)
-			{
-				break;
-			}
-
-			current = parent;
-		}
-
-		return false;
+		const std::filesystem::path relativePath = p_path.lexically_normal().lexically_relative(p_ancestor.lexically_normal());
+		return !relativePath.empty() && *relativePath.begin() != "..";
 	}
 
 	class TexturePreview : public OvUI::Plugins::IPlugin

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -128,6 +128,31 @@ namespace
 		return p_path;
 	}
 
+	bool IsPathSameOrDescendant(const std::filesystem::path& p_path, const std::filesystem::path& p_ancestor)
+	{
+		const std::filesystem::path ancestor = p_ancestor.lexically_normal();
+		std::filesystem::path current = p_path.lexically_normal();
+
+		while (!current.empty())
+		{
+			if (current == ancestor)
+			{
+				return true;
+			}
+
+			const std::filesystem::path parent = current.parent_path();
+
+			if (parent == current)
+			{
+				break;
+			}
+
+			current = parent;
+		}
+
+		return false;
+	}
+
 	class TexturePreview : public OvUI::Plugins::IPlugin
 	{
 	private:
@@ -965,6 +990,18 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 				const std::filesystem::path prevPath = folderReceivedPath;
 				const std::filesystem::path correctPath = m_pathUpdate.find(&treeNode) != m_pathUpdate.end() ? m_pathUpdate.at(&treeNode) : std::filesystem::path(path);
 				const std::filesystem::path newPath = correctPath / folderName;
+
+				if (IsPathSameOrDescendant(correctPath, prevPath))
+				{
+					OVLOG_WARNING(
+						std::format(
+							"Cannot move folder \"{}\" to \"{}\" because the destination is inside the source folder.",
+							prevPath.string(),
+							correctPath.string()
+						)
+					);
+					return;
+				}
 
 				if (!std::filesystem::exists(newPath))
 				{


### PR DESCRIPTION
## Description
This PR fixes a crash in the Asset Browser when a folder is dragged and dropped into one of its own descendants.

The fix adds a local guard in the folder drag-and-drop handler to detect invalid parent->child (or self) moves before filesystem rename/copy operations are executed.  
When such a move is detected, the operation is safely ignored and a warning is logged.

## Related Issue(s)
Fixes #699

## Review Guidance
Please focus review on:
- Folder DDTarget logic in `AssetBrowser.cpp`
- The new path ancestry guard used before move/copy operations
- Regression risk on valid drag/drop scenarios (project/project and engine/project)

## Screenshots/GIFs
N/A (behavioral crash fix; no UI change)

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
