### PR TITLE
Asset browser actions improvements

### DIFF
--- a/Sources/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -266,8 +266,12 @@ namespace OvEditor::Core
 		* Open the given path in the code editor.
 		* Returns true if the operation was successful
 		* @param p_path
+		* @param p_workdir (optional) working directory
 		*/
-		bool OpenInCodeEditor(const std::filesystem::path& p_path);
+		bool OpenInCodeEditor(
+			const std::filesystem::path& p_path,
+			OvTools::Utils::OptRef<const std::filesystem::path> p_workdir = std::nullopt
+		);
 
 		/**
 		* Import an asset

--- a/Sources/OvEditor/include/OvEditor/Settings/EditorSettings.h
+++ b/Sources/OvEditor/include/OvEditor/Settings/EditorSettings.h
@@ -100,7 +100,7 @@ namespace OvEditor::Settings
 		inline static Property<int> ColorTheme = { static_cast<int>(OvUI::Styling::EStyle::DEFAULT_DARK) };
 		inline static Property<int> ConsoleMaxLogs = { 500 };
 		inline static Property<int> FontSize = { static_cast<int>(EFontSize::DEFAULT) };
-		inline static Property<std::string> CodeEditorCommand = { "code {path}" };
+		inline static Property<std::string> CodeEditorCommand = { "code {workdir} --goto {path}" };
 		inline static Property<bool> RegenerateScriptingProjectFilesOnStartup = { true };
 	};
 }

--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -121,7 +121,7 @@ void OvEditor::Core::Editor::SetupUI()
 			{
 				EDITOR_EXEC(LoadSceneFromDisk(path));
 			}
-			else if (fileType == EFileType::SCRIPT)
+			else if (fileType == EFileType::SCRIPT || fileType == EFileType::SHADER || fileType == EFileType::SHADER_PART)
 			{
 				EDITOR_EXEC(OpenInCodeEditor(m_editorActions.GetRealPath(path)));
 			}

--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -127,7 +127,7 @@ void OvEditor::Core::Editor::SetupUI()
 			}
 			else
 			{
-				// SHADER, SHADER_PART, SOUND, FONT, UNKNOWN → open with OS default
+				// SOUND, FONT, UNKNOWN → open with OS default
 				OvTools::Utils::SystemCalls::OpenFile(EDITOR_EXEC(GetRealPath(path)));
 			}
 		}

--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -4,6 +4,7 @@
 * @licence: MIT
 */
 
+#include "OvEditor/Core/EditorActions.h"
 #include <tracy/Tracy.hpp>
 
 #include <OvCore/Helpers/GUIDrawer.h>
@@ -120,9 +121,13 @@ void OvEditor::Core::Editor::SetupUI()
 			{
 				EDITOR_EXEC(LoadSceneFromDisk(path));
 			}
+			else if (fileType == EFileType::SCRIPT)
+			{
+				EDITOR_EXEC(OpenInCodeEditor(m_editorActions.GetRealPath(path)));
+			}
 			else
 			{
-				// SHADER, SHADER_PART, SCRIPT, SOUND, FONT, UNKNOWN → open with OS default
+				// SHADER, SHADER_PART, SOUND, FONT, UNKNOWN → open with OS default
 				OvTools::Utils::SystemCalls::OpenFile(EDITOR_EXEC(GetRealPath(path)));
 			}
 		}

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -770,6 +770,7 @@ bool OvEditor::Core::EditorActions::OpenInCodeEditor(const std::filesystem::path
 			return false;
 		}
 
+		OvTools::Utils::String::ReplaceAll(command, "{workdir}", m_context.projectFolder);
 		OvTools::Utils::String::ReplaceAll(command, "{path}", p_path.string());
 		if (!OvTools::Utils::SystemCalls::ExecuteCommand(command))
 		{

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -4,6 +4,7 @@
 * @licence: MIT
 */
 
+#include "OvTools/Utils/OptRef.h"
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -756,7 +757,7 @@ void OvEditor::Core::EditorActions::RegenerateScriptingProjectFiles()
 	}
 }
 
-bool OvEditor::Core::EditorActions::OpenInCodeEditor(const std::filesystem::path& p_path)
+bool OvEditor::Core::EditorActions::OpenInCodeEditor(const std::filesystem::path& p_path, OvTools::Utils::OptRef<const std::filesystem::path> p_workdir)
 {
 	std::string command = OvEditor::Settings::EditorSettings::CodeEditorCommand.Get();
 	if (!command.empty())
@@ -770,7 +771,7 @@ bool OvEditor::Core::EditorActions::OpenInCodeEditor(const std::filesystem::path
 			return false;
 		}
 
-		OvTools::Utils::String::ReplaceAll(command, "{workdir}", m_context.projectFolder);
+		OvTools::Utils::String::ReplaceAll(command, "{workdir}", p_workdir ? p_workdir->string() : m_context.projectFolder.string());
 		OvTools::Utils::String::ReplaceAll(command, "{path}", p_path.string());
 		if (!OvTools::Utils::SystemCalls::ExecuteCommand(command))
 		{

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -528,10 +528,16 @@ namespace
 
 		virtual void CreateList() override
 		{
-			auto& editAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Open");
+			auto& openAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Open");
 
-			editAction.ClickedEvent += [this] {
+			openAction.ClickedEvent += [this] {
 				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
+			};
+
+			auto& openExternallyAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Open Externally...");
+
+			openExternallyAction.ClickedEvent += [this] {
+				OvTools::Utils::SystemCalls::OpenFile(filePath.string());
 			};
 
 			auto& openInCodeEditor = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Open in code editor");
@@ -588,23 +594,6 @@ namespace
 		OvTools::Eventing::Event<std::filesystem::path> DuplicateEvent;
 	};
 
-	class PreviewableContextualMenu : public FileContextualMenu
-	{
-	public:
-		PreviewableContextualMenu(const std::string& p_filePath, bool p_protected = false) : FileContextualMenu(p_filePath, p_protected) {}
-
-		virtual void CreateList() override
-		{
-			auto& previewAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Preview");
-
-			previewAction.ClickedEvent += [this] {
-				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
-			};
-
-			FileContextualMenu::CreateList();
-		}
-	};
-
 	class ShaderContextualMenu : public FileContextualMenu
 	{
 	public:
@@ -641,16 +630,10 @@ namespace
 		}
 	};
 
-	class ShaderPartContextualMenu : public FileContextualMenu
+	class ModelContextualMenu : public FileContextualMenu
 	{
 	public:
-		ShaderPartContextualMenu(const std::string& p_filePath, bool p_protected = false) : FileContextualMenu(p_filePath, p_protected) {}
-	};
-
-	class ModelContextualMenu : public PreviewableContextualMenu
-	{
-	public:
-		ModelContextualMenu(const std::string& p_filePath, bool p_protected = false) : PreviewableContextualMenu(p_filePath, p_protected) {}
+		ModelContextualMenu(const std::string& p_filePath, bool p_protected = false) : FileContextualMenu(p_filePath, p_protected) {}
 
 		void CreateMaterialFiles(const std::string_view shaderType)
 		{
@@ -713,14 +696,14 @@ namespace
 				CreateMaterialCreationOption(generateMaterialsMenu, "Unlit");
 			}
 
-			PreviewableContextualMenu::CreateList();
+			FileContextualMenu::CreateList();
 		}
 	};
 
-	class TextureContextualMenu : public PreviewableContextualMenu
+	class TextureContextualMenu : public FileContextualMenu
 	{
 	public:
-		TextureContextualMenu(const std::string& p_filePath, bool p_protected = false) : PreviewableContextualMenu(p_filePath, p_protected) {}
+		TextureContextualMenu(const std::string& p_filePath, bool p_protected = false) : FileContextualMenu(p_filePath, p_protected) {}
 
 		virtual void CreateList() override
 		{
@@ -738,42 +721,17 @@ namespace
 				}
 			};
 
-			PreviewableContextualMenu::CreateList();
-		}
-	};
-
-	class SceneContextualMenu : public FileContextualMenu
-	{
-	public:
-		SceneContextualMenu(const std::string& p_filePath, bool p_protected = false) : FileContextualMenu(p_filePath, p_protected) {}
-
-		virtual void CreateList() override
-		{
-			auto& editAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Edit");
-
-			editAction.ClickedEvent += [this]
-			{
-				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
-			};
-
 			FileContextualMenu::CreateList();
 		}
 	};
 
-	class MaterialContextualMenu : public PreviewableContextualMenu
+	class MaterialContextualMenu : public FileContextualMenu
 	{
 	public:
-		MaterialContextualMenu(const std::string& p_filePath, bool p_protected = false) : PreviewableContextualMenu(p_filePath, p_protected) {}
+		MaterialContextualMenu(const std::string& p_filePath, bool p_protected = false) : FileContextualMenu(p_filePath, p_protected) {}
 
 		virtual void CreateList() override
 		{
-			auto& editAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Edit");
-
-			editAction.ClickedEvent += [this]
-			{
-				OvCore::Helpers::GUIHelpers::Open(EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected)));
-			};
-
 			auto& reload = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Reload");
 			reload.ClickedEvent += [this]
 			{
@@ -787,7 +745,7 @@ namespace
 				}
 			};
 
-			PreviewableContextualMenu::CreateList();
+			FileContextualMenu::CreateList();
 		}
 	};
 
@@ -805,9 +763,7 @@ namespace
 			case MODEL: return p_root.AddPlugin<ModelContextualMenu>(path, p_protected);
 			case TEXTURE: return p_root.AddPlugin<TextureContextualMenu>(path, p_protected);
 			case SHADER: return p_root.AddPlugin<ShaderContextualMenu>(path, p_protected);
-			case SHADER_PART: return p_root.AddPlugin<ShaderPartContextualMenu>(path, p_protected);
 			case MATERIAL: return p_root.AddPlugin<MaterialContextualMenu>(path, p_protected);
-			case SCENE: return p_root.AddPlugin<SceneContextualMenu>(path, p_protected);
 			default: return p_root.AddPlugin<FileContextualMenu>(path, p_protected);
 		}
 	}
@@ -844,7 +800,7 @@ OvEditor::Panels::AssetBrowser::AssetBrowser
 	importButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
 	importButton.lineBreak = false;
 
-	auto& codeEditorButton = CreateWidget<Buttons::Button>("Edit Scripts");
+	auto& codeEditorButton = CreateWidget<Buttons::Button>("Open Code Editor");
 	codeEditorButton.ClickedEvent += [this] { EDITOR_EXEC(OpenInCodeEditor(EDITOR_CONTEXT(projectFolder))); };
 	codeEditorButton.idleBackgroundColor = { 0.1f, 0.3f, 0.7f };
 

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -344,12 +344,6 @@ namespace
 				OvTools::Utils::SystemCalls::ShowInExplorer(filePath.string());
 			};
 
-			auto& openInCodeEditor = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Open in code editor");
-			openInCodeEditor.ClickedEvent += [this]
-			{
-				EDITOR_EXEC(OpenInCodeEditor(filePath));
-			};
-
 			if (!m_protected)
 			{
 				auto& importAssetHere = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Import Here...");
@@ -538,12 +532,6 @@ namespace
 
 			openExternallyAction.ClickedEvent += [this] {
 				OvTools::Utils::SystemCalls::OpenFile(filePath.string());
-			};
-
-			auto& openInCodeEditor = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Open in code editor");
-			openInCodeEditor.ClickedEvent += [this]
-			{
-				EDITOR_EXEC(OpenInCodeEditor(filePath));
 			};
 
 			if (!m_protected)

--- a/Sources/OvEditor/src/OvEditor/Panels/MenuBar.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MenuBar.cpp
@@ -197,6 +197,7 @@ void OvEditor::Panels::MenuBar::InitializeSettingsMenu()
 	};
 
 	auto& codeEditorMenu = m_settingsMenu->CreateWidget<MenuList>("Code Editor Command");
+	codeEditorMenu.CreateWidget<Texts::Text>("Use {workdir} to retrieve the project folder.");
 	codeEditorMenu.CreateWidget<Texts::Text>("Use {path} to retrieve the file/folder path.");
 	auto& codeEditorInput = codeEditorMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>(Settings::EditorSettings::CodeEditorCommand.Get());
 	codeEditorInput.ContentChangedEvent += [](const std::string& p_value)

--- a/Sources/OvEditor/src/OvEditor/Panels/MenuBar.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MenuBar.cpp
@@ -281,7 +281,7 @@ void OvEditor::Panels::MenuBar::CreateHelpMenu()
 	helpMenu.CreateWidget<MenuItem>("Wiki").ClickedEvent += [repoURL] {OvTools::Utils::SystemCalls::OpenURL(repoURL + "/wiki"); };
 	helpMenu.CreateWidget<MenuItem>("Lua Reference").ClickedEvent += [] {
 		const std::filesystem::path luaDefinitions = EDITOR_CONTEXT(engineAssetsPath) / "Lua";
-		if (!EDITOR_EXEC(OpenInCodeEditor(luaDefinitions)))
+		if (!EDITOR_EXEC(OpenInCodeEditor(luaDefinitions, luaDefinitions)))
 		{
 			OvTools::Utils::SystemCalls::ShowInExplorer(luaDefinitions.string());
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
- [x] Better asset actions (Open, Open externally...) no more preview
- [x] Add support for `{workdir}` in custom code editor command
- [x] Changed Lua and shaders default action to open the file with the code editor

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #702 
Fixes #693

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

<img width="346" height="513" alt="image" src="https://github.com/user-attachments/assets/0ce60974-bc56-4d54-bd1c-ed10b680c1be" />


## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
