### PR TITLE
Prevent crash when calling `SetModel` with `nil` value

### DIFF
--- a/Sources/OvCore/include/OvCore/ECS/Components/CMaterialRenderer.h
+++ b/Sources/OvCore/include/OvCore/ECS/Components/CMaterialRenderer.h
@@ -46,9 +46,9 @@ namespace OvCore::ECS::Components
 		virtual std::string GetTypeName() override;
 
 		/**
-		* Called on play mode start before scripts are executed
+		* Clears cached inspector pointers for this component
 		*/
-		virtual void OnAwake() override;
+		void InvalidateInspectorCache();
 
 		/**
 		* Fill the material renderer with the given material

--- a/Sources/OvCore/include/OvCore/ECS/Components/CMaterialRenderer.h
+++ b/Sources/OvCore/include/OvCore/ECS/Components/CMaterialRenderer.h
@@ -46,6 +46,11 @@ namespace OvCore::ECS::Components
 		virtual std::string GetTypeName() override;
 
 		/**
+		* Called on play mode start before scripts are executed
+		*/
+		virtual void OnAwake() override;
+
+		/**
 		* Fill the material renderer with the given material
 		* @param p_material
 		*/

--- a/Sources/OvCore/src/OvCore/ECS/Components/CMaterialRenderer.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/CMaterialRenderer.cpp
@@ -22,9 +22,7 @@ OvCore::ECS::Components::CMaterialRenderer::CMaterialRenderer(ECS::Actor & p_own
 {
 	m_materials.fill(nullptr);
 
-	for (uint8_t i = 0; i < kMaxMaterialCount; ++i)
-		m_materialFields[i].fill(nullptr);
-
+	InvalidateInspectorCache();
 	UpdateMaterialList();
 }
 
@@ -38,7 +36,7 @@ std::string OvCore::ECS::Components::CMaterialRenderer::GetTypeName()
 	return std::string{ComponentTraits<CMaterialRenderer>::Name};
 }
 
-void OvCore::ECS::Components::CMaterialRenderer::OnAwake()
+void OvCore::ECS::Components::CMaterialRenderer::InvalidateInspectorCache()
 {
 	m_inspectorRoot = nullptr;
 
@@ -164,12 +162,8 @@ void OvCore::ECS::Components::CMaterialRenderer::OnInspector(OvUI::Internal::Wid
 	using namespace OvCore::Helpers;
 	using enum Rendering::EVisibilityFlags;
 
+	InvalidateInspectorCache();
 	m_inspectorRoot = &p_root;
-
-	for (auto& materialField : m_materialFields)
-	{
-		materialField.fill(nullptr);
-	}
 
 	auto drawVisibilityToggle = [this, &p_root](const std::string& p_flagName, Rendering::EVisibilityFlags p_flag) {
 		GUIDrawer::DrawBoolean(

--- a/Sources/OvCore/src/OvCore/ECS/Components/CMaterialRenderer.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/CMaterialRenderer.cpp
@@ -38,6 +38,11 @@ std::string OvCore::ECS::Components::CMaterialRenderer::GetTypeName()
 	return std::string{ComponentTraits<CMaterialRenderer>::Name};
 }
 
+void OvCore::ECS::Components::CMaterialRenderer::OnAwake()
+{
+	m_inspectorRoot = nullptr;
+}
+
 void OvCore::ECS::Components::CMaterialRenderer::FillWithMaterial(OvCore::Resources::Material & p_material)
 {
 	for (uint8_t i = 0; i < m_materials.size(); ++i)

--- a/Sources/OvCore/src/OvCore/ECS/Components/CMaterialRenderer.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/CMaterialRenderer.cpp
@@ -41,6 +41,11 @@ std::string OvCore::ECS::Components::CMaterialRenderer::GetTypeName()
 void OvCore::ECS::Components::CMaterialRenderer::OnAwake()
 {
 	m_inspectorRoot = nullptr;
+
+	for (auto& materialField : m_materialFields)
+	{
+		materialField.fill(nullptr);
+	}
 }
 
 void OvCore::ECS::Components::CMaterialRenderer::FillWithMaterial(OvCore::Resources::Material & p_material)

--- a/Sources/OvEditor/src/OvEditor/Panels/Inspector.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Inspector.cpp
@@ -104,6 +104,13 @@ namespace
 		CreateComponentInfo<CReflectionProbe>("Reflection Probe"),
 	});
 
+	void InvalidateComponentInspectorCaches(Actor& p_actor)
+	{
+		if (auto materialRenderer = p_actor.GetComponent<CMaterialRenderer>())
+		{
+			materialRenderer->InvalidateInspectorCache();
+		}
+	}
 }
 
 OvEditor::Panels::Inspector::Inspector(
@@ -159,6 +166,7 @@ void OvEditor::Panels::Inspector::UnFocus()
 	m_targetActor->BehaviourAddedEvent -= m_behaviourAddedListener;
 	m_targetActor->BehaviourRemovedEvent -= m_behaviourRemovedListener;
 
+	InvalidateComponentInspectorCaches(m_targetActor.value());
 	m_content->RemoveAllWidgets();
 
 	EDITOR_EVENT(ActorUnselectedEvent).Invoke(m_targetActor.value());
@@ -379,6 +387,7 @@ void OvEditor::Panels::Inspector::Refresh()
 {
 	if (m_targetActor)
 	{
+		InvalidateComponentInspectorCaches(m_targetActor.value());
 		m_content->RemoveAllWidgets();
 		_Populate();
 	}


### PR DESCRIPTION
## Description
This PR fixes a crash triggered when calling `SetModel(nil)` from Lua.

Root cause:
- `CMaterialRenderer` keeps inspector widget pointers (`m_materialFields` / `m_inspectorRoot`).
- During play/stop and selection changes, these UI pointers can become stale.
- A later `SetModel(nil)` path triggers `UpdateMaterialList()`, which can touch invalid widget pointers.

Fix:
- Added `CMaterialRenderer::OnAwake()`.
- Reset inspector cached pointers in `OnAwake()` before script `OnStart()` runs:
  - `m_inspectorRoot = nullptr`
  - `m_materialFields[*].fill(nullptr)`

This keeps runtime behavior unchanged while preventing stale UI pointer access.

## Related Issue(s)
Fixes #705

## Review Guidance
Please validate with the repro from #705:
1. Attach a behaviour that calls `self.owner:GetModelRenderer():SetModel(nil)` in `OnStart()`.
2. Play -> Stop -> select another actor -> Play again.
3. Confirm no crash occurs.

Non-regression checks:
1. Assign a model in inspector and run multiple Play/Stop cycles.
2. Switch actor selection between cycles.
3. Confirm no crash and normal material/model inspector behavior.

## Screenshots/GIFs
N/A (crash fix, no UI visual change)

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
