### PR TITLE
Expose SkinnedMeshRenderer bone API to Lua (read/write local transforms)

### DIFF
--- a/Resources/Engine/Lua/Components/SkinnedMeshRenderer.lua
+++ b/Resources/Engine/Lua/Components/SkinnedMeshRenderer.lua
@@ -77,3 +77,50 @@ function SkinnedMeshRenderer:GetActiveAnimationIndex() end
 --- Returns current clip name or nil
 ---@return string|nil
 function SkinnedMeshRenderer:GetActiveAnimationName() end
+
+--- Returns the number of available bones
+---@return integer
+function SkinnedMeshRenderer:GetBoneCount() end
+
+--- Returns bone name at index or nil
+---@param index integer
+---@return string|nil
+function SkinnedMeshRenderer:GetBoneName(index) end
+
+--- Returns bone index by name or nil
+---@param name string
+---@return integer|nil
+function SkinnedMeshRenderer:GetBoneIndex(name) end
+
+--- Returns local bone position or nil
+---@param boneIndex integer
+---@return Vector3|nil
+function SkinnedMeshRenderer:GetBoneLocalPosition(boneIndex) end
+
+--- Returns local bone rotation or nil
+---@param boneIndex integer
+---@return Quaternion|nil
+function SkinnedMeshRenderer:GetBoneLocalRotation(boneIndex) end
+
+--- Returns local bone scale or nil
+---@param boneIndex integer
+---@return Vector3|nil
+function SkinnedMeshRenderer:GetBoneLocalScale(boneIndex) end
+
+--- Sets local bone position
+---@param boneIndex integer
+---@param position Vector3
+---@return boolean
+function SkinnedMeshRenderer:SetBoneLocalPosition(boneIndex, position) end
+
+--- Sets local bone rotation
+---@param boneIndex integer
+---@param rotation Quaternion
+---@return boolean
+function SkinnedMeshRenderer:SetBoneLocalRotation(boneIndex, rotation) end
+
+--- Sets local bone scale
+---@param boneIndex integer
+---@param scale Vector3
+---@return boolean
+function SkinnedMeshRenderer:SetBoneLocalScale(boneIndex, scale) end

--- a/Sources/OvCore/include/OvCore/ECS/Components/CSkinnedMeshRenderer.h
+++ b/Sources/OvCore/include/OvCore/ECS/Components/CSkinnedMeshRenderer.h
@@ -13,6 +13,8 @@
 
 #include <OvCore/ECS/Components/AComponent.h>
 #include <OvMaths/FMatrix4.h>
+#include <OvMaths/FQuaternion.h>
+#include <OvMaths/FVector3.h>
 
 namespace OvCore::ECS { class Actor; }
 namespace OvRendering::Resources { class Model; }
@@ -151,6 +153,62 @@ namespace OvCore::ECS::Components
 		std::optional<std::string> GetActiveAnimationName() const;
 
 		/**
+		* Returns the number of available bones
+		*/
+		uint32_t GetBoneCount() const;
+
+		/**
+		* Returns the bone name at index (std::nullopt if index is invalid)
+		* @param p_index
+		*/
+		std::optional<std::string> GetBoneName(uint32_t p_index) const;
+
+		/**
+		* Returns the bone index by name (std::nullopt if not found)
+		* @param p_name
+		*/
+		std::optional<uint32_t> GetBoneIndex(const std::string& p_name) const;
+
+		/**
+		* Returns the local bone position (std::nullopt if index is invalid)
+		* @param p_boneIndex
+		*/
+		std::optional<OvMaths::FVector3> GetBoneLocalPosition(uint32_t p_boneIndex) const;
+
+		/**
+		* Returns the local bone rotation (std::nullopt if index is invalid)
+		* @param p_boneIndex
+		*/
+		std::optional<OvMaths::FQuaternion> GetBoneLocalRotation(uint32_t p_boneIndex) const;
+
+		/**
+		* Returns the local bone scale (std::nullopt if index is invalid)
+		* @param p_boneIndex
+		*/
+		std::optional<OvMaths::FVector3> GetBoneLocalScale(uint32_t p_boneIndex) const;
+
+		/**
+		* Sets the local bone position
+		* @param p_boneIndex
+		* @param p_position
+		*/
+		bool SetBoneLocalPosition(uint32_t p_boneIndex, const OvMaths::FVector3& p_position);
+
+		/**
+		* Sets the local bone rotation
+		* @param p_boneIndex
+		* @param p_rotation
+		*/
+		bool SetBoneLocalRotation(uint32_t p_boneIndex, const OvMaths::FQuaternion& p_rotation);
+
+		/**
+		* Sets the local bone scale
+		* @param p_boneIndex
+		* @param p_scale
+		*/
+		bool SetBoneLocalScale(uint32_t p_boneIndex, const OvMaths::FVector3& p_scale);
+
+		/**
 		* Returns the transposed skinning matrix palette ready for GPU upload
 		*/
 		const std::vector<OvMaths::FMatrix4>& GetBoneMatricesTransposed() const;
@@ -191,6 +249,8 @@ namespace OvCore::ECS::Components
 		void SyncWithModel();
 		void RebuildRuntimeData();
 		void EvaluatePose();
+		std::optional<uint32_t> GetNodeIndexFromBoneIndex(uint32_t p_boneIndex) const;
+		void RecomputeBoneMatricesFromLocalPose();
 		float GetAnimationDurationSeconds() const;
 		void UpdatePlayback(float p_deltaTime);
 

--- a/Sources/OvCore/include/OvCore/ECS/Components/CSkinnedMeshRenderer.h
+++ b/Sources/OvCore/include/OvCore/ECS/Components/CSkinnedMeshRenderer.h
@@ -269,6 +269,7 @@ namespace OvCore::ECS::Components
 		std::string m_deserializedAnimationName;
 
 		uint64_t m_poseVersion = 0;
+		bool m_manualPoseOverride = false;
 
 		std::vector<std::string> m_animationNames;
 		std::vector<OvMaths::FMatrix4> m_localPose;

--- a/Sources/OvCore/src/OvCore/ECS/Components/CSkinnedMeshRenderer.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/CSkinnedMeshRenderer.cpp
@@ -173,7 +173,7 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::NotifyModelChanged()
 
 bool OvCore::ECS::Components::CSkinnedMeshRenderer::HasSkinningData() const
 {
-	return HasCompatibleModel() && m_animationIndex.has_value() && !m_boneMatrices.empty();
+	return HasCompatibleModel() && !m_boneMatrices.empty();
 }
 
 void OvCore::ECS::Components::CSkinnedMeshRenderer::Play()

--- a/Sources/OvCore/src/OvCore/ECS/Components/CSkinnedMeshRenderer.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/CSkinnedMeshRenderer.cpp
@@ -17,6 +17,7 @@
 #include <OvCore/ECS/Components/CSkinnedMeshRenderer.h>
 #include <OvCore/Helpers/GUIDrawer.h>
 #include <OvCore/Helpers/Serializer.h>
+#include <OvMaths/FMatrix3.h>
 #include <OvMaths/FTransform.h>
 #include <OvUI/Plugins/DataDispatcher.h>
 #include <OvUI/Widgets/Selection/ComboBox.h>
@@ -99,6 +100,52 @@ namespace
 		const auto& prev = *std::prev(nextIt);
 		const auto& next = *nextIt;
 		return interpolate(prev, next, next.time - prev.time);
+	}
+
+	void DecomposeLocalTransform(
+		const OvMaths::FMatrix4& p_matrix,
+		OvMaths::FVector3& p_position,
+		OvMaths::FQuaternion& p_rotation,
+		OvMaths::FVector3& p_scale
+	)
+	{
+		p_position.x = p_matrix.data[3];
+		p_position.y = p_matrix.data[7];
+		p_position.z = p_matrix.data[11];
+
+		OvMaths::FVector3 columns[3] =
+		{
+			{ p_matrix.data[0], p_matrix.data[4], p_matrix.data[8] },
+			{ p_matrix.data[1], p_matrix.data[5], p_matrix.data[9] },
+			{ p_matrix.data[2], p_matrix.data[6], p_matrix.data[10] }
+		};
+
+		p_scale.x = OvMaths::FVector3::Length(columns[0]);
+		p_scale.y = OvMaths::FVector3::Length(columns[1]);
+		p_scale.z = OvMaths::FVector3::Length(columns[2]);
+
+		if (p_scale.x > 0.0f)
+		{
+			columns[0] /= p_scale.x;
+		}
+
+		if (p_scale.y > 0.0f)
+		{
+			columns[1] /= p_scale.y;
+		}
+
+		if (p_scale.z > 0.0f)
+		{
+			columns[2] /= p_scale.z;
+		}
+
+		const OvMaths::FMatrix3 rotationMatrix(
+			columns[0].x, columns[1].x, columns[2].x,
+			columns[0].y, columns[1].y, columns[2].y,
+			columns[0].z, columns[1].z, columns[2].z
+		);
+
+		p_rotation = OvMaths::FQuaternion(rotationMatrix);
 	}
 }
 
@@ -293,6 +340,144 @@ std::optional<std::string> OvCore::ECS::Components::CSkinnedMeshRenderer::GetAct
 	}
 
 	return GetAnimationName(m_animationIndex.value());
+}
+
+uint32_t OvCore::ECS::Components::CSkinnedMeshRenderer::GetBoneCount() const
+{
+	if (!HasCompatibleModel())
+	{
+		return 0;
+	}
+
+	return static_cast<uint32_t>(m_model->GetSkeleton().value().bones.size());
+}
+
+std::optional<std::string> OvCore::ECS::Components::CSkinnedMeshRenderer::GetBoneName(uint32_t p_index) const
+{
+	if (!HasCompatibleModel())
+	{
+		return std::nullopt;
+	}
+
+	const auto& bones = m_model->GetSkeleton().value().bones;
+	if (p_index >= bones.size())
+	{
+		return std::nullopt;
+	}
+
+	return bones[p_index].name;
+}
+
+std::optional<uint32_t> OvCore::ECS::Components::CSkinnedMeshRenderer::GetBoneIndex(const std::string& p_name) const
+{
+	if (!HasCompatibleModel())
+	{
+		return std::nullopt;
+	}
+
+	return m_model->GetSkeleton().value().FindBoneIndex(p_name);
+}
+
+std::optional<OvMaths::FVector3> OvCore::ECS::Components::CSkinnedMeshRenderer::GetBoneLocalPosition(uint32_t p_boneIndex) const
+{
+	const auto nodeIndex = GetNodeIndexFromBoneIndex(p_boneIndex);
+	if (!nodeIndex.has_value())
+	{
+		return std::nullopt;
+	}
+
+	OvMaths::FVector3 position;
+	OvMaths::FQuaternion rotation;
+	OvMaths::FVector3 scale;
+	DecomposeLocalTransform(m_localPose[*nodeIndex], position, rotation, scale);
+	return position;
+}
+
+std::optional<OvMaths::FQuaternion> OvCore::ECS::Components::CSkinnedMeshRenderer::GetBoneLocalRotation(uint32_t p_boneIndex) const
+{
+	const auto nodeIndex = GetNodeIndexFromBoneIndex(p_boneIndex);
+	if (!nodeIndex.has_value())
+	{
+		return std::nullopt;
+	}
+
+	OvMaths::FVector3 position;
+	OvMaths::FQuaternion rotation;
+	OvMaths::FVector3 scale;
+	DecomposeLocalTransform(m_localPose[*nodeIndex], position, rotation, scale);
+	return rotation;
+}
+
+std::optional<OvMaths::FVector3> OvCore::ECS::Components::CSkinnedMeshRenderer::GetBoneLocalScale(uint32_t p_boneIndex) const
+{
+	const auto nodeIndex = GetNodeIndexFromBoneIndex(p_boneIndex);
+	if (!nodeIndex.has_value())
+	{
+		return std::nullopt;
+	}
+
+	OvMaths::FVector3 position;
+	OvMaths::FQuaternion rotation;
+	OvMaths::FVector3 scale;
+	DecomposeLocalTransform(m_localPose[*nodeIndex], position, rotation, scale);
+	return scale;
+}
+
+bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetBoneLocalPosition(uint32_t p_boneIndex, const OvMaths::FVector3& p_position)
+{
+	const auto nodeIndex = GetNodeIndexFromBoneIndex(p_boneIndex);
+	if (!nodeIndex.has_value())
+	{
+		return false;
+	}
+
+	OvMaths::FVector3 currentPosition;
+	OvMaths::FQuaternion currentRotation;
+	OvMaths::FVector3 currentScale;
+	DecomposeLocalTransform(m_localPose[*nodeIndex], currentPosition, currentRotation, currentScale);
+
+	const OvMaths::FTransform transform(p_position, currentRotation, currentScale);
+	m_localPose[*nodeIndex] = transform.GetLocalMatrix();
+	RecomputeBoneMatricesFromLocalPose();
+	return true;
+}
+
+bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetBoneLocalRotation(uint32_t p_boneIndex, const OvMaths::FQuaternion& p_rotation)
+{
+	const auto nodeIndex = GetNodeIndexFromBoneIndex(p_boneIndex);
+	if (!nodeIndex.has_value())
+	{
+		return false;
+	}
+
+	OvMaths::FVector3 currentPosition;
+	OvMaths::FQuaternion currentRotation;
+	OvMaths::FVector3 currentScale;
+	DecomposeLocalTransform(m_localPose[*nodeIndex], currentPosition, currentRotation, currentScale);
+
+	const OvMaths::FTransform transform(currentPosition, p_rotation, currentScale);
+	m_localPose[*nodeIndex] = transform.GetLocalMatrix();
+	RecomputeBoneMatricesFromLocalPose();
+	return true;
+}
+
+bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetBoneLocalScale(uint32_t p_boneIndex, const OvMaths::FVector3& p_scale)
+{
+	const auto nodeIndex = GetNodeIndexFromBoneIndex(p_boneIndex);
+	if (!nodeIndex.has_value())
+	{
+		return false;
+	}
+
+	OvMaths::FVector3 currentPosition;
+	OvMaths::FQuaternion currentRotation;
+	OvMaths::FVector3 currentScale;
+	DecomposeLocalTransform(m_localPose[*nodeIndex], currentPosition, currentRotation, currentScale);
+
+	const OvMaths::FTransform transform(currentPosition, currentRotation, p_scale);
+	m_localPose[*nodeIndex] = transform.GetLocalMatrix();
+	RecomputeBoneMatricesFromLocalPose();
+	return true;
 }
 
 const std::vector<OvMaths::FMatrix4>& OvCore::ECS::Components::CSkinnedMeshRenderer::GetBoneMatricesTransposed() const
@@ -584,6 +769,49 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::EvaluatePose()
 			const OvMaths::FTransform sampled(sampledPosition, sampledRotation, sampledScale);
 			m_localPose[track.nodeIndex] = sampled.GetLocalMatrix();
 		}
+	}
+
+	RecomputeBoneMatricesFromLocalPose();
+}
+
+std::optional<uint32_t> OvCore::ECS::Components::CSkinnedMeshRenderer::GetNodeIndexFromBoneIndex(uint32_t p_boneIndex) const
+{
+	if (!HasCompatibleModel())
+	{
+		return std::nullopt;
+	}
+
+	const auto& skeleton = m_model->GetSkeleton().value();
+	if (p_boneIndex >= skeleton.bones.size())
+	{
+		return std::nullopt;
+	}
+
+	const uint32_t nodeIndex = skeleton.bones[p_boneIndex].nodeIndex;
+	if (nodeIndex >= m_localPose.size())
+	{
+		return std::nullopt;
+	}
+
+	return nodeIndex;
+}
+
+void OvCore::ECS::Components::CSkinnedMeshRenderer::RecomputeBoneMatricesFromLocalPose()
+{
+	if (!HasCompatibleModel())
+	{
+		return;
+	}
+
+	const auto& skeleton = m_model->GetSkeleton().value();
+	if (
+		m_localPose.size() != skeleton.nodes.size() ||
+		m_globalPose.size() != skeleton.nodes.size() ||
+		m_boneMatrices.size() != skeleton.bones.size() ||
+		m_boneMatricesTransposed.size() != skeleton.bones.size()
+	)
+	{
+		return;
 	}
 
 	for (size_t nodeIndex = 0; nodeIndex < skeleton.nodes.size(); ++nodeIndex)

--- a/Sources/OvCore/src/OvCore/ECS/Components/CSkinnedMeshRenderer.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/CSkinnedMeshRenderer.cpp
@@ -173,7 +173,7 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::NotifyModelChanged()
 
 bool OvCore::ECS::Components::CSkinnedMeshRenderer::HasSkinningData() const
 {
-	return HasCompatibleModel() && !m_boneMatrices.empty();
+	return HasCompatibleModel() && !m_boneMatrices.empty() && (m_animationIndex.has_value() || m_manualPoseOverride);
 }
 
 void OvCore::ECS::Components::CSkinnedMeshRenderer::Play()
@@ -193,6 +193,7 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::Stop()
 	m_playing = false;
 	m_currentTimeTicks = 0.0f;
 	m_poseEvaluationAccumulator = 0.0f;
+	m_manualPoseOverride = false;
 	EvaluatePose();
 }
 
@@ -289,6 +290,7 @@ bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetAnimation(std::optional<u
 		m_animationIndex = std::nullopt;
 		m_currentTimeTicks = 0.0f;
 		m_poseEvaluationAccumulator = 0.0f;
+		m_manualPoseOverride = false;
 		EvaluatePose();
 		return true;
 	}
@@ -301,6 +303,7 @@ bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetAnimation(std::optional<u
 	m_animationIndex = p_index;
 	m_currentTimeTicks = 0.0f;
 	m_poseEvaluationAccumulator = 0.0f;
+	m_manualPoseOverride = false;
 	EvaluatePose();
 	return true;
 }
@@ -438,6 +441,7 @@ bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetBoneLocalPosition(uint32_
 
 	const OvMaths::FTransform transform(p_position, currentRotation, currentScale);
 	m_localPose[*nodeIndex] = transform.GetLocalMatrix();
+	m_manualPoseOverride = true;
 	RecomputeBoneMatricesFromLocalPose();
 	return true;
 }
@@ -457,6 +461,7 @@ bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetBoneLocalRotation(uint32_
 
 	const OvMaths::FTransform transform(currentPosition, p_rotation, currentScale);
 	m_localPose[*nodeIndex] = transform.GetLocalMatrix();
+	m_manualPoseOverride = true;
 	RecomputeBoneMatricesFromLocalPose();
 	return true;
 }
@@ -476,6 +481,7 @@ bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetBoneLocalScale(uint32_t p
 
 	const OvMaths::FTransform transform(currentPosition, currentRotation, p_scale);
 	m_localPose[*nodeIndex] = transform.GetLocalMatrix();
+	m_manualPoseOverride = true;
 	RecomputeBoneMatricesFromLocalPose();
 	return true;
 }
@@ -651,6 +657,7 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::RebuildRuntimeData()
 	m_animationIndex = std::nullopt;
 	m_currentTimeTicks = preservedTimeTicks;
 	m_poseEvaluationAccumulator = 0.0f;
+	m_manualPoseOverride = false;
 
 	if (!HasCompatibleModel())
 	{
@@ -771,6 +778,7 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::EvaluatePose()
 		}
 	}
 
+	m_manualPoseOverride = false;
 	RecomputeBoneMatricesFromLocalPose();
 }
 

--- a/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaComponentsBindings.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaComponentsBindings.cpp
@@ -109,7 +109,16 @@ void BindLuaComponents(sol::state& p_luaState)
 			sol::resolve<bool(const std::string&)>(&CSkinnedMeshRenderer::SetAnimation)
 		),
 		"GetActiveAnimationIndex", &CSkinnedMeshRenderer::GetActiveAnimationIndex,
-		"GetActiveAnimationName", &CSkinnedMeshRenderer::GetActiveAnimationName
+		"GetActiveAnimationName", &CSkinnedMeshRenderer::GetActiveAnimationName,
+		"GetBoneCount", &CSkinnedMeshRenderer::GetBoneCount,
+		"GetBoneName", &CSkinnedMeshRenderer::GetBoneName,
+		"GetBoneIndex", &CSkinnedMeshRenderer::GetBoneIndex,
+		"GetBoneLocalPosition", &CSkinnedMeshRenderer::GetBoneLocalPosition,
+		"GetBoneLocalRotation", &CSkinnedMeshRenderer::GetBoneLocalRotation,
+		"GetBoneLocalScale", &CSkinnedMeshRenderer::GetBoneLocalScale,
+		"SetBoneLocalPosition", &CSkinnedMeshRenderer::SetBoneLocalPosition,
+		"SetBoneLocalRotation", &CSkinnedMeshRenderer::SetBoneLocalRotation,
+		"SetBoneLocalScale", &CSkinnedMeshRenderer::SetBoneLocalScale
 	);
 
 	p_luaState.new_enum<OvPhysics::Entities::PhysicalObject::ECollisionDetectionMode>("CollisionDetectionMode", {


### PR DESCRIPTION
## Description
This PR exposes skeleton/bone runtime controls for `SkinnedMeshRenderer` in Lua.

What was added:
- Bone discovery API:
  - `GetBoneCount()`
  - `GetBoneName(index)`
  - `GetBoneIndex(name)`
- Bone local transform accessors:
  - `GetBoneLocalPosition(index)`
  - `GetBoneLocalRotation(index)`
  - `GetBoneLocalScale(index)`
- Bone local transform mutators:
  - `SetBoneLocalPosition(index, position)`
  - `SetBoneLocalRotation(index, rotation)`
  - `SetBoneLocalScale(index, scale)`

Implementation details:
- Added minimal, localized API in `CSkinnedMeshRenderer`.
- Added safe validation for invalid indices/model state.
- Added pose recomputation path after manual bone transform changes.
- Exposed methods through Lua bindings.
- Updated Lua component API docs/stubs accordingly.

## Related Issue(s)
Fixes #677

## Review Guidance
- Use a skinned actor with a `SkinnedMeshRenderer`.
- In a behaviour script:
  - Resolve a bone index via `GetBoneIndex("Head")` (or another bone).
  - Read local TRS with `GetBoneLocal*`.
  - Apply runtime updates with `SetBoneLocal*`.
- Confirm:
  - Valid index updates the pose at runtime.
  - Invalid index/name safely returns `nil`/`false`.
  - Existing animation controls (`Play`, `SetAnimation`, etc.) keep working.

## Screenshots/GIFs
https://github.com/user-attachments/assets/c0ebf264-8365-4d39-9641-85696019efe2

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
