### PR TITLE
Add minimal prefab workflow based on actor XML serialization

### DIFF
--- a/Sources/OvCore/src/OvCore/Helpers/GUIHelpers.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIHelpers.cpp
@@ -30,6 +30,7 @@ namespace
 		case EFileType::SOUND:    return "Pick Sound";
 		case EFileType::SCRIPT:   return "Pick Script";
 		case EFileType::SCENE:    return "Pick Scene";
+		case EFileType::PREFAB:   return "Pick Prefab";
 		default:                  return "Pick Asset";
 		}
 	}

--- a/Sources/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -223,6 +223,33 @@ namespace OvEditor::Core
 		* @param bool
 		*/
 		void DuplicateActor(OvCore::ECS::Actor& p_toDuplicate, OvCore::ECS::Actor* p_forcedParent = nullptr, bool p_focus = true);
+
+		/**
+		* Save an actor hierarchy as a prefab
+		* @param p_actor
+		*/
+		void SaveActorAsPrefab(OvCore::ECS::Actor& p_actor);
+
+		/**
+		* Save an actor hierarchy as a prefab to disk
+		* @param p_actor
+		* @param p_path
+		*/
+		void SavePrefabToDisk(OvCore::ECS::Actor& p_actor, const std::string& p_path);
+
+		/**
+		* Instantiate a prefab from disk
+		* @param p_path
+		* @param p_absolute
+		* @param p_parent
+		* @param p_focusOnCreation
+		*/
+		OvCore::ECS::Actor* InstantiatePrefabFromDisk(
+			const std::string& p_path,
+			bool p_absolute = false,
+			OvCore::ECS::Actor* p_parent = nullptr,
+			bool p_focusOnCreation = true
+		);
 		#pragma endregion
 
 		#pragma region ACTOR_MANIPULATION

--- a/Sources/OvEditor/include/OvEditor/Panels/SceneView.h
+++ b/Sources/OvEditor/include/OvEditor/Panels/SceneView.h
@@ -62,6 +62,7 @@ namespace OvEditor::Panels
 		void HandleActorPicking();
 		OvEditor::Rendering::PickingRenderPass::PickingResult GetPickingResult();
 		void OnSceneDropped(const std::string& p_path);
+		void OnPrefabDropped(const std::string& p_path);
 		void OnModelDropped(const std::string& p_path);
 		void OnMaterialDropped(const std::string& p_path);
 

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -53,6 +53,25 @@
 namespace
 {
 	constexpr std::string_view kDefaultMaterialPath = ":Materials\\Default.ovmat";
+	bool s_logActorCreation = true;
+
+	class ScopedActorCreationLog
+	{
+	public:
+		explicit ScopedActorCreationLog(bool p_enabled) :
+			m_previousState(s_logActorCreation)
+		{
+			s_logActorCreation = p_enabled;
+		}
+
+		~ScopedActorCreationLog()
+		{
+			s_logActorCreation = m_previousState;
+		}
+
+	private:
+		bool m_previousState;
+	};
 
 	void SerializeActorHierarchy(
 		tinyxml2::XMLDocument& p_doc,
@@ -723,7 +742,8 @@ OvCore::ECS::Actor & OvEditor::Core::EditorActions::CreateEmptyActor(bool p_focu
 	if (p_focusOnCreation)
 		SelectActor(instance);
 
-	OVLOG_INFO("Actor created");
+	if (s_logActorCreation)
+		OVLOG_INFO("Actor created");
 
 	return instance;
 }
@@ -904,6 +924,7 @@ OvCore::ECS::Actor* OvEditor::Core::EditorActions::InstantiatePrefabFromDisk(
 
 	std::vector<OvCore::ECS::Actor*> createdActors;
 	std::unordered_map<int64_t, OvCore::ECS::Actor*> actorLookup;
+	ScopedActorCreationLog actorCreationLogScope(false);
 
 	for (tinyxml2::XMLElement* currentActor = actorsRoot->FirstChildElement("actor"); currentActor; currentActor = currentActor->NextSiblingElement("actor"))
 	{

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <ranges>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 #include <tinyxml2.h>
 
@@ -52,6 +53,20 @@
 namespace
 {
 	constexpr std::string_view kDefaultMaterialPath = ":Materials\\Default.ovmat";
+
+	void SerializeActorHierarchy(
+		tinyxml2::XMLDocument& p_doc,
+		tinyxml2::XMLNode& p_actorsRoot,
+		OvCore::ECS::Actor& p_actor
+	)
+	{
+		p_actor.OnSerialize(p_doc, &p_actorsRoot);
+
+		for (auto* child : p_actor.GetChildren())
+		{
+			SerializeActorHierarchy(p_doc, p_actorsRoot, *child);
+		}
+	}
 
 	template<typename TResourceManager, typename TAssetNameValidator>
 	void MoveEmbeddedResourcesForRenamedModel(
@@ -800,6 +815,150 @@ void OvEditor::Core::EditorActions::DuplicateActor(OvCore::ECS::Actor & p_toDupl
 		DuplicateActor(*child, &newActor, false);
 }
 
+void OvEditor::Core::EditorActions::SaveActorAsPrefab(OvCore::ECS::Actor& p_actor)
+{
+	OvWindowing::Dialogs::SaveFileDialog dialog("Save Prefab");
+	const auto initialPath = m_context.projectAssetsPath / p_actor.GetName();
+	dialog.SetInitialDirectory(initialPath.string());
+	dialog.DefineExtension("Overload Prefab", ".ovprefab");
+	dialog.Show();
+
+	if (!dialog.HasSucceeded())
+	{
+		return;
+	}
+
+	if (dialog.IsFileExisting())
+	{
+		OvWindowing::Dialogs::MessageBox message(
+			"File already exists!",
+			"The file \"" + dialog.GetSelectedFileName() + "\" already exists.\n\nUsing this file as the new home for your prefab will erase any content stored in this file.\n\nAre you ok with that?",
+			OvWindowing::Dialogs::MessageBox::EMessageType::WARNING,
+			OvWindowing::Dialogs::MessageBox::EButtonLayout::YES_NO,
+			true
+		);
+
+		if (message.GetUserAction() != OvWindowing::Dialogs::MessageBox::EUserAction::YES)
+		{
+			return;
+		}
+	}
+
+	SavePrefabToDisk(p_actor, dialog.GetSelectedFilePath());
+	OVLOG_INFO("Prefab saved to: " + dialog.GetSelectedFilePath());
+}
+
+void OvEditor::Core::EditorActions::SavePrefabToDisk(OvCore::ECS::Actor& p_actor, const std::string& p_path)
+{
+	tinyxml2::XMLDocument doc;
+	tinyxml2::XMLNode* rootNode = doc.NewElement("root");
+	doc.InsertFirstChild(rootNode);
+
+	tinyxml2::XMLNode* actorsNode = doc.NewElement("actors");
+	rootNode->InsertEndChild(actorsNode);
+
+	SerializeActorHierarchy(doc, *actorsNode, p_actor);
+
+	doc.SaveFile(p_path.c_str());
+}
+
+OvCore::ECS::Actor* OvEditor::Core::EditorActions::InstantiatePrefabFromDisk(
+	const std::string& p_path,
+	bool p_absolute,
+	OvCore::ECS::Actor* p_parent,
+	bool p_focusOnCreation
+)
+{
+	const auto isAbsolutePath = p_absolute || std::filesystem::path{ p_path }.is_absolute();
+	const std::string resolvedPath = isAbsolutePath ? p_path : GetRealPath(p_path);
+
+	tinyxml2::XMLDocument doc;
+	doc.LoadFile(resolvedPath.c_str());
+
+	if (doc.Error())
+	{
+		OVLOG_ERROR("Failed to load prefab from disk: " + resolvedPath);
+		return nullptr;
+	}
+
+	tinyxml2::XMLNode* root = doc.FirstChildElement("root");
+
+	if (!root)
+	{
+		root = doc.FirstChild();
+	}
+
+	if (!root)
+	{
+		OVLOG_ERROR("Failed to instantiate prefab: Invalid prefab file \"" + resolvedPath + "\"");
+		return nullptr;
+	}
+
+	tinyxml2::XMLNode* actorsRoot = root->FirstChildElement("actors");
+
+	if (!actorsRoot)
+	{
+		OVLOG_ERROR("Failed to instantiate prefab: Missing actor data in \"" + resolvedPath + "\"");
+		return nullptr;
+	}
+
+	std::vector<OvCore::ECS::Actor*> createdActors;
+	std::unordered_map<int64_t, OvCore::ECS::Actor*> actorLookup;
+
+	for (tinyxml2::XMLElement* currentActor = actorsRoot->FirstChildElement("actor"); currentActor; currentActor = currentActor->NextSiblingElement("actor"))
+	{
+		auto& newActor = CreateEmptyActor(false);
+		const int64_t generatedID = newActor.GetID();
+		newActor.OnDeserialize(doc, currentActor);
+
+		const int64_t sourceID = newActor.GetID();
+		actorLookup[sourceID] = &newActor;
+
+		newActor.SetID(generatedID);
+		createdActors.push_back(&newActor);
+	}
+
+	if (createdActors.empty())
+	{
+		OVLOG_ERROR("Failed to instantiate prefab: No actor found in \"" + resolvedPath + "\"");
+		return nullptr;
+	}
+
+	for (auto* actor : createdActors)
+	{
+		const int64_t parentID = actor->GetParentID();
+
+		if (parentID <= 0)
+		{
+			continue;
+		}
+
+		if (auto found = actorLookup.find(parentID); found != actorLookup.end())
+		{
+			actor->SetParent(*found->second);
+		}
+		else
+		{
+			actor->DetachFromParent();
+		}
+	}
+
+	auto* rootActor = createdActors.front();
+
+	if (p_parent)
+	{
+		rootActor->SetParent(*p_parent);
+	}
+
+	if (p_focusOnCreation)
+	{
+		SelectActor(*rootActor);
+	}
+
+	OVLOG_INFO("Prefab instantiated from disk: " + resolvedPath);
+	return rootActor;
+}
+
 void OvEditor::Core::EditorActions::SelectActor(OvCore::ECS::Actor& p_target)
 {
 	EDITOR_PANEL(Panels::Inspector, "Inspector").FocusActor(p_target);
@@ -1138,6 +1297,7 @@ void OvEditor::Core::EditorActions::MigrateScripts()
 				const auto newRelPath = (std::filesystem::path("Scripts") / entry.path().filename()).generic_string();
 
 				PropagateFileRenameThroughSavedFilesOfType(stem, newRelPath, OvTools::Utils::PathParser::EFileType::SCENE);
+				PropagateFileRenameThroughSavedFilesOfType(stem, newRelPath, OvTools::Utils::PathParser::EFileType::PREFAB);
 			}
 		}
 	}
@@ -1299,6 +1459,7 @@ void OvEditor::Core::EditorActions::PropagateFileRename(std::string p_previousNa
 		if (next != "?")
 		{
 			PropagateFileRenameThroughSavedFilesOfType(prev, next, OvTools::Utils::PathParser::EFileType::SCENE);
+			PropagateFileRenameThroughSavedFilesOfType(prev, next, OvTools::Utils::PathParser::EFileType::PREFAB);
 		}
 
 		EDITOR_PANEL(Panels::Inspector, "Inspector").Refresh();
@@ -1306,9 +1467,11 @@ void OvEditor::Core::EditorActions::PropagateFileRename(std::string p_previousNa
 	}
 	case OvTools::Utils::PathParser::EFileType::MATERIAL:
 		PropagateFileRenameThroughSavedFilesOfType(p_previousName, p_newName, OvTools::Utils::PathParser::EFileType::SCENE);
+		PropagateFileRenameThroughSavedFilesOfType(p_previousName, p_newName, OvTools::Utils::PathParser::EFileType::PREFAB);
 		break;
 	case OvTools::Utils::PathParser::EFileType::MODEL:
 		PropagateFileRenameThroughSavedFilesOfType(p_previousName, p_newName, OvTools::Utils::PathParser::EFileType::SCENE);
+		PropagateFileRenameThroughSavedFilesOfType(p_previousName, p_newName, OvTools::Utils::PathParser::EFileType::PREFAB);
 		PropagateFileRenameThroughSavedFilesOfType(p_previousName, p_newName, OvTools::Utils::PathParser::EFileType::MATERIAL);
 		break;
 	case OvTools::Utils::PathParser::EFileType::SHADER:
@@ -1319,6 +1482,7 @@ void OvEditor::Core::EditorActions::PropagateFileRename(std::string p_previousNa
 		break;
 	case OvTools::Utils::PathParser::EFileType::SOUND:
 		PropagateFileRenameThroughSavedFilesOfType(p_previousName, p_newName, OvTools::Utils::PathParser::EFileType::SCENE);
+		PropagateFileRenameThroughSavedFilesOfType(p_previousName, p_newName, OvTools::Utils::PathParser::EFileType::PREFAB);
 		break;
 	default:
 		break;

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -53,25 +53,6 @@
 namespace
 {
 	constexpr std::string_view kDefaultMaterialPath = ":Materials\\Default.ovmat";
-	bool s_logActorCreation = true;
-
-	class ScopedActorCreationLog
-	{
-	public:
-		explicit ScopedActorCreationLog(bool p_enabled) :
-			m_previousState(s_logActorCreation)
-		{
-			s_logActorCreation = p_enabled;
-		}
-
-		~ScopedActorCreationLog()
-		{
-			s_logActorCreation = m_previousState;
-		}
-
-	private:
-		bool m_previousState;
-	};
 
 	void SerializeActorHierarchy(
 		tinyxml2::XMLDocument& p_doc,
@@ -742,9 +723,6 @@ OvCore::ECS::Actor & OvEditor::Core::EditorActions::CreateEmptyActor(bool p_focu
 	if (p_focusOnCreation)
 		SelectActor(instance);
 
-	if (s_logActorCreation)
-		OVLOG_INFO("Actor created");
-
 	return instance;
 }
 
@@ -924,7 +902,6 @@ OvCore::ECS::Actor* OvEditor::Core::EditorActions::InstantiatePrefabFromDisk(
 
 	std::vector<OvCore::ECS::Actor*> createdActors;
 	std::unordered_map<int64_t, OvCore::ECS::Actor*> actorLookup;
-	ScopedActorCreationLog actorCreationLogScope(false);
 
 	for (tinyxml2::XMLElement* currentActor = actorsRoot->FirstChildElement("actor"); currentActor; currentActor = currentActor->NextSiblingElement("actor"))
 	{

--- a/Sources/OvEditor/src/OvEditor/Core/EditorResources.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorResources.cpp
@@ -123,6 +123,7 @@ OvEditor::Core::EditorResources::EditorResources(const std::string& p_editorAsse
 		{"Component", CreateTexture<LINEAR>(texturesFolder / "Component.png")},
 		{"Material", CreateTexture<LINEAR>(texturesFolder / "Material.png")},
 		{"Scene", CreateTexture<LINEAR>(texturesFolder / "Scene.png")},
+		{"Prefab", CreateTexture<LINEAR>(texturesFolder / "Actor.png")},
 		{"Sound", CreateTexture<LINEAR>(texturesFolder / "Sound.png")},
 		{"Script", CreateTexture<LINEAR>(texturesFolder / "Script.png")},
 		{"Font", CreateTexture<LINEAR>(texturesFolder / "Font.png")},

--- a/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -61,6 +61,12 @@ public:
 				EDITOR_EXEC(DelayAction(EDITOR_BIND(DuplicateActor, std::ref(*m_target), nullptr, true), 0));
 			};
 
+			auto& createPrefabButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Save as prefab...");
+			createPrefabButton.ClickedEvent += [this]
+			{
+				EDITOR_EXEC(SaveActorAsPrefab(*m_target));
+			};
+
 			auto& deleteButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Delete");
 			deleteButton.ClickedEvent += [this]
 			{

--- a/Sources/OvEditor/src/OvEditor/Panels/SceneView.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/SceneView.cpp
@@ -59,6 +59,7 @@ OvEditor::Panels::SceneView::SceneView
 		switch (PathParser::GetFileType(path))
 		{
 			case SCENE: OnSceneDropped(path); break;
+			case PREFAB: OnPrefabDropped(path); break;
 			case MODEL: OnModelDropped(path); break;
 			case MATERIAL: OnMaterialDropped(path); break;
 			default: break;
@@ -276,6 +277,11 @@ OvEditor::Rendering::PickingRenderPass::PickingResult OvEditor::Panels::SceneVie
 void OvEditor::Panels::SceneView::OnSceneDropped(const std::string& p_path)
 {
 	EDITOR_EXEC(LoadSceneFromDisk(p_path));
+}
+
+void OvEditor::Panels::SceneView::OnPrefabDropped(const std::string& p_path)
+{
+	EDITOR_EXEC(InstantiatePrefabFromDisk(p_path));
 }
 
 void OvEditor::Panels::SceneView::OnModelDropped(const std::string& p_path)

--- a/Sources/OvTools/include/OvTools/Utils/PathParser.h
+++ b/Sources/OvTools/include/OvTools/Utils/PathParser.h
@@ -27,6 +27,7 @@ namespace OvTools::Utils
 			MATERIAL,
 			SOUND,
 			SCENE,
+			PREFAB,
 			SCRIPT,
 			FONT
 		};

--- a/Sources/OvTools/src/OvTools/Utils/PathParser.cpp
+++ b/Sources/OvTools/src/OvTools/Utils/PathParser.cpp
@@ -102,6 +102,7 @@ std::string OvTools::Utils::PathParser::FileTypeToString(EFileType p_fileType)
 	case OvTools::Utils::PathParser::EFileType::MATERIAL:	return "Material";
 	case OvTools::Utils::PathParser::EFileType::SOUND:		return "Sound";
 	case OvTools::Utils::PathParser::EFileType::SCENE:		return "Scene";
+	case OvTools::Utils::PathParser::EFileType::PREFAB:	return "Prefab";
 	case OvTools::Utils::PathParser::EFileType::SCRIPT:		return "Script";
 	case OvTools::Utils::PathParser::EFileType::FONT:		return "Font";
 	default:												return "Unknown";
@@ -115,6 +116,7 @@ OvTools::Utils::PathParser::EFileType OvTools::Utils::PathParser::StringToFileTy
 	if (p_type == "Shader")   return EFileType::SHADER;
 	if (p_type == "Material") return EFileType::MATERIAL;
 	if (p_type == "Sound")    return EFileType::SOUND;
+	if (p_type == "Prefab")   return EFileType::PREFAB;
 	return EFileType::UNKNOWN;
 }
 
@@ -130,6 +132,7 @@ OvTools::Utils::PathParser::EFileType OvTools::Utils::PathParser::GetFileType(co
 	else if (ext == "ovmat") return EFileType::MATERIAL;
 	else if (ext == "wav" || ext == "mp3" || ext == "ogg") return EFileType::SOUND;
 	else if (ext == "ovscene") return EFileType::SCENE;
+	else if (ext == "ovprefab") return EFileType::PREFAB;
 	else if (ext == "lua" || ext == "ovscript") return EFileType::SCRIPT;
 	else if (ext == "ttf") return EFileType::FONT;
 


### PR DESCRIPTION
## Description
This PR implements a minimal prefab workflow based on the existing actor/scene XML serialization system.

What is included:
- Added `.ovprefab` file type support in `PathParser`.
- Added editor integration to save an actor hierarchy as a prefab from the Hierarchy contextual menu.
- Added prefab instantiation by drag-and-drop in Scene View.
- Reused `Actor::OnSerialize` / `Actor::OnDeserialize` for prefab save/load to stay consistent with `.ovscene` behavior.
- Added prefab-aware asset retargeting propagation for renames (scripts, models, materials, sounds) so references in prefab files stay valid.
- Reduced log noise during prefab instantiation:
  - no per-actor `Actor created` spam
  - keep a single log entry:
    `Prefab instantiated from disk: <path>`

## Related Issue(s)
Fixes #25

## Review Guidance
Key areas to review:
- Prefab file type integration:
  - `Sources/OvTools/include/OvTools/Utils/PathParser.h`
  - `Sources/OvTools/src/OvTools/Utils/PathParser.cpp`
- Prefab save/load actions:
  - `Sources/OvEditor/include/OvEditor/Core/EditorActions.h`
  - `Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp`
- Editor UI integration:
  - `Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp` (Save as prefab)
  - `Sources/OvEditor/include/OvEditor/Panels/SceneView.h`
  - `Sources/OvEditor/src/OvEditor/Panels/SceneView.cpp` (drop instantiate)
- Minor UI/type support:
  - `Sources/OvCore/src/OvCore/Helpers/GUIHelpers.cpp`
  - `Sources/OvEditor/src/OvEditor/Core/EditorResources.cpp`

Suggested manual checks:
1. Create an actor with children/components, then use **Save as prefab...**.
2. Drag the `.ovprefab` into Scene View and verify hierarchy/component restoration.
3. Confirm log output only shows the prefab instantiation message (no actor creation spam).
4. Rename referenced assets/scripts and verify `.ovprefab` references are retargeted.

## Screenshots/GIFs
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors