### PR TITLE
`MaterialEditor` and `AssetProperties` are now readonly for engine assets and embedded materials

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
@@ -6,24 +6,32 @@
 
 #include <filesystem>
 
-#include <OvTools/Utils/PathParser.h>
-#include <OvTools/Utils/SizeConverter.h>
-
-#include <OvCore/Helpers/GUIDrawer.h>
 #include <OvCore/Global/ServiceLocator.h>
+#include <OvCore/Helpers/GUIDrawer.h>
 #include <OvCore/ResourceManagement/ModelManager.h>
 #include <OvCore/ResourceManagement/TextureManager.h>
 
-#include <OvUI/Widgets/Visual/Separator.h>
+#include <OvEditor/Core/EditorActions.h>
+#include <OvEditor/Panels/AssetProperties.h>
+#include <OvEditor/Panels/AssetView.h>
+
+#include <OvTools/Utils/PathParser.h>
+#include <OvTools/Utils/SizeConverter.h>
+
+#include <OvUI/Widgets/Buttons/Button.h>
 #include <OvUI/Widgets/Layout/Group.h>
 #include <OvUI/Widgets/Layout/GroupCollapsable.h>
 #include <OvUI/Widgets/Layout/NewLine.h>
-#include <OvUI/Widgets/Buttons/Button.h>
 #include <OvUI/Widgets/Selection/ComboBox.h>
+#include <OvUI/Widgets/Visual/Separator.h>
 
-#include "OvEditor/Panels/AssetProperties.h"
-#include "OvEditor/Panels/AssetView.h"
-#include "OvEditor/Core/EditorActions.h"
+namespace
+{
+	bool IsReadOnlyAsset(const std::string& p_path)
+	{
+		return p_path.starts_with(":");
+	}
+}
 
 OvEditor::Panels::AssetProperties::AssetProperties
 (
@@ -43,10 +51,12 @@ OvEditor::Panels::AssetProperties::AssetProperties
 	CreateAssetSelector();
 
 	m_settings = &CreateWidget<OvUI::Widgets::Layout::GroupCollapsable>("Settings");
+	m_settings->neverDisabled = true;
 	m_settingsColumns = &m_settings->CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
 	m_settingsColumns->widths[0] = 150;
 
 	m_info = &CreateWidget<OvUI::Widgets::Layout::GroupCollapsable>("Info");
+	m_info->neverDisabled = true;
 	m_infoColumns = &m_info->CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
 	m_infoColumns->widths[0] = 150;
 
@@ -55,6 +65,8 @@ OvEditor::Panels::AssetProperties::AssetProperties
 
 void OvEditor::Panels::AssetProperties::SetTarget(const std::string& p_path)
 {
+	disabled = IsReadOnlyAsset(p_path);
+
 	m_resource = p_path == "" ? p_path : EDITOR_EXEC(GetResourcePath(p_path));
 
 	if (m_assetSelector)

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
@@ -4,6 +4,7 @@
 * @licence: MIT
 */
 
+#include "OvCore/ResourceManagement/MaterialManager.h"
 #include <filesystem>
 
 #include <OvCore/Global/ServiceLocator.h>
@@ -125,6 +126,13 @@ void OvEditor::Panels::AssetProperties::Preview()
 			assetView.SetResource(resource);
 		}
 	}
+	else if (fileType == OvTools::Utils::PathParser::EFileType::MATERIAL)
+	{
+		if (auto resource = OVSERVICE(OvCore::ResourceManagement::MaterialManager).GetResource(m_resource))
+		{
+			assetView.SetResource(resource);
+		}
+	}
 
 	assetView.Open();
 }
@@ -145,6 +153,7 @@ void OvEditor::Panels::AssetProperties::CreateHeaderButtons()
 	m_revertButton->ClickedEvent += [this] { SetTarget(m_resource); };
 
 	m_previewButton = &CreateWidget<OvUI::Widgets::Buttons::Button>("Preview");
+	m_previewButton->neverDisabled = true;
 	m_previewButton->tooltip = "Preview the asset in the Asset View";
 	m_previewButton->enabled = false;
 	m_previewButton->lineBreak = false;

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
@@ -178,6 +178,9 @@ void OvEditor::Panels::AssetProperties::CreateAssetSelector()
 	auto& columns = CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
 	columns.widths[0] = 150;
 	m_assetSelector = &OvCore::Helpers::GUIDrawer::DrawAsset(columns, "Target", m_resource, &m_targetChanged);
+	const auto& widgets = columns.GetWidgets();
+	widgets[widgets.size() - 1].first->neverDisabled = true;
+	widgets[widgets.size() - 2].first->neverDisabled = true;
 }
 
 void OvEditor::Panels::AssetProperties::CreateSettings()

--- a/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -179,7 +179,7 @@ void OvEditor::Panels::MaterialEditor::SetTarget(OvCore::Resources::Material & p
 {
 	m_target = &p_newTarget;
 	m_targetMaterialText->content = m_target->path;
-	readonly = IsReadyOnlyMaterial(*m_target);
+	disabled = IsReadyOnlyMaterial(*m_target);
 	OnMaterialDropped();
 }
 
@@ -278,7 +278,7 @@ void OvEditor::Panels::MaterialEditor::CreateHeaderButtons()
 	};
 
 	auto& reloadButton = CreateWidget<Buttons::Button>("Reload");
-	reloadButton.neverReadonly = true;
+	reloadButton.neverDisabled = true;
 	reloadButton.tooltip = "Reload the current material from file";
 	reloadButton.lineBreak = false;
 	reloadButton.ClickedEvent += [this] {
@@ -292,7 +292,7 @@ void OvEditor::Panels::MaterialEditor::CreateHeaderButtons()
 
 	auto& compileButton = CreateWidget<Buttons::Button>("Compile");
 	m_compileShaderButton = &compileButton;
-	compileButton.neverReadonly = true;
+	compileButton.neverDisabled = true;
 	compileButton.tooltip = "Compile the shader of the current material";
 	compileButton.lineBreak = false;
 	compileButton.ClickedEvent += [this] {
@@ -323,7 +323,7 @@ void OvEditor::Panels::MaterialEditor::CreateHeaderButtons()
 	};
 
 	auto& previewButton = CreateWidget<Buttons::Button>("Preview");
-	previewButton.neverReadonly = true;
+	previewButton.neverDisabled = true;
 	previewButton.tooltip = "Preview the current material in the Asset View";
 	previewButton.lineBreak = false;
 	previewButton.ClickedEvent += std::bind(&MaterialEditor::Preview, this);
@@ -351,10 +351,12 @@ void OvEditor::Panels::MaterialEditor::CreateShaderSelector()
 void OvEditor::Panels::MaterialEditor::CreateMaterialSettings()
 {
 	m_materialPipelineState = &m_settings->CreateWidget<Layout::GroupCollapsable>("Pipeline State");
+	m_materialPipelineState->neverDisabled = true;
 	m_materialPipelineStateColumns = &m_materialPipelineState->CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
 	m_materialPipelineStateColumns->widths[0] = 150;
 
 	m_materialSettings = &m_settings->CreateWidget<Layout::GroupCollapsable>("Settings");
+	m_materialSettings->neverDisabled = true;
 	m_materialSettingsColumns = &m_materialSettings->CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
 	m_materialSettingsColumns->widths[0] = 150;
 }
@@ -362,6 +364,7 @@ void OvEditor::Panels::MaterialEditor::CreateMaterialSettings()
 void OvEditor::Panels::MaterialEditor::CreateMaterialFeatures()
 {
 	m_materialFeatures = &m_settings->CreateWidget<Layout::GroupCollapsable>("Features");
+	m_materialFeatures->neverDisabled = true;
 	m_materialFeaturesColumns = &m_materialFeatures->CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
 	m_materialFeaturesColumns->widths[0] = 150;
 }
@@ -369,6 +372,7 @@ void OvEditor::Panels::MaterialEditor::CreateMaterialFeatures()
 void OvEditor::Panels::MaterialEditor::CreateMaterialProperties()
 {
 	m_materialProperties = &m_settings->CreateWidget<Layout::GroupCollapsable>("Properties");
+	m_materialProperties->neverDisabled = true;
 	m_materialPropertiesColumns = &m_materialProperties->CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
 	m_materialPropertiesColumns->widths[0] = 150;
 }

--- a/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -4,6 +4,7 @@
 * @licence: MIT
 */
 
+#include "OvRendering/Resources/Parsers/EmbeddedAssetPath.h"
 #include <OvCore/Helpers/GUIDrawer.h>
 #include <OvCore/Resources/Loaders/MaterialLoader.h>
 
@@ -136,6 +137,13 @@ namespace
 			rgbaWidget.enabled = true;
 		};
 	}
+
+	bool IsReadyOnlyMaterial(const OvCore::Resources::Material& p_material)
+	{
+		return
+			p_material.path.starts_with(":") || // check if the material is an engine material
+			OvRendering::Resources::Parsers::ParseEmbeddedAssetPath(p_material.path).has_value();
+	}
 }
 
 OvEditor::Panels::MaterialEditor::MaterialEditor(
@@ -171,6 +179,7 @@ void OvEditor::Panels::MaterialEditor::SetTarget(OvCore::Resources::Material & p
 {
 	m_target = &p_newTarget;
 	m_targetMaterialText->content = m_target->path;
+	readonly = IsReadyOnlyMaterial(*m_target);
 	OnMaterialDropped();
 }
 

--- a/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -339,6 +339,9 @@ void OvEditor::Panels::MaterialEditor::CreateMaterialSelector()
 	auto& columns = CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
 	columns.widths[0] = 150;
 	m_targetMaterialText = &GUIDrawer::DrawMaterial(columns, "Material", m_target, &m_materialDroppedEvent);
+	const auto& widgets = columns.GetWidgets();
+	widgets[widgets.size() - 1].first->neverDisabled = true;
+	widgets[widgets.size() - 2].first->neverDisabled = true;
 }
 
 void OvEditor::Panels::MaterialEditor::CreateShaderSelector()

--- a/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -4,7 +4,6 @@
 * @licence: MIT
 */
 
-#include "OvRendering/Resources/Parsers/EmbeddedAssetPath.h"
 #include <OvCore/Helpers/GUIDrawer.h>
 #include <OvCore/Resources/Loaders/MaterialLoader.h>
 
@@ -12,6 +11,7 @@
 #include <OvEditor/Panels/AssetView.h>
 #include <OvEditor/Panels/MaterialEditor.h>
 
+#include <OvRendering/Resources/Parsers/EmbeddedAssetPath.h>
 #include <OvTools/Utils/SystemCalls.h>
 
 #include <OvUI/Widgets/Buttons/Button.h>

--- a/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -278,6 +278,7 @@ void OvEditor::Panels::MaterialEditor::CreateHeaderButtons()
 	};
 
 	auto& reloadButton = CreateWidget<Buttons::Button>("Reload");
+	reloadButton.neverReadonly = true;
 	reloadButton.tooltip = "Reload the current material from file";
 	reloadButton.lineBreak = false;
 	reloadButton.ClickedEvent += [this] {
@@ -291,6 +292,7 @@ void OvEditor::Panels::MaterialEditor::CreateHeaderButtons()
 
 	auto& compileButton = CreateWidget<Buttons::Button>("Compile");
 	m_compileShaderButton = &compileButton;
+	compileButton.neverReadonly = true;
 	compileButton.tooltip = "Compile the shader of the current material";
 	compileButton.lineBreak = false;
 	compileButton.ClickedEvent += [this] {
@@ -321,6 +323,7 @@ void OvEditor::Panels::MaterialEditor::CreateHeaderButtons()
 	};
 
 	auto& previewButton = CreateWidget<Buttons::Button>("Preview");
+	previewButton.neverReadonly = true;
 	previewButton.tooltip = "Preview the current material in the Asset View";
 	previewButton.lineBreak = false;
 	previewButton.ClickedEvent += std::bind(&MaterialEditor::Preview, this);

--- a/Sources/OvUI/include/OvUI/Internal/WidgetContainer.h
+++ b/Sources/OvUI/include/OvUI/Internal/WidgetContainer.h
@@ -59,9 +59,8 @@ namespace OvUI::Internal
 
 		/**
 		* Draw every widgets
-		* @param p_readonly Disable all widgets (can be bypassed on a per-widget basis)
 		*/
-		void DrawWidgets(bool p_readonly = false);
+		void DrawWidgets();
 
 		/**
 		* Allow the user to reverse the draw order of this widget container

--- a/Sources/OvUI/include/OvUI/Internal/WidgetContainer.h
+++ b/Sources/OvUI/include/OvUI/Internal/WidgetContainer.h
@@ -59,13 +59,14 @@ namespace OvUI::Internal
 
 		/**
 		* Draw every widgets
+		* @param p_readonly Disable all widgets (can be bypassed on a per-widget basis)
 		*/
-		void DrawWidgets();
+		void DrawWidgets(bool p_readonly = false);
 
-        /**
-        * Allow the user to reverse the draw order of this widget container
-        */
-        void ReverseDrawOrder(bool reversed = true);
+		/**
+		* Allow the user to reverse the draw order of this widget container
+		*/
+		void ReverseDrawOrder(bool reversed = true);
 
 		/**
 		* Create a widget

--- a/Sources/OvUI/include/OvUI/Panels/PanelWindow.h
+++ b/Sources/OvUI/include/OvUI/Panels/PanelWindow.h
@@ -108,7 +108,7 @@ namespace OvUI::Panels
 		OvMaths::FVector2 minSize = { 0.f, 0.f };
 		OvMaths::FVector2 maxSize = { 0.f, 0.f };
 
-		bool readonly = false;
+		bool disabled = false;
 		bool resizable = true;
 		bool closable = false;
 		bool movable = true;
@@ -130,9 +130,9 @@ namespace OvUI::Panels
 		bool m_opened = false;
 		bool m_hovered = false;
 		bool m_focused = false;
-        bool m_mustScrollToBottom = false;
-        bool m_mustScrollToTop = false;
-        bool m_scrolledToBottom = false;
-        bool m_scrolledToTop = false;
+		bool m_mustScrollToBottom = false;
+		bool m_mustScrollToTop = false;
+		bool m_scrolledToBottom = false;
+		bool m_scrolledToTop = false;
 	};
 }

--- a/Sources/OvUI/include/OvUI/Panels/PanelWindow.h
+++ b/Sources/OvUI/include/OvUI/Panels/PanelWindow.h
@@ -79,25 +79,25 @@ namespace OvUI::Panels
 		*/
 		bool IsVisible() const;
 
-        /**
-        * Scrolls to the bottom of the window
-        */
-        void ScrollToBottom();
+		/**
+		* Scrolls to the bottom of the window
+		*/
+		void ScrollToBottom();
 
-        /**
-        * Scrolls to the top of the window
-        */
-        void ScrollToTop();
+		/**
+		* Scrolls to the top of the window
+		*/
+		void ScrollToTop();
 
-        /**
-        * Returns true if the window is scrolled to the bottom
-        */
-        bool IsScrolledToBottom() const;
+		/**
+		* Returns true if the window is scrolled to the bottom
+		*/
+		bool IsScrolledToBottom() const;
 
-        /**
-        * Returns true if the window is scrolled to the bottom
-        */
-        bool IsScrolledToTop() const;
+		/**
+		* Returns true if the window is scrolled to the bottom
+		*/
+		bool IsScrolledToTop() const;
 
 	protected:
 		void _Draw_Impl() override;
@@ -108,6 +108,7 @@ namespace OvUI::Panels
 		OvMaths::FVector2 minSize = { 0.f, 0.f };
 		OvMaths::FVector2 maxSize = { 0.f, 0.f };
 
+		bool readonly = false;
 		bool resizable = true;
 		bool closable = false;
 		bool movable = true;

--- a/Sources/OvUI/include/OvUI/Widgets/AWidget.h
+++ b/Sources/OvUI/include/OvUI/Widgets/AWidget.h
@@ -78,21 +78,25 @@ namespace OvUI::Widgets
 
 	protected:
 		virtual void _Draw_Impl() = 0;
+		void BeginDisableOverride();
+		void EndDisableOverride();
 
 	public:
 		std::string tooltip;
 		bool enabled = true;
 		bool disabled = false;
 		bool lineBreak = true;
-		bool neverReadonly = false; // provide a way to bypass the "readonly" setting used by a WidgetContainer
+		bool neverDisabled = false; // provide a way to bypass the "readonly" setting used by a WidgetContainer
 
 	protected:
 		Internal::WidgetContainer* m_parent;
 		std::string m_widgetID = "?";
 		bool m_autoExecutePlugins = true;
+		bool m_skipDisableOverrideLogic = false;
 
 	private:
 		static uint64_t __WIDGET_ID_INCREMENT;
 		bool m_destroyed = false;
+		bool m_isInDisableOverrideScope = false;
 	};
 }

--- a/Sources/OvUI/include/OvUI/Widgets/AWidget.h
+++ b/Sources/OvUI/include/OvUI/Widgets/AWidget.h
@@ -84,6 +84,7 @@ namespace OvUI::Widgets
 		bool enabled = true;
 		bool disabled = false;
 		bool lineBreak = true;
+		bool neverReadonly = false; // provide a way to bypass the "readonly" setting used by a WidgetContainer
 
 	protected:
 		Internal::WidgetContainer* m_parent;

--- a/Sources/OvUI/src/OvUI/Internal/WidgetContainer.cpp
+++ b/Sources/OvUI/src/OvUI/Internal/WidgetContainer.cpp
@@ -8,6 +8,7 @@
 #include <ranges>
 
 #include "OvUI/Internal/WidgetContainer.h"
+#include "imgui.h"
 
 OvUI::Internal::WidgetContainer::~WidgetContainer()
 {
@@ -74,7 +75,7 @@ void OvUI::Internal::WidgetContainer::CollectGarbages()
 	}), m_widgets.end());
 }
 
-void OvUI::Internal::WidgetContainer::DrawWidgets()
+void OvUI::Internal::WidgetContainer::DrawWidgets(bool p_readonly)
 {
 	CollectGarbages();
 
@@ -87,18 +88,31 @@ void OvUI::Internal::WidgetContainer::DrawWidgets()
 	widgetsToDraw.reserve(m_widgets.size());
 	std::ranges::copy(m_widgets | std::views::keys, std::back_inserter(widgetsToDraw));
 
+	auto drawWidget = [p_readonly](const WidgetType& widget) {
+		if (p_readonly && !widget->neverReadonly)
+		{
+			ImGui::BeginDisabled();
+			widget->Draw();
+			ImGui::EndDisabled();
+		}
+		else
+		{
+			widget->Draw();
+		}
+	};
+
 	if (m_reversedDrawOrder) [[unlikely]]
 	{
 		for (WidgetType widget : widgetsToDraw | std::views::reverse)
 		{
-			widget->Draw();
+			drawWidget(widget);
 		}
 	}
 	else
 	{
 		for (WidgetType widget : widgetsToDraw)
 		{
-			widget->Draw();
+			drawWidget(widget);
 		}
 	}
 }

--- a/Sources/OvUI/src/OvUI/Internal/WidgetContainer.cpp
+++ b/Sources/OvUI/src/OvUI/Internal/WidgetContainer.cpp
@@ -75,7 +75,7 @@ void OvUI::Internal::WidgetContainer::CollectGarbages()
 	}), m_widgets.end());
 }
 
-void OvUI::Internal::WidgetContainer::DrawWidgets(bool p_readonly)
+void OvUI::Internal::WidgetContainer::DrawWidgets()
 {
 	CollectGarbages();
 
@@ -88,31 +88,18 @@ void OvUI::Internal::WidgetContainer::DrawWidgets(bool p_readonly)
 	widgetsToDraw.reserve(m_widgets.size());
 	std::ranges::copy(m_widgets | std::views::keys, std::back_inserter(widgetsToDraw));
 
-	auto drawWidget = [p_readonly](const WidgetType& widget) {
-		if (p_readonly && !widget->neverReadonly)
-		{
-			ImGui::BeginDisabled();
-			widget->Draw();
-			ImGui::EndDisabled();
-		}
-		else
-		{
-			widget->Draw();
-		}
-	};
-
 	if (m_reversedDrawOrder) [[unlikely]]
 	{
 		for (WidgetType widget : widgetsToDraw | std::views::reverse)
 		{
-			drawWidget(widget);
+			widget->Draw();
 		}
 	}
 	else
 	{
 		for (WidgetType widget : widgetsToDraw)
 		{
-			drawWidget(widget);
+			widget->Draw();
 		}
 	}
 }

--- a/Sources/OvUI/src/OvUI/Panels/PanelWindow.cpp
+++ b/Sources/OvUI/src/OvUI/Panels/PanelWindow.cpp
@@ -175,7 +175,18 @@ void OvUI::Panels::PanelWindow::_Draw_Impl()
 			}
 
 			ExecutePlugins(Plugins::EPluginExecutionContext::PANEL);
-			DrawWidgets(readonly);
+
+			if (disabled)
+			{
+				ImGui::BeginDisabled();
+			}
+
+			DrawWidgets();
+
+			if (disabled)
+			{
+				ImGui::EndDisabled();
+			}
 		}
 
 		ImGui::End();

--- a/Sources/OvUI/src/OvUI/Panels/PanelWindow.cpp
+++ b/Sources/OvUI/src/OvUI/Panels/PanelWindow.cpp
@@ -118,11 +118,6 @@ bool OvUI::Panels::PanelWindow::IsScrolledToTop() const
 
 void OvUI::Panels::PanelWindow::_Draw_Impl()
 {
-	if (readonly)
-	{
-		ImGui::BeginDisabled();
-	}
-
 	if (m_opened)
 	{
 		int windowFlags = ImGuiWindowFlags_None;
@@ -180,14 +175,9 @@ void OvUI::Panels::PanelWindow::_Draw_Impl()
 			}
 
 			ExecutePlugins(Plugins::EPluginExecutionContext::PANEL);
-			DrawWidgets();
+			DrawWidgets(readonly);
 		}
 
 		ImGui::End();
-	}
-
-	if (readonly)
-	{
-		ImGui::EndDisabled();
 	}
 }

--- a/Sources/OvUI/src/OvUI/Panels/PanelWindow.cpp
+++ b/Sources/OvUI/src/OvUI/Panels/PanelWindow.cpp
@@ -118,22 +118,27 @@ bool OvUI::Panels::PanelWindow::IsScrolledToTop() const
 
 void OvUI::Panels::PanelWindow::_Draw_Impl()
 {
+	if (readonly)
+	{
+		ImGui::BeginDisabled();
+	}
+
 	if (m_opened)
 	{
 		int windowFlags = ImGuiWindowFlags_None;
 
-		if (!resizable)					windowFlags |= ImGuiWindowFlags_NoResize;
-		if (!movable)					windowFlags |= ImGuiWindowFlags_NoMove;
-		if (!dockable)					windowFlags |= ImGuiWindowFlags_NoDocking;
-		if (hideBackground)				windowFlags |= ImGuiWindowFlags_NoBackground;
-		if (forceHorizontalScrollbar)	windowFlags |= ImGuiWindowFlags_AlwaysHorizontalScrollbar;
-		if (forceVerticalScrollbar)		windowFlags |= ImGuiWindowFlags_AlwaysVerticalScrollbar;
-		if (allowHorizontalScrollbar)	windowFlags |= ImGuiWindowFlags_HorizontalScrollbar;
-		if (!bringToFrontOnFocus)		windowFlags |= ImGuiWindowFlags_NoBringToFrontOnFocus;
-		if (!collapsable)				windowFlags |= ImGuiWindowFlags_NoCollapse;
-		if (!allowInputs)				windowFlags |= ImGuiWindowFlags_NoInputs;
-        if (!scrollable)                windowFlags |= ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoScrollbar;
-		if (!titleBar)					windowFlags |= ImGuiWindowFlags_NoTitleBar;
+		if (!resizable) windowFlags |= ImGuiWindowFlags_NoResize;
+		if (!movable) windowFlags |= ImGuiWindowFlags_NoMove;
+		if (!dockable) windowFlags |= ImGuiWindowFlags_NoDocking;
+		if (hideBackground) windowFlags |= ImGuiWindowFlags_NoBackground;
+		if (forceHorizontalScrollbar) windowFlags |= ImGuiWindowFlags_AlwaysHorizontalScrollbar;
+		if (forceVerticalScrollbar) windowFlags |= ImGuiWindowFlags_AlwaysVerticalScrollbar;
+		if (allowHorizontalScrollbar) windowFlags |= ImGuiWindowFlags_HorizontalScrollbar;
+		if (!bringToFrontOnFocus) windowFlags |= ImGuiWindowFlags_NoBringToFrontOnFocus;
+		if (!collapsable) windowFlags |= ImGuiWindowFlags_NoCollapse;
+		if (!allowInputs) windowFlags |= ImGuiWindowFlags_NoInputs;
+		if (!scrollable) windowFlags |= ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoScrollbar;
+		if (!titleBar) windowFlags |= ImGuiWindowFlags_NoTitleBar;
 
 		ImVec2 minSizeConstraint = Internal::Converter::ToImVec2(minSize);
 		ImVec2 maxSizeConstraint = Internal::Converter::ToImVec2(maxSize);
@@ -152,32 +157,37 @@ void OvUI::Panels::PanelWindow::_Draw_Impl()
 			m_hovered = ImGui::IsWindowHovered();
 			m_focused = ImGui::IsWindowFocused();
 
-            auto scrollY = ImGui::GetScrollY();
+			auto scrollY = ImGui::GetScrollY();
 
-            m_scrolledToBottom = scrollY == ImGui::GetScrollMaxY();
-            m_scrolledToTop = scrollY == 0.0f;
+			m_scrolledToBottom = scrollY == ImGui::GetScrollMaxY();
+			m_scrolledToTop = scrollY == 0.0f;
 
 			if (!m_opened)
 				CloseEvent.Invoke();
 
 			Update();
 
-            if (m_mustScrollToBottom)
-            {
-                ImGui::SetScrollY(ImGui::GetScrollMaxY());
-                m_mustScrollToBottom = false;
-            }
+			if (m_mustScrollToBottom)
+			{
+					ImGui::SetScrollY(ImGui::GetScrollMaxY());
+					m_mustScrollToBottom = false;
+			}
 
-            if (m_mustScrollToTop)
-            {
-                ImGui::SetScrollY(0.0f);
-                m_mustScrollToTop = false;
-            }
+			if (m_mustScrollToTop)
+			{
+					ImGui::SetScrollY(0.0f);
+					m_mustScrollToTop = false;
+			}
 
 			ExecutePlugins(Plugins::EPluginExecutionContext::PANEL);
 			DrawWidgets();
 		}
 
 		ImGui::End();
+	}
+
+	if (readonly)
+	{
+		ImGui::EndDisabled();
 	}
 }

--- a/Sources/OvUI/src/OvUI/Widgets/AWidget.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/AWidget.cpp
@@ -4,9 +4,10 @@
 * @licence: MIT
 */
 
-#include <imgui.h>
-
 #include <OvUI/Widgets/AWidget.h>
+
+#include <imgui.h>
+#include <imgui_internal.h>
 
 uint64_t OvUI::Widgets::AWidget::__WIDGET_ID_INCREMENT = 0;
 
@@ -45,6 +46,24 @@ OvUI::Internal::WidgetContainer * OvUI::Widgets::AWidget::GetParent()
 	return m_parent;
 }
 
+void OvUI::Widgets::AWidget::BeginDisableOverride()
+{
+	if (GImGui->CurrentItemFlags & ImGuiItemFlags_Disabled && neverDisabled)
+	{
+		ImGui::BeginDisabledOverrideReenable();
+		m_isInDisableOverrideScope = true;
+	}
+}
+
+void OvUI::Widgets::AWidget::EndDisableOverride()
+{
+	if (m_isInDisableOverrideScope)
+	{
+		ImGui::EndDisabledOverrideReenable();
+		m_isInDisableOverrideScope = false;
+	}
+}
+
 void OvUI::Widgets::AWidget::Draw()
 {
 	if (enabled)
@@ -53,6 +72,8 @@ void OvUI::Widgets::AWidget::Draw()
 		{
 			ImGui::BeginDisabled();
 		}
+
+		BeginDisableOverride();
 
 		_Draw_Impl();
 
@@ -63,6 +84,8 @@ void OvUI::Widgets::AWidget::Draw()
 				ImGui::SetTooltip("%s", tooltip.c_str());
 			}
 		}
+
+		EndDisableOverride();
 
 		if (disabled)
 		{

--- a/Sources/OvUI/src/OvUI/Widgets/Layout/GroupCollapsable.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/Layout/GroupCollapsable.cpp
@@ -20,6 +20,8 @@ void OvUI::Widgets::Layout::GroupCollapsable::_Draw_Impl()
 
 	bool isOpen = ImGui::CollapsingHeader(name.c_str(), closable ? &opened : nullptr, ImGuiTreeNodeFlags_DefaultOpen);
 
+	EndDisableOverride(); // Early end disable override group so that children are not affected
+
 	if (reorderable)
 	{
 		const ImVec2 headerMin = ImGui::GetItemRectMin();


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
- Added `disabled` option to `PanelWindow`
- Added an anonymous function in `MaterialEditor` to check if a material is readonly (engine material or embedded)
- Added an anonymous function in `AssetProperties` to check if an asset is readonly (engine asset)
- Added disable override capabilities to widgets, so that they can be interactable even when their parent is disabled
- Fixed "Preview" button not working for materials in asset properties

## To-Do
- [x] Make a system so widgets can ignore/bypass the read-only nature of a panel
- [x] Bug: nested widgets cannot bypass the readonly setting

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #690

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

<img width="464" height="669" alt="image" src="https://github.com/user-attachments/assets/4ec40bfc-dba2-4a7c-bcdc-c55ceaf9d671" />

_Disabled panel (embedded material in this case), with some exclusions for a few widgets (compile, reload, preview...)_

<img width="447" height="430" alt="image" src="https://github.com/user-attachments/assets/d45c0c8a-d0c6-4213-a00f-86704c1c4990" />

_Disabled asset properties for engine model_

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
