### PR TITLE
Fixed & reworked hybrid vector/color widgets

### DIFF
--- a/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
+++ b/Sources/OvCore/include/OvCore/Helpers/GUIDrawer.h
@@ -62,6 +62,8 @@ namespace OvCore::Helpers
 		static void DrawVec2(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector2& p_data, float p_step = 1.f, float p_min = _MIN_FLOAT, float p_max = _MAX_FLOAT);
 		static void DrawVec3(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector3& p_data, float p_step = 1.f, float p_min = _MIN_FLOAT, float p_max = _MAX_FLOAT);
 		static void DrawVec4(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector4& p_data, float p_step = 1.f, float p_min = _MIN_FLOAT, float p_max = _MAX_FLOAT);
+		static void DrawHybridVec3(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector3& p_data, float p_step = 1.f, float p_min = _MIN_FLOAT, float p_max = _MAX_FLOAT);
+		static void DrawHybridVec4(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector4& p_data, float p_step = 1.f, float p_min = _MIN_FLOAT, float p_max = _MAX_FLOAT);
 		static void DrawQuat(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FQuaternion& p_data, float p_step = 1.f, float p_min = _MIN_FLOAT, float p_max = _MAX_FLOAT);
 		static void DrawString(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, std::string& p_data);
 		static void DrawColor(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvUI::Types::Color& p_color, bool p_hasAlpha = false);

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -8,6 +8,8 @@
 #include <filesystem>
 #include <memory>
 
+#include <imgui.h>
+
 #include <OvTools/Utils/PathParser.h>
 
 #include <OvCore/Helpers/GUIHelpers.h>
@@ -75,79 +77,161 @@ void OvCore::Helpers::GUIDrawer::DrawVec4(OvUI::Internal::WidgetContainer & p_ro
 	dispatcher.RegisterReference(reinterpret_cast<std::array<float, 4>&>(p_data));
 }
 
-void OvCore::Helpers::GUIDrawer::DrawHybridVec3(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector3& p_data, float p_step, float p_min, float p_max)
+namespace
 {
-	CreateTitle(p_root, p_name);
+	/**
+	* A two-state segmented toggle rendered as a single unified pill.
+	* Both halves share one invisible button: clicking anywhere toggles the state.
+	* The active half is highlighted in amber; the inactive half is dark.
+	*/
+	class HybridModeToggle : public OvUI::Widgets::AWidget
+	{
+	public:
+		HybridModeToggle(std::string_view p_labelA, std::string_view p_labelB)
+			: m_labelA(p_labelA), m_labelB(p_labelB) {}
 
-	auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
-	rightSide.horizontal = true;
-	rightSide.stretchWidget = 0;
+		OvTools::Eventing::Event<bool> StateChangedEvent; // true = B (right) active
+		bool state = false;
 
-	auto& inputField = rightSide.CreateWidget<OvUI::Widgets::Layout::Group>();
-
-	auto& xyzWidget = inputField.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 3>>(GetDataType<float>(), p_min, p_max, 0.f, p_step, "", GetFormat<float>());
-	auto& xyzDispatcher = xyzWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 3>>>();
-	xyzDispatcher.RegisterReference(reinterpret_cast<std::array<float, 3>&>(p_data));
-
-	auto& rgbWidget = inputField.CreateWidget<OvUI::Widgets::Selection::ColorEdit>(false, OvUI::Types::Color{ p_data.x, p_data.y, p_data.z });
-	auto& rgbDispatcher = rgbWidget.AddPlugin<OvUI::Plugins::DataDispatcher<OvUI::Types::Color>>();
-	rgbDispatcher.RegisterGatherer([&p_data]() -> OvUI::Types::Color { return { p_data.x, p_data.y, p_data.z }; });
-	rgbDispatcher.RegisterProvider([&p_data](OvUI::Types::Color c) { p_data.x = c.r; p_data.y = c.g; p_data.z = c.b; });
-	rgbWidget.enabled = false;
-
-	auto& toggle = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZ");
-	toggle.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-	toggle.ClickedEvent += [&] {
-		if (toggle.label == "XYZ")
+	protected:
+		void _Draw_Impl() override
 		{
-			toggle.label = "RGB";
-			xyzWidget.enabled = false;
-			rgbWidget.enabled = true;
+			const float rounding = ImGui::GetStyle().FrameRounding;
+			const float padX     = ImGui::GetStyle().FramePadding.x;
+			const float padY     = ImGui::GetStyle().FramePadding.y;
+			const float height   = ImGui::GetFrameHeight();
+			const float widthA   = ImGui::CalcTextSize(m_labelA.c_str()).x + padX * 2.0f;
+			const float widthB   = ImGui::CalcTextSize(m_labelB.c_str()).x + padX * 2.0f;
+			constexpr float kSep = 1.0f;
+
+			ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ImGui::GetStyle().ItemSpacing.x);
+			const ImVec2 origin = ImGui::GetCursorScreenPos();
+			const ImVec2 posB   = { origin.x + widthA + kSep, origin.y };
+
+			// Single interaction area covering the entire pill
+			const bool clicked = ImGui::InvisibleButton(m_widgetID.c_str(), { widthA + kSep + widthB, height });
+			const bool hovered = ImGui::IsItemHovered();
+			const bool pressed = ImGui::IsItemActive();
+
+			// Color palette — fully self-contained, no theme bleed
+			static const ImVec4 kAmberIdle  = { 0.70f, 0.50f, 0.00f, 1.0f };
+			static const ImVec4 kAmberHover = { 0.80f, 0.60f, 0.00f, 1.0f };
+			static const ImVec4 kAmberPress = { 0.55f, 0.38f, 0.00f, 1.0f };
+			static const ImVec4 kDarkIdle   = { 0.18f, 0.18f, 0.18f, 1.0f };
+			static const ImVec4 kDarkHover  = { 0.26f, 0.26f, 0.26f, 1.0f };
+			static const ImVec4 kDarkPress  = { 0.12f, 0.12f, 0.12f, 1.0f };
+
+			auto resolveColor = [&](bool isActive) -> ImU32 {
+				const ImVec4& c = pressed ? (isActive ? kAmberPress : kDarkPress)
+				                : hovered ? (isActive ? kAmberHover : kDarkHover)
+				                :           (isActive ? kAmberIdle  : kDarkIdle);
+				return ImGui::ColorConvertFloat4ToU32(c);
+			};
+
+			ImDrawList* dl = ImGui::GetWindowDrawList();
+
+			// Left half — rounded left corners only
+			dl->AddRectFilled(
+				origin,
+				{ origin.x + widthA, origin.y + height },
+				resolveColor(!state),
+				rounding,
+				ImDrawFlags_RoundCornersLeft);
+
+			// Right half — rounded right corners only
+			dl->AddRectFilled(
+				posB,
+				{ posB.x + widthB, posB.y + height },
+				resolveColor(state),
+				rounding,
+				ImDrawFlags_RoundCornersRight);
+
+			// Labels (vertically centered)
+			const ImU32 textColor = ImGui::ColorConvertFloat4ToU32(ImGui::GetStyle().Colors[ImGuiCol_Text]);
+			dl->AddText({ origin.x + padX, origin.y + padY }, textColor, m_labelA.c_str());
+			dl->AddText({ posB.x   + padX, posB.y   + padY }, textColor, m_labelB.c_str());
+
+			if (clicked)
+			{
+				state = !state;
+				StateChangedEvent.Invoke(state);
+			}
+		}
+
+	private:
+		std::string m_labelA;
+		std::string m_labelB;
+	};
+
+	template <size_t N>
+	requires (N == 3 || N == 4)
+	void DrawHybridVecNImpl(
+		OvUI::Internal::WidgetContainer& p_root,
+		const std::string& p_name,
+		float* p_data,
+		float p_step,
+		float p_min,
+		float p_max)
+	{
+		using namespace OvUI::Widgets;
+		using namespace OvUI::Plugins;
+
+		constexpr auto kVecLabel   = "Vector";
+		constexpr auto kColorLabel = "Color";
+		constexpr bool kHasAlpha   = N == 4;
+
+		OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);
+
+		auto& rightSide = p_root.CreateWidget<Layout::Group>();
+		rightSide.horizontal = true;
+		rightSide.stretchWidget = 0;
+
+		// Stretch column: holds the active input widget
+		auto& inputField = rightSide.CreateWidget<Layout::Group>();
+
+		auto& vecWidget = inputField.CreateWidget<Drags::DragMultipleScalars<float, N>>(
+			OvCore::Helpers::GUIDrawer::GetDataType<float>(), p_min, p_max, 0.f, p_step, "", OvCore::Helpers::GUIDrawer::GetFormat<float>());
+		vecWidget.template AddPlugin<DataDispatcher<std::array<float, N>>>()
+			.RegisterReference(reinterpret_cast<std::array<float, N>&>(*p_data));
+
+		OvUI::Types::Color initialColor;
+		if constexpr (N == 3)
+			initialColor = { p_data[0], p_data[1], p_data[2] };
+		else
+			initialColor = { p_data[0], p_data[1], p_data[2], p_data[3] };
+
+		auto& colorWidget = inputField.CreateWidget<Selection::ColorEdit>(kHasAlpha, initialColor);
+		auto& colorDispatcher = colorWidget.AddPlugin<DataDispatcher<OvUI::Types::Color>>();
+		if constexpr (N == 3)
+		{
+			colorDispatcher.RegisterGatherer([p_data]() -> OvUI::Types::Color { return { p_data[0], p_data[1], p_data[2] }; });
+			colorDispatcher.RegisterProvider([p_data](OvUI::Types::Color c) { p_data[0] = c.r; p_data[1] = c.g; p_data[2] = c.b; });
 		}
 		else
 		{
-			toggle.label = "XYZ";
-			xyzWidget.enabled = true;
-			rgbWidget.enabled = false;
+			colorDispatcher.RegisterReference(reinterpret_cast<OvUI::Types::Color&>(*p_data));
 		}
-	};
+		colorWidget.enabled = false;
+
+		// Fixed column: unified pill toggle
+		auto& toggle = rightSide.CreateWidget<HybridModeToggle>(kVecLabel, kColorLabel);
+		toggle.tooltip = "Toggle between vector and color display";
+		toggle.neverDisabled = true;
+		toggle.StateChangedEvent += [&vecWidget, &colorWidget](bool colorMode) {
+			vecWidget.enabled   = !colorMode;
+			colorWidget.enabled =  colorMode;
+		};
+	}
+}
+
+void OvCore::Helpers::GUIDrawer::DrawHybridVec3(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector3& p_data, float p_step, float p_min, float p_max)
+{
+	DrawHybridVecNImpl<3>(p_root, p_name, &p_data.x, p_step, p_min, p_max);
 }
 
 void OvCore::Helpers::GUIDrawer::DrawHybridVec4(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector4& p_data, float p_step, float p_min, float p_max)
 {
-	CreateTitle(p_root, p_name);
-
-	auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
-	rightSide.horizontal = true;
-	rightSide.stretchWidget = 0;
-
-	auto& inputField = rightSide.CreateWidget<OvUI::Widgets::Layout::Group>();
-
-	auto& xyzwWidget = inputField.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 4>>(GetDataType<float>(), p_min, p_max, 0.f, p_step, "", GetFormat<float>());
-	auto& xyzwDispatcher = xyzwWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 4>>>();
-	xyzwDispatcher.RegisterReference(reinterpret_cast<std::array<float, 4>&>(p_data));
-
-	auto& rgbaWidget = inputField.CreateWidget<OvUI::Widgets::Selection::ColorEdit>(true, OvUI::Types::Color{ p_data.x, p_data.y, p_data.z, p_data.w });
-	auto& rgbaDispatcher = rgbaWidget.AddPlugin<OvUI::Plugins::DataDispatcher<OvUI::Types::Color>>();
-	rgbaDispatcher.RegisterReference(reinterpret_cast<OvUI::Types::Color&>(p_data));
-	rgbaWidget.enabled = false;
-
-	auto& toggle = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZW");
-	toggle.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-	toggle.ClickedEvent += [&] {
-		if (toggle.label == "XYZW")
-		{
-			toggle.label = "RGBA";
-			xyzwWidget.enabled = false;
-			rgbaWidget.enabled = true;
-		}
-		else
-		{
-			toggle.label = "XYZW";
-			xyzwWidget.enabled = true;
-			rgbaWidget.enabled = false;
-		}
-	};
+	DrawHybridVecNImpl<4>(p_root, p_name, &p_data.x, p_step, p_min, p_max);
 }
 
 void OvCore::Helpers::GUIDrawer::DrawQuat(OvUI::Internal::WidgetContainer & p_root, const std::string & p_name, OvMaths::FQuaternion & p_data, float p_step, float p_min, float p_max)

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -8,8 +8,6 @@
 #include <filesystem>
 #include <memory>
 
-#include <imgui.h>
-
 #include <OvTools/Utils/PathParser.h>
 
 #include <OvCore/Helpers/GUIHelpers.h>
@@ -25,6 +23,7 @@
 #include <OvUI/Widgets/Selection/CheckBox.h>
 #include <OvUI/Widgets/Buttons/Button.h>
 #include <OvUI/Widgets/Buttons/ButtonSmall.h>
+#include <OvUI/Widgets/Buttons/Toggle.h>
 #include <OvUI/Plugins/DDTarget.h>
 
 #include <OvCore/Global/ServiceLocator.h>
@@ -79,90 +78,6 @@ void OvCore::Helpers::GUIDrawer::DrawVec4(OvUI::Internal::WidgetContainer & p_ro
 
 namespace
 {
-	/**
-	* A two-state segmented toggle rendered as a single unified pill.
-	* Both halves share one invisible button: clicking anywhere toggles the state.
-	* The active half is highlighted in amber; the inactive half is dark.
-	*/
-	class HybridModeToggle : public OvUI::Widgets::AWidget
-	{
-	public:
-		HybridModeToggle(std::string_view p_labelA, std::string_view p_labelB)
-			: m_labelA(p_labelA), m_labelB(p_labelB) {}
-
-		OvTools::Eventing::Event<bool> StateChangedEvent; // true = B (right) active
-		bool state = false;
-
-	protected:
-		void _Draw_Impl() override
-		{
-			const float rounding = ImGui::GetStyle().FrameRounding;
-			const float padX     = ImGui::GetStyle().FramePadding.x;
-			const float padY     = ImGui::GetStyle().FramePadding.y;
-			const float height   = ImGui::GetFrameHeight();
-			const float widthA   = ImGui::CalcTextSize(m_labelA.c_str()).x + padX * 2.0f;
-			const float widthB   = ImGui::CalcTextSize(m_labelB.c_str()).x + padX * 2.0f;
-			constexpr float kSep = 1.0f;
-
-			ImGui::SetCursorPosX(ImGui::GetCursorPosX() + ImGui::GetStyle().ItemSpacing.x);
-			const ImVec2 origin = ImGui::GetCursorScreenPos();
-			const ImVec2 posB   = { origin.x + widthA + kSep, origin.y };
-
-			// Single interaction area covering the entire pill
-			const bool clicked = ImGui::InvisibleButton(m_widgetID.c_str(), { widthA + kSep + widthB, height });
-			const bool hovered = ImGui::IsItemHovered();
-			const bool pressed = ImGui::IsItemActive();
-
-			// Color palette — fully self-contained, no theme bleed
-			static const ImVec4 kAmberIdle  = { 0.70f, 0.50f, 0.00f, 1.0f };
-			static const ImVec4 kAmberHover = { 0.80f, 0.60f, 0.00f, 1.0f };
-			static const ImVec4 kAmberPress = { 0.55f, 0.38f, 0.00f, 1.0f };
-			static const ImVec4 kDarkIdle   = { 0.18f, 0.18f, 0.18f, 1.0f };
-			static const ImVec4 kDarkHover  = { 0.26f, 0.26f, 0.26f, 1.0f };
-			static const ImVec4 kDarkPress  = { 0.12f, 0.12f, 0.12f, 1.0f };
-
-			auto resolveColor = [&](bool isActive) -> ImU32 {
-				const ImVec4& c = pressed ? (isActive ? kAmberPress : kDarkPress)
-				                : hovered ? (isActive ? kAmberHover : kDarkHover)
-				                :           (isActive ? kAmberIdle  : kDarkIdle);
-				return ImGui::ColorConvertFloat4ToU32(c);
-			};
-
-			ImDrawList* dl = ImGui::GetWindowDrawList();
-
-			// Left half — rounded left corners only
-			dl->AddRectFilled(
-				origin,
-				{ origin.x + widthA, origin.y + height },
-				resolveColor(!state),
-				rounding,
-				ImDrawFlags_RoundCornersLeft);
-
-			// Right half — rounded right corners only
-			dl->AddRectFilled(
-				posB,
-				{ posB.x + widthB, posB.y + height },
-				resolveColor(state),
-				rounding,
-				ImDrawFlags_RoundCornersRight);
-
-			// Labels (vertically centered)
-			const ImU32 textColor = ImGui::ColorConvertFloat4ToU32(ImGui::GetStyle().Colors[ImGuiCol_Text]);
-			dl->AddText({ origin.x + padX, origin.y + padY }, textColor, m_labelA.c_str());
-			dl->AddText({ posB.x   + padX, posB.y   + padY }, textColor, m_labelB.c_str());
-
-			if (clicked)
-			{
-				state = !state;
-				StateChangedEvent.Invoke(state);
-			}
-		}
-
-	private:
-		std::string m_labelA;
-		std::string m_labelB;
-	};
-
 	template <size_t N>
 	requires (N == 3 || N == 4)
 	void DrawHybridVecNImpl(
@@ -176,9 +91,7 @@ namespace
 		using namespace OvUI::Widgets;
 		using namespace OvUI::Plugins;
 
-		constexpr auto kVecLabel   = "VEC";
-		constexpr auto kColorLabel = "COL";
-		constexpr bool kHasAlpha   = N == 4;
+		constexpr bool kHasAlpha = N == 4;
 
 		OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);
 
@@ -186,7 +99,6 @@ namespace
 		rightSide.horizontal = true;
 		rightSide.stretchWidget = 0;
 
-		// Stretch column: holds the active input widget
 		auto& inputField = rightSide.CreateWidget<Layout::Group>();
 
 		auto& vecWidget = inputField.CreateWidget<Drags::DragMultipleScalars<float, N>>(
@@ -213,8 +125,7 @@ namespace
 		}
 		colorWidget.enabled = false;
 
-		// Fixed column: unified pill toggle
-		auto& toggle = rightSide.CreateWidget<HybridModeToggle>(kVecLabel, kColorLabel);
+		auto& toggle = rightSide.CreateWidget<Buttons::Toggle>("VEC", "COL");
 		toggle.tooltip = "Toggle between vector and color display";
 		toggle.neverDisabled = true;
 		toggle.StateChangedEvent += [&vecWidget, &colorWidget](bool colorMode) {

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -176,8 +176,8 @@ namespace
 		using namespace OvUI::Widgets;
 		using namespace OvUI::Plugins;
 
-		constexpr auto kVecLabel   = "Vector";
-		constexpr auto kColorLabel = "Color";
+		constexpr auto kVecLabel   = "VEC";
+		constexpr auto kColorLabel = "COL";
 		constexpr bool kHasAlpha   = N == 4;
 
 		OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -75,6 +75,81 @@ void OvCore::Helpers::GUIDrawer::DrawVec4(OvUI::Internal::WidgetContainer & p_ro
 	dispatcher.RegisterReference(reinterpret_cast<std::array<float, 4>&>(p_data));
 }
 
+void OvCore::Helpers::GUIDrawer::DrawHybridVec3(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector3& p_data, float p_step, float p_min, float p_max)
+{
+	CreateTitle(p_root, p_name);
+
+	auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
+	rightSide.horizontal = true;
+	rightSide.stretchWidget = 0;
+
+	auto& inputField = rightSide.CreateWidget<OvUI::Widgets::Layout::Group>();
+
+	auto& xyzWidget = inputField.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 3>>(GetDataType<float>(), p_min, p_max, 0.f, p_step, "", GetFormat<float>());
+	auto& xyzDispatcher = xyzWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 3>>>();
+	xyzDispatcher.RegisterReference(reinterpret_cast<std::array<float, 3>&>(p_data));
+
+	auto& rgbWidget = inputField.CreateWidget<OvUI::Widgets::Selection::ColorEdit>(false, OvUI::Types::Color{ p_data.x, p_data.y, p_data.z });
+	auto& rgbDispatcher = rgbWidget.AddPlugin<OvUI::Plugins::DataDispatcher<OvUI::Types::Color>>();
+	rgbDispatcher.RegisterGatherer([&p_data]() -> OvUI::Types::Color { return { p_data.x, p_data.y, p_data.z }; });
+	rgbDispatcher.RegisterProvider([&p_data](OvUI::Types::Color c) { p_data.x = c.r; p_data.y = c.g; p_data.z = c.b; });
+	rgbWidget.enabled = false;
+
+	auto& toggle = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZ");
+	toggle.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
+	toggle.ClickedEvent += [&] {
+		if (toggle.label == "XYZ")
+		{
+			toggle.label = "RGB";
+			xyzWidget.enabled = false;
+			rgbWidget.enabled = true;
+		}
+		else
+		{
+			toggle.label = "XYZ";
+			xyzWidget.enabled = true;
+			rgbWidget.enabled = false;
+		}
+	};
+}
+
+void OvCore::Helpers::GUIDrawer::DrawHybridVec4(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector4& p_data, float p_step, float p_min, float p_max)
+{
+	CreateTitle(p_root, p_name);
+
+	auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
+	rightSide.horizontal = true;
+	rightSide.stretchWidget = 0;
+
+	auto& inputField = rightSide.CreateWidget<OvUI::Widgets::Layout::Group>();
+
+	auto& xyzwWidget = inputField.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 4>>(GetDataType<float>(), p_min, p_max, 0.f, p_step, "", GetFormat<float>());
+	auto& xyzwDispatcher = xyzwWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 4>>>();
+	xyzwDispatcher.RegisterReference(reinterpret_cast<std::array<float, 4>&>(p_data));
+
+	auto& rgbaWidget = inputField.CreateWidget<OvUI::Widgets::Selection::ColorEdit>(true, OvUI::Types::Color{ p_data.x, p_data.y, p_data.z, p_data.w });
+	auto& rgbaDispatcher = rgbaWidget.AddPlugin<OvUI::Plugins::DataDispatcher<OvUI::Types::Color>>();
+	rgbaDispatcher.RegisterReference(reinterpret_cast<OvUI::Types::Color&>(p_data));
+	rgbaWidget.enabled = false;
+
+	auto& toggle = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZW");
+	toggle.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
+	toggle.ClickedEvent += [&] {
+		if (toggle.label == "XYZW")
+		{
+			toggle.label = "RGBA";
+			xyzwWidget.enabled = false;
+			rgbaWidget.enabled = true;
+		}
+		else
+		{
+			toggle.label = "XYZW";
+			xyzwWidget.enabled = true;
+			rgbaWidget.enabled = false;
+		}
+	};
+}
+
 void OvCore::Helpers::GUIDrawer::DrawQuat(OvUI::Internal::WidgetContainer & p_root, const std::string & p_name, OvMaths::FQuaternion & p_data, float p_step, float p_min, float p_max)
 {
 	CreateTitle(p_root, p_name);

--- a/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -4,6 +4,7 @@
 * @licence: MIT
 */
 
+#include "OvUI/Widgets/Layout/Group.h"
 #include <OvCore/Helpers/GUIDrawer.h>
 #include <OvCore/Resources/Loaders/MaterialLoader.h>
 
@@ -15,12 +16,9 @@
 #include <OvTools/Utils/SystemCalls.h>
 
 #include <OvUI/Widgets/Buttons/Button.h>
-#include <OvUI/Widgets/Buttons/ButtonSmall.h>
 #include <OvUI/Widgets/Layout/Columns.h>
 #include <OvUI/Widgets/Layout/GroupCollapsable.h>
-#include <OvUI/Widgets/Selection/ColorEdit.h>
 #include <OvUI/Widgets/Selection/ComboBox.h>
-#include <OvUI/Widgets/Texts/TextColored.h>
 #include <OvUI/Widgets/Visual/Separator.h>
 
 using namespace OvUI::Panels;
@@ -66,76 +64,6 @@ namespace
 		}
 
 		return result;
-	}
-
-	void DrawHybridVec3(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector3& p_data, float p_step, float p_min, float p_max)
-	{
-		OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);
-
-		auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
-
-		auto& xyzWidget = rightSide.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 3>>(OvCore::Helpers::GUIDrawer::GetDataType<float>(), p_min, p_max, 0.f, p_step, "", OvCore::Helpers::GUIDrawer::GetFormat<float>());
-		auto& xyzDispatcher = xyzWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 3>>>();
-		xyzDispatcher.RegisterReference(reinterpret_cast<std::array<float, 3>&>(p_data));
-		xyzWidget.lineBreak = false;
-
-		auto& rgbWidget = rightSide.CreateWidget<OvUI::Widgets::Selection::ColorEdit>(false, OvUI::Types::Color{ p_data.x, p_data.y, p_data.z });
-		auto& rgbDispatcher = rgbWidget.AddPlugin<OvUI::Plugins::DataDispatcher<OvUI::Types::Color>>();
-		rgbDispatcher.RegisterReference(reinterpret_cast<OvUI::Types::Color&>(p_data));
-		rgbWidget.enabled = false;
-		rgbWidget.lineBreak = false;
-
-		auto& xyzButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZ");
-		xyzButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-		xyzButton.lineBreak = false;
-
-		auto& rgbButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("RGB");
-		rgbButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-
-		xyzButton.ClickedEvent += [&] {
-			xyzWidget.enabled = true;
-			rgbWidget.enabled = false;
-		};
-
-		rgbButton.ClickedEvent += [&] {
-			xyzWidget.enabled = false;
-			rgbWidget.enabled = true;
-		};
-	}
-
-	void DrawHybridVec4(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector4& p_data, float p_step, float p_min, float p_max)
-	{
-		OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);
-
-		auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
-
-		auto& xyzWidget = rightSide.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 4>>(OvCore::Helpers::GUIDrawer::GetDataType<float>(), p_min, p_max, 0.f, p_step, "", OvCore::Helpers::GUIDrawer::GetFormat<float>());
-		auto& xyzDispatcher = xyzWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 4>>>();
-		xyzDispatcher.RegisterReference(reinterpret_cast<std::array<float, 4>&>(p_data));
-		xyzWidget.lineBreak = false;
-
-		auto& rgbaWidget = rightSide.CreateWidget<OvUI::Widgets::Selection::ColorEdit>(true, OvUI::Types::Color{ p_data.x, p_data.y, p_data.z, p_data.w });
-		auto& rgbaDispatcher = rgbaWidget.AddPlugin<OvUI::Plugins::DataDispatcher<OvUI::Types::Color>>();
-		rgbaDispatcher.RegisterReference(reinterpret_cast<OvUI::Types::Color&>(p_data));
-		rgbaWidget.enabled = false;
-		rgbaWidget.lineBreak = false;
-
-		auto& xyzwButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZW");
-		xyzwButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-		xyzwButton.lineBreak = false;
-
-		auto& rgbaButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("RGBA");
-		rgbaButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-
-		xyzwButton.ClickedEvent += [&] {
-			xyzWidget.enabled = true;
-			rgbaWidget.enabled = false;
-		};
-
-		rgbaButton.ClickedEvent += [&] {
-			xyzWidget.enabled = false;
-			rgbaWidget.enabled = true;
-		};
 	}
 
 	bool IsReadyOnlyMaterial(const OvCore::Resources::Material& p_material)
@@ -534,11 +462,11 @@ void OvEditor::Panels::MaterialEditor::GenerateMaterialPropertiesContent()
 			}
 			else if constexpr (std::is_same_v<T, OvMaths::FVector3>)
 			{
-				DrawHybridVec3(*m_materialPropertiesColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
+				GUIDrawer::DrawHybridVec3(*m_materialPropertiesColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
 			}
 			else if constexpr (std::is_same_v<T, OvMaths::FVector4>)
 			{
-				DrawHybridVec4(*m_materialPropertiesColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
+				GUIDrawer::DrawHybridVec4(*m_materialPropertiesColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
 			}
 			else if constexpr (std::is_same_v<T, Texture*>)
 			{

--- a/Sources/OvUI/include/OvUI/Widgets/Buttons/Toggle.h
+++ b/Sources/OvUI/include/OvUI/Widgets/Buttons/Toggle.h
@@ -1,0 +1,50 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <string>
+
+#include <OvTools/Eventing/Event.h>
+
+#include <OvUI/Types/Color.h>
+#include <OvUI/Widgets/AWidget.h>
+
+namespace OvUI::Widgets::Buttons
+{
+	/**
+	* A two-state segmented toggle.
+	* Clicking anywhere toggles between state A (false) and state B (true).
+	*/
+	class Toggle : public AWidget
+	{
+	public:
+		/**
+		* Constructor
+		* @param p_labelA  Label for the first state (false)
+		* @param p_labelB  Label for the second state (true)
+		* @param p_state   Initial state (false = A active, true = B active)
+		*/
+		Toggle(const std::string& p_labelA = "A", const std::string& p_labelB = "B", bool p_state = false);
+
+	protected:
+		void _Draw_Impl() override;
+
+	public:
+		std::string labelA;
+		std::string labelB;
+		bool state = false;
+
+		Types::Color activeColor;
+		Types::Color activeHoveredColor;
+		Types::Color activePressedColor;
+		Types::Color inactiveColor;
+		Types::Color inactiveHoveredColor;
+		Types::Color inactivePressedColor;
+
+		OvTools::Eventing::Event<bool> StateChangedEvent; // true = B active
+	};
+}

--- a/Sources/OvUI/src/OvUI/Widgets/Buttons/Toggle.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/Buttons/Toggle.cpp
@@ -1,0 +1,73 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <imgui.h>
+
+#include "OvUI/Widgets/Buttons/Toggle.h"
+
+OvUI::Widgets::Buttons::Toggle::Toggle(const std::string& p_labelA, const std::string& p_labelB, bool p_state)
+	: labelA(p_labelA), labelB(p_labelB), state(p_state)
+	, activeColor          { 0.70f, 0.50f, 0.00f, 1.0f }
+	, activeHoveredColor   { 0.80f, 0.60f, 0.00f, 1.0f }
+	, activePressedColor   { 0.55f, 0.38f, 0.00f, 1.0f }
+	, inactiveColor        { 0.18f, 0.18f, 0.18f, 1.0f }
+	, inactiveHoveredColor { 0.26f, 0.26f, 0.26f, 1.0f }
+	, inactivePressedColor { 0.12f, 0.12f, 0.12f, 1.0f }
+{}
+
+void OvUI::Widgets::Buttons::Toggle::_Draw_Impl()
+{
+	const float rounding = ImGui::GetStyle().FrameRounding;
+	const float padX     = ImGui::GetStyle().FramePadding.x;
+	const float padY     = ImGui::GetStyle().FramePadding.y;
+	const float height   = ImGui::GetFrameHeight();
+	const float widthA   = ImGui::CalcTextSize(labelA.c_str()).x + padX * 2.0f;
+	const float widthB   = ImGui::CalcTextSize(labelB.c_str()).x + padX * 2.0f;
+	constexpr float kSep = 1.0f;
+
+	const ImVec2 origin = ImGui::GetCursorScreenPos();
+	const ImVec2 posB   = { origin.x + widthA + kSep, origin.y };
+
+	// Single interaction area covering the entire pill
+	const bool clicked = ImGui::InvisibleButton(m_widgetID.c_str(), { widthA + kSep + widthB, height });
+	const bool hovered = ImGui::IsItemHovered();
+	const bool pressed = ImGui::IsItemActive();
+
+	auto pickColor = [&](bool isActive) -> ImU32 {
+		const Types::Color& c = pressed ? (isActive ? activePressedColor   : inactivePressedColor)
+		                      : hovered ? (isActive ? activeHoveredColor   : inactiveHoveredColor)
+		                      :           (isActive ? activeColor          : inactiveColor);
+		return ImGui::ColorConvertFloat4ToU32({ c.r, c.g, c.b, c.a });
+	};
+
+	ImDrawList* dl = ImGui::GetWindowDrawList();
+
+	// Left half — rounded left corners only
+	dl->AddRectFilled(
+		origin,
+		{ origin.x + widthA, origin.y + height },
+		pickColor(!state),
+		rounding,
+		ImDrawFlags_RoundCornersLeft);
+
+	// Right half — rounded right corners only
+	dl->AddRectFilled(
+		posB,
+		{ posB.x + widthB, posB.y + height },
+		pickColor(state),
+		rounding,
+		ImDrawFlags_RoundCornersRight);
+
+	const ImU32 textColor = ImGui::ColorConvertFloat4ToU32(ImGui::GetStyle().Colors[ImGuiCol_Text]);
+	dl->AddText({ origin.x + padX, origin.y + padY }, textColor, labelA.c_str());
+	dl->AddText({ posB.x   + padX, posB.y   + padY }, textColor, labelB.c_str());
+
+	if (clicked)
+	{
+		state = !state;
+		StateChangedEvent.Invoke(state);
+	}
+}

--- a/Sources/OvUI/src/OvUI/Widgets/Layout/Group.cpp
+++ b/Sources/OvUI/src/OvUI/Widgets/Layout/Group.cpp
@@ -25,6 +25,9 @@ void OvUI::Widgets::Layout::Group::_Draw_Impl()
 		return;
 	}
 
+	const auto& style = ImGui::GetStyle();
+	ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, ImVec2{ style.ItemSpacing.x * 0.5f, style.CellPadding.y });
+
 	if (ImGui::BeginTable(("group" + m_widgetID).c_str(), static_cast<int>(m_widgets.size()), ImGuiTableFlags_NoSavedSettings))
 	{
 		for (size_t index = 0; index < m_widgets.size(); ++index)
@@ -56,4 +59,6 @@ void OvUI::Widgets::Layout::Group::_Draw_Impl()
 
 		ImGui::EndTable();
 	}
+
+	ImGui::PopStyleVar();
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
- Added `Toggle` widget to `OvUI`
- Re-introduced the Color/Vector buttons as a unified toggle
- Moved the custom hybrid Color/Vector drawers to `GUIDrawer` so they can be reused.
- Fixed group no padding styling leaked onto other widgets

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #718 

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

<img width="400" height="74" alt="image" src="https://github.com/user-attachments/assets/cd1af185-32a5-4146-b58c-e08d07c56938" />

## Checklist
<!-- Mark items with 'x' (no spaces around x) -->
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
