### PR TITLE
Fix FBX metallic import and inspector refresh for embedded materials on model reload

### DIFF
--- a/Sources/OvCore/src/OvCore/ResourceManagement/ModelManager.cpp
+++ b/Sources/OvCore/src/OvCore/ResourceManagement/ModelManager.cpp
@@ -11,6 +11,7 @@
 #include <OvCore/ResourceManagement/TextureManager.h>
 #include <OvRendering/Resources/Parsers/EmbeddedAssetPath.h>
 #include <OvTools/Filesystem/IniFile.h>
+#include <OvTools/Utils/PathParser.h>
 
 namespace
 {
@@ -69,11 +70,16 @@ namespace
 		TIndexParser p_parseIndex
 	)
 	{
+		const std::string normalizedModelPath = OvTools::Utils::PathParser::MakeNonWindowsStyle(p_modelPath);
+
 		for (auto& [resourcePath, resource] : p_resourceManager.GetResources())
 		{
 			(void)resource;
 			const auto embeddedAssetPath = OvRendering::Resources::Parsers::ParseEmbeddedAssetPath(resourcePath.string());
-			if (!embeddedAssetPath || embeddedAssetPath->modelPath != p_modelPath)
+			if (
+				!embeddedAssetPath ||
+				OvTools::Utils::PathParser::MakeNonWindowsStyle(embeddedAssetPath->modelPath) != normalizedModelPath
+			)
 			{
 				continue;
 			}

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -25,6 +25,7 @@
 #include <OvEditor/Core/EditorResources.h>
 #include <OvEditor/Panels/AssetBrowser.h>
 #include <OvEditor/Panels/AssetProperties.h>
+#include <OvEditor/Panels/Inspector.h>
 #include <OvEditor/Panels/MaterialEditor.h>
 #include <OvEditor/Settings/EditorSettings.h>
 
@@ -669,6 +670,8 @@ namespace
 				if (modelManager.IsResourceRegistered(resourcePath))
 				{
 					modelManager.AResourceManager::ReloadResource(resourcePath);
+					EDITOR_PANEL(OvEditor::Panels::Inspector, "Inspector").Refresh();
+					EDITOR_PANEL(OvEditor::Panels::MaterialEditor, "Material Editor").Refresh();
 				}
 			};
 

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
@@ -15,6 +15,8 @@
 #include <OvEditor/Core/EditorActions.h>
 #include <OvEditor/Panels/AssetProperties.h>
 #include <OvEditor/Panels/AssetView.h>
+#include <OvEditor/Panels/Inspector.h>
+#include <OvEditor/Panels/MaterialEditor.h>
 
 #include <OvTools/Utils/PathParser.h>
 #include <OvTools/Utils/SizeConverter.h>
@@ -386,6 +388,8 @@ void OvEditor::Panels::AssetProperties::Apply()
 		if (modelManager.IsResourceRegistered(resourcePath))
 		{
 			modelManager.AResourceManager::ReloadResource(resourcePath);
+			EDITOR_PANEL(OvEditor::Panels::Inspector, "Inspector").Refresh();
+			EDITOR_PANEL(OvEditor::Panels::MaterialEditor, "Material Editor").Refresh();
 		}
 	}
 	else if (fileType == OvTools::Utils::PathParser::EFileType::TEXTURE)

--- a/Sources/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
+++ b/Sources/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
@@ -549,14 +549,7 @@ namespace
 
 #if defined(AI_MATKEY_METALLIC_FACTOR)
 			float metallicFactor = 0.0f;
-			bool hasMetallicFactor = material->Get(AI_MATKEY_METALLIC_FACTOR, metallicFactor) == AI_SUCCESS;
-#if defined(AI_MATKEY_REFLECTIVITY)
-			if (!hasMetallicFactor)
-			{
-				// FBX can expose metallic as ReflectionFactor.
-				hasMetallicFactor = material->Get(AI_MATKEY_REFLECTIVITY, metallicFactor) == AI_SUCCESS;
-			}
-#endif
+			const bool hasMetallicFactor = material->Get(AI_MATKEY_METALLIC_FACTOR, metallicFactor) == AI_SUCCESS;
 
 			if (hasMetallicFactor)
 			{
@@ -566,6 +559,17 @@ namespace
 			{
 				embeddedMaterial.metallic = 1.0f;
 			}
+#if defined(AI_MATKEY_REFLECTIVITY)
+			else
+			{
+				float reflectivityFactor = 0.0f;
+				if (material->Get(AI_MATKEY_REFLECTIVITY, reflectivityFactor) == AI_SUCCESS && reflectivityFactor > 0.0f)
+				{
+					// FBX can expose metallic as ReflectionFactor when no metallic data is available.
+					embeddedMaterial.metallic = std::clamp(reflectivityFactor, 0.0f, 1.0f);
+				}
+			}
+#endif
 #else
 			if (embeddedMaterial.metallicTexture.has_value())
 			{

--- a/Sources/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
+++ b/Sources/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
@@ -549,7 +549,16 @@ namespace
 
 #if defined(AI_MATKEY_METALLIC_FACTOR)
 			float metallicFactor = 0.0f;
-			if (material->Get(AI_MATKEY_METALLIC_FACTOR, metallicFactor) == AI_SUCCESS)
+			bool hasMetallicFactor = material->Get(AI_MATKEY_METALLIC_FACTOR, metallicFactor) == AI_SUCCESS;
+#if defined(AI_MATKEY_REFLECTIVITY)
+			if (!hasMetallicFactor)
+			{
+				// FBX can expose metallic as ReflectionFactor.
+				hasMetallicFactor = material->Get(AI_MATKEY_REFLECTIVITY, metallicFactor) == AI_SUCCESS;
+			}
+#endif
+
+			if (hasMetallicFactor)
 			{
 				embeddedMaterial.metallic = std::clamp(metallicFactor, 0.0f, 1.0f);
 			}


### PR DESCRIPTION
## Description
This PR fixes FBX metallic import/reload behavior and improves editor refresh flow for embedded materials.

Changes included:
- Add a fallback in Assimp material parsing to read metallic from `AI_MATKEY_REFLECTIVITY` when `AI_MATKEY_METALLIC_FACTOR` is missing (common with FBX exports).
- Normalize model paths when reloading embedded resources so embedded materials/textures are reliably matched and refreshed.
- Refresh `Inspector` and `Material Editor` panels after model reload actions (Asset Browser reload and Asset Properties apply), so updated embedded material values are visible immediately without closing/reopening panels.

## Related Issue(s)
#719

## Review Guidance
1. Import an FBX model with metallic set to `0` in Blender and open one of its embedded materials.
2. Change metallic to `1` in Blender, re-export over the same FBX file.
3. In Overload, reload the model:
   - either from Asset Browser context menu (`Reload`)
   - or from Asset Properties (`Apply`) for the model.
4. Verify the embedded material metallic value updates immediately in the Material Editor/Inspector, without restarting the editor.

## Screenshots/GIFs
N/A (resource reload and inspector refresh behavior fix)

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
