### PR TITLE
Fix material editor hybrid vector/color toggles

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -79,17 +79,14 @@ namespace
 		auto& xyzWidget = rightSide.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 3>>(OvCore::Helpers::GUIDrawer::GetDataType<float>(), p_min, p_max, 0.f, p_step, "", OvCore::Helpers::GUIDrawer::GetFormat<float>());
 		auto& xyzDispatcher = xyzWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 3>>>();
 		xyzDispatcher.RegisterReference(reinterpret_cast<std::array<float, 3>&>(p_data));
-		xyzWidget.lineBreak = false;
 
 		auto& rgbWidget = rightSide.CreateWidget<OvUI::Widgets::Selection::ColorEdit>(false, OvUI::Types::Color{ p_data.x, p_data.y, p_data.z });
 		auto& rgbDispatcher = rgbWidget.AddPlugin<OvUI::Plugins::DataDispatcher<OvUI::Types::Color>>();
 		rgbDispatcher.RegisterReference(reinterpret_cast<OvUI::Types::Color&>(p_data));
 		rgbWidget.enabled = false;
-		rgbWidget.lineBreak = false;
 
 		auto& xyzButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZ");
 		xyzButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-		xyzButton.lineBreak = false;
 
 		auto& rgbButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("RGB");
 		rgbButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
@@ -118,17 +115,14 @@ namespace
 		auto& xyzWidget = rightSide.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 4>>(OvCore::Helpers::GUIDrawer::GetDataType<float>(), p_min, p_max, 0.f, p_step, "", OvCore::Helpers::GUIDrawer::GetFormat<float>());
 		auto& xyzDispatcher = xyzWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 4>>>();
 		xyzDispatcher.RegisterReference(reinterpret_cast<std::array<float, 4>&>(p_data));
-		xyzWidget.lineBreak = false;
 
 		auto& rgbaWidget = rightSide.CreateWidget<OvUI::Widgets::Selection::ColorEdit>(true, OvUI::Types::Color{ p_data.x, p_data.y, p_data.z, p_data.w });
 		auto& rgbaDispatcher = rgbaWidget.AddPlugin<OvUI::Plugins::DataDispatcher<OvUI::Types::Color>>();
 		rgbaDispatcher.RegisterReference(reinterpret_cast<OvUI::Types::Color&>(p_data));
 		rgbaWidget.enabled = false;
-		rgbaWidget.lineBreak = false;
 
 		auto& xyzwButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZW");
 		xyzwButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-		xyzwButton.lineBreak = false;
 
 		auto& rgbaButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("RGBA");
 		rgbaButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };

--- a/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -73,6 +73,8 @@ namespace
 		OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);
 
 		auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
+		rightSide.horizontal = true;
+		rightSide.stretchWidget = 0;
 
 		auto& xyzWidget = rightSide.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 3>>(OvCore::Helpers::GUIDrawer::GetDataType<float>(), p_min, p_max, 0.f, p_step, "", OvCore::Helpers::GUIDrawer::GetFormat<float>());
 		auto& xyzDispatcher = xyzWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 3>>>();
@@ -95,11 +97,13 @@ namespace
 		xyzButton.ClickedEvent += [&] {
 			xyzWidget.enabled = true;
 			rgbWidget.enabled = false;
+			rightSide.stretchWidget = 0;
 		};
 
 		rgbButton.ClickedEvent += [&] {
 			xyzWidget.enabled = false;
 			rgbWidget.enabled = true;
+			rightSide.stretchWidget = 1;
 		};
 	}
 
@@ -108,6 +112,8 @@ namespace
 		OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);
 
 		auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
+		rightSide.horizontal = true;
+		rightSide.stretchWidget = 0;
 
 		auto& xyzWidget = rightSide.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 4>>(OvCore::Helpers::GUIDrawer::GetDataType<float>(), p_min, p_max, 0.f, p_step, "", OvCore::Helpers::GUIDrawer::GetFormat<float>());
 		auto& xyzDispatcher = xyzWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 4>>>();
@@ -130,11 +136,13 @@ namespace
 		xyzwButton.ClickedEvent += [&] {
 			xyzWidget.enabled = true;
 			rgbaWidget.enabled = false;
+			rightSide.stretchWidget = 0;
 		};
 
 		rgbaButton.ClickedEvent += [&] {
 			xyzWidget.enabled = false;
 			rgbaWidget.enabled = true;
+			rightSide.stretchWidget = 1;
 		};
 	}
 

--- a/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -17,6 +17,7 @@
 #include <OvUI/Widgets/Buttons/Button.h>
 #include <OvUI/Widgets/Buttons/ButtonSmall.h>
 #include <OvUI/Widgets/Layout/Columns.h>
+#include <OvUI/Widgets/Layout/Dummy.h>
 #include <OvUI/Widgets/Layout/GroupCollapsable.h>
 #include <OvUI/Widgets/Selection/ColorEdit.h>
 #include <OvUI/Widgets/Selection/ComboBox.h>
@@ -88,6 +89,8 @@ namespace
 		auto& xyzButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZ");
 		xyzButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
 
+		rightSide.CreateWidget<OvUI::Widgets::Layout::Dummy>(OvMaths::FVector2{ 4.0f, 0.0f });
+
 		auto& rgbButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("RGB");
 		rgbButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
 
@@ -123,6 +126,8 @@ namespace
 
 		auto& xyzwButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZW");
 		xyzwButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
+
+		rightSide.CreateWidget<OvUI::Widgets::Layout::Dummy>(OvMaths::FVector2{ 4.0f, 0.0f });
 
 		auto& rgbaButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("RGBA");
 		rgbaButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };


### PR DESCRIPTION
## Description
This PR fixes a regression in the Material Editor where hybrid vector/color controls lost their toggle visibility after recent UI layout changes.

Changes included:
- Restored proper visibility/placement of hybrid toggles for vec3 and vec4 material properties in `MaterialEditor`.
- Ensured the active widget (vector or color) keeps the expected layout behavior when toggling.
- Removed redundant `lineBreak` assignments in the same hybrid controls to keep the implementation clean and local.

## Related Issue(s)
#718

## Review Guidance
Please focus review on:
- `Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp`
- Hybrid vec3/vec4 rows in Material Editor properties (e.g. Albedo and any vec3/vec4 uniform)
- Toggle visibility and switching behavior between vector and color display modes

## Screenshots/GIFs
See issue #718 for before/after screenshots and reproduction context.

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
