### PR TITLE
Fix material editor widgets not updating after shader compilation from asset browser

### DIFF
--- a/Sources/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <filesystem>
+
 #include <OvCore/Global/ServiceLocator.h>
 #include <OvEditor/Core/Context.h>
 #include <OvEditor/Core/PanelsManager.h>
@@ -264,6 +266,11 @@ namespace OvEditor::Core
 		* Compile the given shader
 		*/
 		void CompileShader(OvRendering::Resources::Shader& p_shader);
+
+		/**
+		* Compile the shader at the given resource path
+		*/
+		void CompileShader(const std::filesystem::path& p_shaderPath);
 
 		/**
 		* Save every materials to their respective files

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -69,7 +69,7 @@ namespace
 
 	void RefreshMaterialEditorIfTargetUsesShader(OvRendering::Resources::Shader& p_shader)
 	{
-		auto& materialEditor = EDITOR_PANEL(Panels::MaterialEditor, "Material Editor");
+		auto& materialEditor = EDITOR_PANEL(OvEditor::Panels::MaterialEditor, "Material Editor");
 
 		if (auto* targetMaterial = materialEditor.GetTarget(); targetMaterial && targetMaterial->GetShader() == &p_shader)
 		{

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -53,6 +53,30 @@ namespace
 {
 	constexpr std::string_view kDefaultMaterialPath = ":Materials\\Default.ovmat";
 
+	void RefreshMaterialsUsingShader(
+		OvCore::ResourceManagement::MaterialManager& p_materialManager,
+		OvRendering::Resources::Shader& p_shader
+	)
+	{
+		for (const auto material : p_materialManager.GetResources() | std::views::values)
+		{
+			if (material && material->GetShader() == &p_shader)
+			{
+				material->UpdateProperties();
+			}
+		}
+	}
+
+	void RefreshMaterialEditorIfTargetUsesShader(OvRendering::Resources::Shader& p_shader)
+	{
+		auto& materialEditor = EDITOR_PANEL(Panels::MaterialEditor, "Material Editor");
+
+		if (auto* targetMaterial = materialEditor.GetTarget(); targetMaterial && targetMaterial->GetShader() == &p_shader)
+		{
+			materialEditor.Refresh();
+		}
+	}
+
 	template<typename TResourceManager, typename TAssetNameValidator>
 	void MoveEmbeddedResourcesForRenamedModel(
 		TResourceManager& p_resourceManager,
@@ -829,11 +853,19 @@ void OvEditor::Core::EditorActions::CompileShaders()
 {
 	for (const auto shader : m_context.shaderManager.GetResources() | std::views::values)
 	{
-		CompileShader(*shader);
+		if (shader)
+		{
+			CompileShader(shader->path);
+		}
 	}
 }
 
 void OvEditor::Core::EditorActions::CompileShader(OvRendering::Resources::Shader& p_shader)
+{
+	CompileShader(p_shader.path);
+}
+
+void OvEditor::Core::EditorActions::CompileShader(const std::filesystem::path& p_shaderPath)
 {
 	using namespace OvRendering::Resources::Loaders;
 
@@ -841,10 +873,29 @@ void OvEditor::Core::EditorActions::CompileShader(OvRendering::Resources::Shader
 	auto newLoggingSettings = previousLoggingSettings;
 	newLoggingSettings.summary = true; // Force enable summary logging
 	ShaderLoader::SetLoggingSettings(newLoggingSettings);
+	OvRendering::Resources::Shader* compiledShader = nullptr;
 
-	m_context.shaderManager.ReloadResource(&p_shader, GetRealPath(p_shader.path));
+	if (m_context.shaderManager.IsResourceRegistered(p_shaderPath))
+	{
+		compiledShader = m_context.shaderManager[p_shaderPath];
+
+		if (compiledShader)
+		{
+			m_context.shaderManager.ReloadResource(compiledShader, GetRealPath(compiledShader->path));
+		}
+	}
+	else
+	{
+		compiledShader = m_context.shaderManager.LoadResource(p_shaderPath);
+	}
 
 	ShaderLoader::SetLoggingSettings(previousLoggingSettings);
+
+	if (compiledShader)
+	{
+		RefreshMaterialsUsingShader(m_context.materialManager, *compiledShader);
+		RefreshMaterialEditorIfTargetUsesShader(*compiledShader);
+	}
 }
 
 void OvEditor::Core::EditorActions::SaveMaterials()

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -594,36 +594,8 @@ namespace
 			auto& compileAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Compile");
 
 			compileAction.ClickedEvent += [this] {
-				using namespace OvRendering::Resources::Loaders;
-				auto& shaderManager = OVSERVICE(OvCore::ResourceManagement::ShaderManager);
 				const std::string resourcePath = EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected));
-				const auto previousLoggingSettings = ShaderLoader::GetLoggingSettings();
-				auto newLoggingSettings = previousLoggingSettings;
-				newLoggingSettings.summary = true; // Force enable summary logging
-				ShaderLoader::SetLoggingSettings(newLoggingSettings);
-				OvRendering::Resources::Shader* compiledShader = nullptr;
-
-				if (shaderManager.IsResourceRegistered(resourcePath))
-				{
-					// Trying to recompile
-					compiledShader = shaderManager[resourcePath];
-					shaderManager.ReloadResource(compiledShader, filePath.string());
-				}
-				else
-				{
-					// Trying to compile
-					compiledShader = shaderManager.LoadResource(resourcePath);
-				}
-
-				ShaderLoader::SetLoggingSettings(previousLoggingSettings);
-
-				auto& materialEditor = EDITOR_PANEL(OvEditor::Panels::MaterialEditor, "Material Editor");
-				if (auto* targetMaterial = materialEditor.GetTarget(); targetMaterial && compiledShader && targetMaterial->GetShader() == compiledShader)
-				{
-					targetMaterial->UpdateProperties();
-					materialEditor.Refresh();
-				}
-
+				EDITOR_EXEC(CompileShader(resourcePath));
 			};
 		}
 	};

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -617,6 +617,13 @@ namespace
 
 				ShaderLoader::SetLoggingSettings(previousLoggingSettings);
 
+				auto& materialEditor = EDITOR_PANEL(OvEditor::Panels::MaterialEditor, "Material Editor");
+				if (auto* targetMaterial = materialEditor.GetTarget(); targetMaterial && compiledShader && targetMaterial->GetShader() == compiledShader)
+				{
+					targetMaterial->UpdateProperties();
+					materialEditor.Refresh();
+				}
+
 			};
 		}
 	};

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -601,19 +601,22 @@ namespace
 				auto newLoggingSettings = previousLoggingSettings;
 				newLoggingSettings.summary = true; // Force enable summary logging
 				ShaderLoader::SetLoggingSettings(newLoggingSettings);
+				OvRendering::Resources::Shader* compiledShader = nullptr;
 
 				if (shaderManager.IsResourceRegistered(resourcePath))
 				{
 					// Trying to recompile
-					shaderManager.ReloadResource(shaderManager[resourcePath], filePath.string());
+					compiledShader = shaderManager[resourcePath];
+					shaderManager.ReloadResource(compiledShader, filePath.string());
 				}
 				else
 				{
 					// Trying to compile
-					OVSERVICE(OvCore::ResourceManagement::ShaderManager).LoadResource(resourcePath);
+					compiledShader = shaderManager.LoadResource(resourcePath);
 				}
 
 				ShaderLoader::SetLoggingSettings(previousLoggingSettings);
+
 			};
 		}
 	};

--- a/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -301,8 +301,6 @@ void OvEditor::Panels::MaterialEditor::CreateHeaderButtons()
 			if (const auto shader = m_target->GetShader())
 			{
 				EDITOR_EXEC(CompileShader(*shader));
-				m_target->UpdateProperties();
-				OnShaderDropped();
 			}
 		}
 	};


### PR DESCRIPTION
## Description
The material editor currently regenerates shader uniforms/features when selecting a material or changing its shader, but not when compiling that shader from the Asset Browser contextual menu.

This PR updates the shader contextual compile flow to:
- keep a reference to the shader that was just compiled/reloaded
- refresh the Material Editor only when its current target material uses that compiled shader
- force a property update before refresh so newly added uniforms/features appear immediately

This fixes the missing UI update while keeping the behavior scoped and minimal.

## Related Issue(s)
Fixes #471

## Review Guidance
1. Open a material in Material Editor.
2. Add a new feature in its shader (e.g. `#feature FOO`).
3. Compile the shader from the Asset Browser contextual menu.
4. Verify the Material Editor updates immediately (features/properties regenerated).

## Screenshots/GIFs
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
