### PR TITLE
Fix embedded roughness texture loading for FBX materials

### DIFF
--- a/Sources/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
+++ b/Sources/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
@@ -46,7 +46,8 @@ namespace
 	};
 
 	constexpr std::array kRoughnessTextureTypes{
-		aiTextureType_DIFFUSE_ROUGHNESS
+		aiTextureType_DIFFUSE_ROUGHNESS,
+		aiTextureType_SHININESS
 	};
 
 	constexpr std::array kAmbientOcclusionTextureTypes{


### PR DESCRIPTION
## Description
Fixes embedded roughness texture detection for imported materials when Assimp exposes roughness maps as `aiTextureType_SHININESS` (common FBX case).

The change is minimal and localized:
- Added `aiTextureType_SHININESS` as a fallback in roughness texture lookup.
- Kept existing behavior unchanged otherwise.
- Preserved current material logic where roughness is set to `1.0` when a roughness map is found.

## Related Issue(s)
Fixes #726

## Review Guidance
Please focus review on:
- `Sources/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp`
- `kRoughnessTextureTypes` now includes `aiTextureType_SHININESS` fallback.
- Repro from issue #726 (Goblet asset): roughness map should now be detected and bound for embedded material import.

## Screenshots/GIFs
N/A (import/parser fix, no UI workflow change)

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
