### PR TITLE
Add actor copy/paste workflow in Hierarchy and Scene View

### DIFF
--- a/Sources/OvEditor/include/OvEditor/Core/Context.h
+++ b/Sources/OvEditor/include/OvEditor/Core/Context.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
+#include <variant>
 
 #include <OvAudio/Core/AudioEngine.h>
 #include <OvCore/ResourceManagement/MaterialManager.h>
@@ -35,6 +37,13 @@ namespace OvEditor::Core
 	class Context
 	{
 	public:
+		struct ActorCopyBuffer
+		{
+			uint64_t guid = 0;
+		};
+
+		using CopyBuffer = std::variant<std::monostate, ActorCopyBuffer>;
+
 		/**
 		* Constructor
 		* @param p_projectFolder (including the .ovproject file)
@@ -92,5 +101,7 @@ namespace OvEditor::Core
 		OvWindowing::Settings::WindowSettings windowSettings;
 
 		OvTools::Filesystem::IniFile projectSettings;
+
+		CopyBuffer copyBuffer;
 	};
 }

--- a/Sources/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -229,6 +229,18 @@ namespace OvEditor::Core
 
 		#pragma region ACTOR_MANIPULATION
 		/**
+		* Copy the given actor in the editor copy buffer
+		* @param p_actor
+		*/
+		void CopyActor(OvCore::ECS::Actor& p_actor);
+
+		/**
+		* Paste the copied actor, optionally as a child of the given parent
+		* @param p_parent
+		*/
+		void PasteActor(OvCore::ECS::Actor* p_parent = nullptr);
+
+		/**
 		* Select an actor and show him in inspector
 		* @param p_target
 		*/

--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -206,10 +206,39 @@ void OvEditor::Core::Editor::Update(float p_deltaTime)
 
 void OvEditor::Core::Editor::HandleGlobalShortcuts()
 {
+	auto& sceneView = EDITOR_PANEL(SceneView, "Scene View");
+	auto& hierarchy = EDITOR_PANEL(Hierarchy, "Hierarchy");
+	const bool isSceneViewFocused = sceneView.IsFocused();
+	const bool isHierarchyFocused = hierarchy.IsFocused();
+
 	// If the [Del] key is pressed while an actor is selected and the Scene View or Hierarchy is focused
-	if (m_context.inputManager->IsKeyPressed(OvWindowing::Inputs::EKey::KEY_DELETE) && EDITOR_EXEC(IsAnyActorSelected()) && (EDITOR_PANEL(SceneView, "Scene View").IsFocused() || EDITOR_PANEL(Hierarchy, "Hierarchy").IsFocused()))
+	if (m_context.inputManager->IsKeyPressed(OvWindowing::Inputs::EKey::KEY_DELETE) && EDITOR_EXEC(IsAnyActorSelected()) && (isSceneViewFocused || isHierarchyFocused))
 	{
 		EDITOR_EXEC(DestroyActor(EDITOR_EXEC(GetSelectedActor())));
+	}
+
+	const bool isControlPressed =
+		m_context.inputManager->GetKeyState(OvWindowing::Inputs::EKey::KEY_LEFT_CONTROL) == OvWindowing::Inputs::EKeyState::KEY_DOWN ||
+		m_context.inputManager->GetKeyState(OvWindowing::Inputs::EKey::KEY_RIGHT_CONTROL) == OvWindowing::Inputs::EKeyState::KEY_DOWN;
+
+	if (isControlPressed && (isSceneViewFocused || isHierarchyFocused))
+	{
+		if (m_context.inputManager->IsKeyPressed(OvWindowing::Inputs::EKey::KEY_C) && EDITOR_EXEC(IsAnyActorSelected()))
+		{
+			EDITOR_EXEC(CopyActor(EDITOR_EXEC(GetSelectedActor())));
+		}
+
+		if (m_context.inputManager->IsKeyPressed(OvWindowing::Inputs::EKey::KEY_V))
+		{
+			OvCore::ECS::Actor* parent = nullptr;
+
+			if (EDITOR_EXEC(IsAnyActorSelected()))
+			{
+				parent = &EDITOR_EXEC(GetSelectedActor());
+			}
+
+			EDITOR_EXEC(PasteActor(parent));
+		}
 	}
 }
 

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -800,30 +800,69 @@ void OvEditor::Core::EditorActions::DuplicateActor(OvCore::ECS::Actor & p_toDupl
 	
 	newActor.SetID(idToUse);
 	newActor.SetGUID(guidToUse);
+	auto currentScene = m_context.sceneManager.GetCurrentScene();
 
 	if (p_forcedParent)
-		newActor.SetParent(*p_forcedParent);
-	else
 	{
-        auto currentScene = m_context.sceneManager.GetCurrentScene();
+		newActor.SetParent(*p_forcedParent);
+	}
+	else if (newActor.GetParentID() > 0)
+	{
+		if (auto found = currentScene->FindActorByID(newActor.GetParentID()); found)
+		{
+			newActor.SetParent(*found);
+		}
+	}
 
-        if (newActor.GetParentID() > 0)
-        {
-            if (auto found = currentScene->FindActorByID(newActor.GetParentID()); found)
-            {
-                newActor.SetParent(*found);
-            }
-        }
-
-        const auto uniqueName = FindDuplicatedActorUniqueName(p_toDuplicate, newActor, *currentScene);
-        newActor.SetName(uniqueName);
+	if (p_focus || !p_forcedParent)
+	{
+		const auto uniqueName = FindDuplicatedActorUniqueName(p_toDuplicate, newActor, *currentScene);
+		newActor.SetName(uniqueName);
 	}
 
 	if (p_focus)
+	{
 		SelectActor(newActor);
+	}
 
 	for (auto& child : p_toDuplicate.GetChildren())
 		DuplicateActor(*child, &newActor, false);
+}
+
+void OvEditor::Core::EditorActions::CopyActor(OvCore::ECS::Actor& p_actor)
+{
+	m_context.copyBuffer = Context::ActorCopyBuffer{
+		.guid = p_actor.GetGUID()
+	};
+}
+
+void OvEditor::Core::EditorActions::PasteActor(OvCore::ECS::Actor* p_parent)
+{
+	const auto actorCopyBuffer = std::get_if<Context::ActorCopyBuffer>(&m_context.copyBuffer);
+	if (!actorCopyBuffer)
+	{
+		return;
+	}
+
+	const auto currentScene = m_context.sceneManager.GetCurrentScene();
+	if (!currentScene)
+	{
+		return;
+	}
+
+	if (const auto copiedActor = currentScene->FindActorByGUID(actorCopyBuffer->guid))
+	{
+		auto* destinationParent = p_parent;
+
+		// Pasting on the copied actor itself falls back to its current parent,
+		// preserving the "duplicate-like" behavior by default.
+		if (destinationParent && destinationParent->GetGUID() == copiedActor->GetGUID())
+		{
+			destinationParent = copiedActor->GetParent();
+		}
+
+		DuplicateActor(*copiedActor, destinationParent, true);
+	}
 }
 
 void OvEditor::Core::EditorActions::SelectActor(OvCore::ECS::Actor& p_target)

--- a/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -55,10 +55,22 @@ public:
 				EDITOR_EXEC(MoveToTarget(*m_target));
 			};
 
+			auto& copyButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Copy");
+			copyButton.ClickedEvent += [this]
+			{
+				EDITOR_EXEC(CopyActor(*m_target));
+			};
+
 			auto& duplicateButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Duplicate");
 			duplicateButton.ClickedEvent += [this]
 			{
 				EDITOR_EXEC(DelayAction(EDITOR_BIND(DuplicateActor, std::ref(*m_target), nullptr, true), 0));
+			};
+
+			auto& pasteButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Paste");
+			pasteButton.ClickedEvent += [this]
+			{
+				EDITOR_EXEC(DelayAction(EDITOR_BIND(PasteActor, m_target), 0));
 			};
 
 			auto& deleteButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Delete");
@@ -80,6 +92,14 @@ public:
 			nameEditor.EnterPressedEvent += [this](std::string p_newName)
 			{
 				m_target->SetName(p_newName);
+			};
+		}
+		else
+		{
+			auto& pasteButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Paste");
+			pasteButton.ClickedEvent += [this]
+			{
+				EDITOR_EXEC(DelayAction(EDITOR_BIND(PasteActor, nullptr), 0));
 			};
 		}
 


### PR DESCRIPTION
## Description
Implemented actor copy/paste workflow in the editor for both Hierarchy and Scene View.

Main changes:
- Added an editor copy buffer in the context storing copied actor data (GUID-based).
- Added `CopyActor` and `PasteActor` actions in `EditorActions`.
- Added `CTRL + C` / `CTRL + V` global shortcuts when Hierarchy or Scene View is focused.
- Added `Copy` / `Paste` entries in Hierarchy contextual menus:
  - On actor node: copy actor / paste under actor
  - On panel background: paste at root level
- Kept actor duplication behavior aligned with existing duplication logic (unique naming and hierarchy handling).

## Related Issue(s)
Fixes #732

## Review Guidance
Please validate the following flows:
1. Focus Hierarchy or Scene View, select an actor, press `CTRL + C` then `CTRL + V`:
   - A duplicate is created with a unique name.
2. In Hierarchy, copy actor A, select actor B, then `CTRL + V`:
   - A is pasted as a child of B.
3. In Hierarchy contextual menu:
   - `Copy` and `Paste` work on actor nodes.
   - `Paste` works on empty-space menu (root paste).
4. If no actor is copied (or copied GUID no longer exists), paste is a safe no-op.

## Screenshots/GIFs
N/A (input workflow update only)

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
