### PR TITLE
Avoid off-white albedo factor when albedo map is present

### DIFF
--- a/Sources/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
+++ b/Sources/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
@@ -530,7 +530,7 @@ namespace
 				embeddedMaterial.albedo.z = ToPerceptualColor(albedoColor.b);
 				embeddedMaterial.albedo.w = std::clamp(albedoColor.a, 0.0f, 1.0f);
 			}
-			else
+			else if (!embeddedMaterial.albedoTexture.has_value())
 			{
 				aiColor3D diffuseColor{};
 				if (material->Get(AI_MATKEY_COLOR_DIFFUSE, diffuseColor) == AI_SUCCESS)


### PR DESCRIPTION
## Description
This PR fixes embedded material import when an albedo texture is present.

Before this change, `AI_MATKEY_COLOR_DIFFUSE` could still be used as fallback and tint the albedo factor to an off-white value, which darkened textured materials.

The importer logic now keeps the following priority:
1. Use `AI_MATKEY_BASE_COLOR` when available.
2. If no base color is available, only use `AI_MATKEY_COLOR_DIFFUSE` when no albedo texture is bound.

This keeps textured materials neutral by default while preserving diffuse fallback for non-textured materials.

## Related Issue(s)
Fixes #727

## Review Guidance
Please review:
- `Sources/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp`
- the albedo color extraction logic in `ProcessMaterials`

Validation:
1. Import Goblet or Sponza and open an embedded material with an albedo map.
2. Confirm albedo map is bound and albedo factor is no longer off-white.
3. Non-regression: materials without albedo texture should still use diffuse fallback.

## Screenshots/GIFs
N/A (importer logic change only)

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors