### PR TITLE
Prevent intermittent crash when closing OvEditor

### DIFF
--- a/Sources/OvAudio/include/OvAudio/Core/AudioEngine.h
+++ b/Sources/OvAudio/include/OvAudio/Core/AudioEngine.h
@@ -116,6 +116,10 @@ namespace OvAudio::Core
 		std::vector<std::reference_wrapper<Entities::AudioSource>> m_audioSources;
 		std::vector<std::reference_wrapper<Entities::AudioSource>> m_suspendedAudioSources;
 		std::vector<std::reference_wrapper<Entities::AudioListener>> m_audioListeners;
+		std::optional<OvTools::Eventing::ListenerID> m_audioSourceCreatedListenerID;
+		std::optional<OvTools::Eventing::ListenerID> m_audioSourceDestroyedListenerID;
+		std::optional<OvTools::Eventing::ListenerID> m_audioListenerCreatedListenerID;
+		std::optional<OvTools::Eventing::ListenerID> m_audioListenerDestroyedListenerID;
 
 		std::unique_ptr<SoLoud::Soloud> m_backend;
 	};

--- a/Sources/OvAudio/src/OvAudio/Core/AudioEngine.cpp
+++ b/Sources/OvAudio/src/OvAudio/Core/AudioEngine.cpp
@@ -30,14 +30,38 @@ OvAudio::Core::AudioEngine::AudioEngine()
 	using AudioSourceReceiver = void(AudioEngine::*)(OvAudio::Entities::AudioSource&);
 	using AudioListenerReceiver = void(AudioEngine::*)(OvAudio::Entities::AudioListener&);
 
-	Entities::AudioSource::CreatedEvent += std::bind(static_cast<AudioSourceReceiver>(&AudioEngine::Consider), this, std::placeholders::_1);
-	Entities::AudioSource::DestroyedEvent += std::bind(static_cast<AudioSourceReceiver>(&AudioEngine::Unconsider), this, std::placeholders::_1);
-	Entities::AudioListener::CreatedEvent += std::bind(static_cast<AudioListenerReceiver>(&AudioEngine::Consider), this, std::placeholders::_1);
-	Entities::AudioListener::DestroyedEvent += std::bind(static_cast<AudioListenerReceiver>(&AudioEngine::Unconsider), this, std::placeholders::_1);
+	m_audioSourceCreatedListenerID = Entities::AudioSource::CreatedEvent +=
+		std::bind(static_cast<AudioSourceReceiver>(&AudioEngine::Consider), this, std::placeholders::_1);
+	m_audioSourceDestroyedListenerID = Entities::AudioSource::DestroyedEvent +=
+		std::bind(static_cast<AudioSourceReceiver>(&AudioEngine::Unconsider), this, std::placeholders::_1);
+	m_audioListenerCreatedListenerID = Entities::AudioListener::CreatedEvent +=
+		std::bind(static_cast<AudioListenerReceiver>(&AudioEngine::Consider), this, std::placeholders::_1);
+	m_audioListenerDestroyedListenerID = Entities::AudioListener::DestroyedEvent +=
+		std::bind(static_cast<AudioListenerReceiver>(&AudioEngine::Unconsider), this, std::placeholders::_1);
 }
 
 OvAudio::Core::AudioEngine::~AudioEngine()
 {
+	if (m_audioSourceCreatedListenerID.has_value())
+	{
+		Entities::AudioSource::CreatedEvent.RemoveListener(m_audioSourceCreatedListenerID.value());
+	}
+
+	if (m_audioSourceDestroyedListenerID.has_value())
+	{
+		Entities::AudioSource::DestroyedEvent.RemoveListener(m_audioSourceDestroyedListenerID.value());
+	}
+
+	if (m_audioListenerCreatedListenerID.has_value())
+	{
+		Entities::AudioListener::CreatedEvent.RemoveListener(m_audioListenerCreatedListenerID.value());
+	}
+
+	if (m_audioListenerDestroyedListenerID.has_value())
+	{
+		Entities::AudioListener::DestroyedEvent.RemoveListener(m_audioListenerDestroyedListenerID.value());
+	}
+
 	if (IsValid())
 	{
 		m_backend->deinit();


### PR DESCRIPTION
## Description
Fixes an intermittent crash when closing OvEditor by making AudioEngine properly unsubscribe from static audio entity events during shutdown.

Root cause:
- `AudioEngine` subscribed to static `AudioSource` / `AudioListener` events but never removed those listeners.
- During teardown, stale callbacks could target a destroyed `AudioEngine`, causing undefined behavior/crash.

What changed:
- Stored listener IDs for:
  - `AudioSource::CreatedEvent`
  - `AudioSource::DestroyedEvent`
  - `AudioListener::CreatedEvent`
  - `AudioListener::DestroyedEvent`
- Explicitly removed those listeners in `AudioEngine` destructor before backend deinit.

Scope:
- Minimal and local changes only in `OvAudio/Core/AudioEngine.*`.
- No API change, no behavior change outside shutdown safety.

## Related Issue(s)
Fixes #731

## Review Guidance
Please review destruction/lifecycle order in `AudioEngine`:
- Event subscriptions are now tracked by ID.
- Event unsubscriptions happen in `~AudioEngine()` before `m_backend->deinit()`.

Files changed:
- `Sources/OvAudio/include/OvAudio/Core/AudioEngine.h`
- `Sources/OvAudio/src/OvAudio/Core/AudioEngine.cpp`

## Screenshots/GIFs
N/A (no UI change)

## Checklist
- [x] My code follows the project's code style guidelines
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
