### PR TITLE
Handle Scripts migration when Assets/Scripts already exists

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -1166,6 +1166,18 @@ void OvEditor::Core::EditorActions::MigrateScripts()
 	}
 
 	const auto targetPath = m_context.projectAssetsPath / "Scripts";
+	std::vector<std::filesystem::path> migratedScriptNames;
+
+	for (const auto& entry : std::filesystem::recursive_directory_iterator(legacyScriptsPath))
+	{
+		if (!entry.is_directory())
+		{
+			if (OvTools::Utils::PathParser::GetFileType(entry.path().string()) == OvTools::Utils::PathParser::EFileType::SCRIPT)
+			{
+				migratedScriptNames.push_back(entry.path().filename());
+			}
+		}
+	}
 
 	std::error_code err;
 
@@ -1224,18 +1236,12 @@ void OvEditor::Core::EditorActions::MigrateScripts()
 	OVLOG_INFO("Scripts/ folder migrated to Assets/Scripts/");
 
 	// Update all scene files: replace old behaviour type (just the stem) with the new relative path
-	for (const auto& entry : std::filesystem::recursive_directory_iterator(targetPath))
+	for (const auto& scriptName : migratedScriptNames)
 	{
-		if (!entry.is_directory())
-		{
-			if (OvTools::Utils::PathParser::GetFileType(entry.path().string()) == OvTools::Utils::PathParser::EFileType::SCRIPT)
-			{
-				const auto stem = entry.path().stem().string();
-				const auto newRelPath = (std::filesystem::path("Scripts") / entry.path().filename()).generic_string();
+		const auto stem = scriptName.stem().string();
+		const auto newRelPath = (std::filesystem::path("Scripts") / scriptName).generic_string();
 
-				PropagateFileRenameThroughSavedFilesOfType(stem, newRelPath, OvTools::Utils::PathParser::EFileType::SCENE);
-			}
-		}
+		PropagateFileRenameThroughSavedFilesOfType(stem, newRelPath, OvTools::Utils::PathParser::EFileType::SCENE);
 	}
 
 	OVLOG_INFO("Scene files updated with new script paths");

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -1168,7 +1168,52 @@ void OvEditor::Core::EditorActions::MigrateScripts()
 	const auto targetPath = m_context.projectAssetsPath / "Scripts";
 
 	std::error_code err;
-	std::filesystem::rename(legacyScriptsPath, targetPath, err);
+
+	if (!std::filesystem::exists(targetPath))
+	{
+		std::filesystem::rename(legacyScriptsPath, targetPath, err);
+	}
+	else if (std::filesystem::is_directory(targetPath))
+	{
+		std::filesystem::create_directories(targetPath, err);
+
+		if (!err)
+		{
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(legacyScriptsPath))
+			{
+				const auto destination = targetPath / entry.path().lexically_relative(legacyScriptsPath);
+
+				if (entry.is_directory())
+				{
+					std::filesystem::create_directories(destination, err);
+				}
+				else
+				{
+					std::filesystem::create_directories(destination.parent_path(), err);
+
+					if (!err)
+					{
+						std::filesystem::copy_file(entry.path(), destination, std::filesystem::copy_options::overwrite_existing, err);
+					}
+				}
+
+				if (err)
+				{
+					break;
+				}
+			}
+		}
+
+		if (!err)
+		{
+			std::filesystem::remove_all(legacyScriptsPath, err);
+		}
+	}
+	else
+	{
+		OVLOG_ERROR("Failed to migrate Scripts/ folder: Assets/Scripts exists but is not a directory.");
+		return;
+	}
 
 	if (err)
 	{


### PR DESCRIPTION
## Description
Fixes a critical migration failure when opening legacy projects that still contain a root `Scripts/` folder.

When `Assets/Scripts/` already exists, using `std::filesystem::rename` on the legacy `Scripts/` directory fails with `Access is denied`.  
This PR updates the migration flow to:

- Keep the existing fast path (`rename`) when `Assets/Scripts/` does not exist.
- Merge legacy `Scripts/` content into existing `Assets/Scripts/` when it already exists.
- Remove the legacy `Scripts/` folder after a successful merge.
- Retarget scene references only for scripts that were actually migrated from the legacy folder (to avoid unintended rewrites of existing `Assets/Scripts/` references).

## Related Issue(s)
Fixes #712

## Review Guidance
Focus review on `EditorActions::MigrateScripts()`:

- Migration succeeds in both cases:
  - `Assets/Scripts/` absent (rename path)
  - `Assets/Scripts/` already present (merge path)
- Legacy folder is removed only after successful merge.
- Scene retargeting is limited to migrated legacy scripts.
- Error path is explicit when `Assets/Scripts` exists but is not a directory.

## Screenshots/GIFs
N/A (behavioral fix in migration logic).

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
