### PR TITLE
fix-missing-reference-asset-display

### DIFF
--- a/Sources/OvCore/include/OvCore/Helpers/GUIHelpers.h
+++ b/Sources/OvCore/include/OvCore/Helpers/GUIHelpers.h
@@ -62,6 +62,7 @@ namespace OvCore::Helpers
 		using PickerProviderCallback = std::function<void(PickerItemList, std::string)>;
 		using IconProviderCallback = std::function<uint32_t(OvTools::Utils::PathParser::EFileType)>;
 		using ActorSelectionProviderCallback = std::function<void(uint64_t)>;
+		using AssetExistsCallback = std::function<bool(const std::string&)>;
 
 		static void ProvideEmptyTexture(OvRendering::Resources::Texture& p_emptyTexture);
 		static OvRendering::Resources::Texture* GetEmptyTexture();
@@ -89,5 +90,8 @@ namespace OvCore::Helpers
 
 		static void SetActorSelectionProvider(ActorSelectionProviderCallback p_provider);
 		static void SelectActor(uint64_t p_guid);
+
+		static void SetAssetExistsChecker(AssetExistsCallback p_checker);
+		static bool AssetExists(const std::string& p_path);
 	};
 }

--- a/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIDrawer.cpp
@@ -170,8 +170,13 @@ void OvCore::Helpers::GUIDrawer::DrawColor(OvUI::Internal::WidgetContainer & p_r
 
 std::string OvCore::Helpers::GUIDrawer::GetAssetDisplayName(const std::string& p_path)
 {
+	if (p_path.empty())
+		return "";
 	const std::string friendly = OvTools::Utils::PathParser::GetFriendlyPath(p_path);
-	return friendly.empty() ? "" : std::filesystem::path(friendly).stem().string();
+	const std::string stem = friendly.empty() ? "" : std::filesystem::path(friendly).stem().string();
+	if (!GUIHelpers::AssetExists(p_path))
+		return stem.empty() ? "(Missing Reference)" : stem + " (Missing Reference)";
+	return stem;
 }
 
 std::string OvCore::Helpers::GUIDrawer::GetAssetTooltip(const std::string& p_path)

--- a/Sources/OvCore/src/OvCore/Helpers/GUIHelpers.cpp
+++ b/Sources/OvCore/src/OvCore/Helpers/GUIHelpers.cpp
@@ -16,6 +16,7 @@ namespace
 	OvCore::Helpers::GUIHelpers::IconProviderCallback __ICON_PROVIDER;
 	OvCore::Helpers::GUIHelpers::OpenProviderCallback __OPEN_PROVIDER;
 	OvCore::Helpers::GUIHelpers::ActorSelectionProviderCallback __ACTOR_SELECTION_PROVIDER;
+	OvCore::Helpers::GUIHelpers::AssetExistsCallback __ASSET_EXISTS_CHECKER;
 	uint32_t __ACTOR_ICON_ID = 0;
 
 	std::string TitleFromFileType(OvTools::Utils::PathParser::EFileType p_type)
@@ -121,4 +122,14 @@ void OvCore::Helpers::GUIHelpers::SelectActor(uint64_t p_guid)
 {
 	if (__ACTOR_SELECTION_PROVIDER)
 		__ACTOR_SELECTION_PROVIDER(p_guid);
+}
+
+void OvCore::Helpers::GUIHelpers::SetAssetExistsChecker(AssetExistsCallback p_checker)
+{
+	__ASSET_EXISTS_CHECKER = std::move(p_checker);
+}
+
+bool OvCore::Helpers::GUIHelpers::AssetExists(const std::string& p_path)
+{
+	return __ASSET_EXISTS_CHECKER && __ASSET_EXISTS_CHECKER(p_path);
 }

--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -7,6 +7,8 @@
 #include "OvEditor/Core/EditorActions.h"
 #include <tracy/Tracy.hpp>
 
+#include <filesystem>
+
 #include <OvCore/Helpers/GUIDrawer.h>
 #include <OvCore/Helpers/GUIHelpers.h>
 
@@ -136,6 +138,14 @@ void OvEditor::Core::Editor::SetupUI()
 	// Provide the actor icon ID for ActorField widgets.
 	if (auto* actorTexture = m_context.editorResources->GetTexture("Actor"))
 		OvCore::Helpers::GUIHelpers::SetActorIconID(actorTexture->GetTexture().GetID());
+
+	// Provide asset existence checker so AssetFields show "(Missing Reference)" for invalid paths.
+	OvCore::Helpers::GUIHelpers::SetAssetExistsChecker(
+		[this](const std::string& p_path)
+		{
+			return std::filesystem::exists(m_editorActions.GetRealPath(p_path));
+		}
+	);
 
 	// Provide actor selection so double-clicking an ActorField selects it in the inspector.
 	OvCore::Helpers::GUIHelpers::SetActorSelectionProvider(


### PR DESCRIPTION
## Description
fix: display "(Missing Reference)" for missing asset references (#739)

 Added an asset existence checker callback to the GUIHelpers system.
 When an asset reference points to a non-existent file, AssetFields now
 display the asset name with "(Missing Reference)" appended, making it
 clear that the reference is invalid.


## Related Issue(s)
[(#739)](https://github.com/Overload-Technologies/Overload/issues/739)
Fixes #(issue number)
739

## Checklist
<!-- Check all that apply -->
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
