### PR TITLE
Disabled drag-an-drop to disabled widget

### DIFF
--- a/Sources/OvUI/include/OvUI/Plugins/DDTarget.h
+++ b/Sources/OvUI/include/OvUI/Plugins/DDTarget.h
@@ -41,6 +41,10 @@ namespace OvUI::Plugins
 
 			if (p_context == EPluginExecutionContext::WIDGET)
 			{
+				// If the widget is disabled, don't accept drag-and-drop
+				if ((GImGui->CurrentItemFlags & ImGuiItemFlags_Disabled) != 0)
+					return;
+
 				const ImGuiID itemID = ImGui::GetItemID();
 				const ImGuiID targetSeed = itemID != 0 ? itemID : ImGui::GetID(this);
 				const ImGuiID targetID = ImHashStr(identifier.c_str(), 0, targetSeed);


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
This PR prevents `DDTarget` from receiving drag and drop events when its associated widget is disabled.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #743 

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.

## AI Usage Disclosure
<!-- Replace with "None" if not used -->
None

## Checklist
<!-- Check all that apply -->
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
