### PR TITLE
Attempt to fix blank screen on startup

### DIFF
--- a/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLTexture.cpp
+++ b/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLTexture.cpp
@@ -143,10 +143,10 @@ void OvRendering::HAL::GLTexture::Upload(const void* p_data, Settings::EFormat p
 					0,
 					0,
 					0,
-					0,
+					i,
 					m_textureContext.desc.width,
 					m_textureContext.desc.height,
-					i,
+					1,
 					EnumToValue<GLenum>(p_format),
 					EnumToValue<GLenum>(p_type),
 					p_data


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
I think I messed up `glTextureSubImage3D` arg ordering when I added support for reflection probes (and therefore cubemaps). This PR changes zoffset to use the cubemap subimage index, and sets the depth to 1.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #645
Fixes #630

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.

## AI Usage Disclosure
<!-- Replace with "None" if not used -->
None

## Checklist
<!-- Check all that apply -->
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
