### PR TITLE
Fix ImGui assertions in built game UI

### DIFF
--- a/Sources/OvUI/include/OvUI/Core/UIManager.h
+++ b/Sources/OvUI/include/OvUI/Core/UIManager.h
@@ -152,10 +152,10 @@ namespace OvUI::Core
 	private:
 		OvWindowing::Window& m_window;
 		OvTools::Eventing::ListenerID m_contentScaleChangedListener;
-		bool m_dockingState;
+		bool m_dockingState = false;
 		Styling::EStyle m_currentStyle;
-		float m_scale;
-		bool m_dpiAware;
+		float m_scale = 1.0f;
+		bool m_dpiAware = true;
 		bool m_refreshStyle = false;
 		Modules::Canvas* m_currentCanvas = nullptr;
 		std::unordered_map<std::string, ImFont*> m_fonts;

--- a/Sources/OvUI/include/OvUI/Core/UIManager.h
+++ b/Sources/OvUI/include/OvUI/Core/UIManager.h
@@ -155,7 +155,7 @@ namespace OvUI::Core
 		bool m_dockingState = false;
 		Styling::EStyle m_currentStyle;
 		float m_scale = 1.0f;
-		bool m_dpiAware = true;
+		bool m_dpiAware = false;
 		bool m_refreshStyle = false;
 		Modules::Canvas* m_currentCanvas = nullptr;
 		std::unordered_map<std::string, ImFont*> m_fonts;

--- a/Sources/OvUI/src/OvUI/Panels/PanelUndecorated.cpp
+++ b/Sources/OvUI/src/OvUI/Panels/PanelUndecorated.cpp
@@ -20,8 +20,8 @@ void OvUI::Panels::PanelUndecorated::_Draw_Impl()
 		DrawWidgets();
 	}
 
-	ImGui::PopStyleVar(2);
 	ImGui::End();
+	ImGui::PopStyleVar(2);
 }
 
 int OvUI::Panels::PanelUndecorated::CollectFlags()

--- a/Sources/OvUI/src/OvUI/Panels/PanelUndecorated.cpp
+++ b/Sources/OvUI/src/OvUI/Panels/PanelUndecorated.cpp
@@ -15,18 +15,13 @@ void OvUI::Panels::PanelUndecorated::_Draw_Impl()
 
 	if (ImGui::Begin(m_panelID.c_str(), nullptr, CollectFlags()))
 	{
-		ImGui::PopStyleVar(2);
-
 		Update();
 
 		DrawWidgets();
+	}
 
-		ImGui::End();
-	}
-	else
-	{
-		ImGui::PopStyleVar(2);
-	}
+	ImGui::PopStyleVar(2);
+	ImGui::End();
 }
 
 int OvUI::Panels::PanelUndecorated::CollectFlags()

--- a/Sources/OvUI/src/OvUI/Panels/PanelUndecorated.cpp
+++ b/Sources/OvUI/src/OvUI/Panels/PanelUndecorated.cpp
@@ -11,14 +11,14 @@
 void OvUI::Panels::PanelUndecorated::_Draw_Impl()
 {
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, { 0, 0 });
-	ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, { 0, 0 });
+	ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, { 1.0f, 1.0f });
 
 	if (ImGui::Begin(m_panelID.c_str(), nullptr, CollectFlags()))
 	{
 		ImGui::PopStyleVar(2);
 
 		Update();
-			
+
 		DrawWidgets();
 
 		ImGui::End();


### PR DESCRIPTION
## Description
Fixes two ImGui runtime assertions that were occurring in built games:
- `Invalid style setting` on `WindowMinSize`
- `Missing End()`

Changes made:
- In `PanelUndecorated`, set `ImGuiStyleVar_WindowMinSize` to a valid value (`{1.0f, 1.0f}`).
- In `PanelUndecorated`, ensure window scope is properly balanced with `Begin()`/`End()` and `PushStyleVar()`/`PopStyleVar()`.
- In `UIManager`, initialize UI state members (`m_scale`, `m_dpiAware`, `m_dockingState`) to deterministic defaults to avoid undefined style scaling at startup.

Scope is intentionally minimal and limited to:
- `Sources/OvUI/src/OvUI/Panels/PanelUndecorated.cpp`
- `Sources/OvUI/include/OvUI/Core/UIManager.h`

## Related Issue(s)
Fixes #752

## Review Guidance
Please review commit-by-commit:
1. Valid ImGui `WindowMinSize` in `PanelUndecorated`.
2. Balanced ImGui window/style stack in `PanelUndecorated`.
3. Safe default initialization for UI manager scale-related state.

Expected result:
- Built game starts without ImGui assertion on `WindowMinSize`.
- No `Missing End()` assertion during frame end.

## Screenshots/GIFs
N/A (runtime stability fix, no visual UI change expected)

## AI Usage Disclosure
Debugging

## Checklist
- [x] My code follows the project's code style guidelines
- [ ] ~~When applicable, I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~When applicable, I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
