### PR TITLE
Avoid `(Missing Reference)` on embedded material asset fields

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -147,7 +147,22 @@ void OvEditor::Core::Editor::SetupUI()
 	OvCore::Helpers::GUIHelpers::SetAssetExistsChecker(
 		[this](const std::string& p_path)
 		{
-			return std::filesystem::exists(m_editorActions.GetRealPath(p_path));
+			const std::string path = OvTools::Utils::PathParser::MakeNonWindowsStyle(p_path);
+
+			if (const auto embeddedAssetPath = ParseEmbeddedAssetPath(path); embeddedAssetPath)
+			{
+				const bool isEmbeddedMaterial = ParseEmbeddedMaterialIndex(embeddedAssetPath->assetName).has_value();
+				const bool isEmbeddedTexture = ParseEmbeddedTextureIndex(embeddedAssetPath->assetName).has_value();
+
+				if (isEmbeddedMaterial || isEmbeddedTexture)
+				{
+					return std::filesystem::exists(m_editorActions.GetRealPath(embeddedAssetPath->modelPath));
+				}
+
+				return false;
+			}
+
+			return std::filesystem::exists(m_editorActions.GetRealPath(path));
 		}
 	);
 


### PR DESCRIPTION
## Description
Asset fields were incorrectly showing "(Missing Reference)" for embedded material/texture references (virtual paths like `model:embedded_material_*.ovmat`), because existence checks used filesystem paths directly.

This PR updates the editor asset existence checker to:
- detect embedded asset paths,
- validate embedded material/texture references,
- resolve existence via the source model file,
- keep the previous behavior unchanged for non-embedded paths.

## Related Issue(s)
Fixes #756

## Review Guidance
- Import/load a model with embedded materials.
- In Inspector (`Material Renderer`) and material-related asset fields, verify embedded references no longer display "(Missing Reference)" when the source model exists.
- Verify regular invalid asset paths still display "(Missing Reference)".

## Screenshots/GIFs
N/A

## AI Usage Disclosure
Debugging

## Checklist
- [x] My code follows the project's code style guidelines
- [ ] ~~When applicable, I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~When applicable, I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
