### PR TITLE
Update material editor read-only state when changing target material

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -107,7 +107,6 @@ void OvEditor::Panels::MaterialEditor::SetTarget(OvCore::Resources::Material & p
 {
 	m_target = &p_newTarget;
 	m_targetMaterialText->content = m_target->path;
-	disabled = IsReadyOnlyMaterial(*m_target);
 	OnMaterialDropped();
 }
 
@@ -146,6 +145,7 @@ void OvEditor::Panels::MaterialEditor::Reset()
 
 void OvEditor::Panels::MaterialEditor::OnMaterialDropped()
 {
+	disabled = m_target && IsReadyOnlyMaterial(*m_target);
 	m_settings->enabled = m_target; // Enable m_settings group if the target material is non-null
 
 	if (m_settings->enabled)


### PR DESCRIPTION
## Description
This PR fixes a Material Editor state update issue where changing the target material from an engine material to a non-engine material did not refresh the panel read-only state.

The read-only flag is now recalculated in `OnMaterialDropped()`, which is the callback triggered when the material field changes (picker/drag&drop), ensuring the UI state is always in sync with the current target material.

## Related Issue(s)
Fixes #757

## Review Guidance
Follow issue #757

## Screenshots/GIFs
N/A

## AI Usage Disclosure
None

## Checklist
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
