### PR TITLE
Prevent repeated paste from nesting actors as children

### DIFF
--- a/Sources/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -235,7 +235,7 @@ namespace OvEditor::Core
 		void CopyActor(OvCore::ECS::Actor& p_actor);
 
 		/**
-		* Paste the copied actor, optionally as a child of the given parent
+		* Paste the copied actor next to the given actor (same parent), or at root if null
 		* @param p_parent
 		*/
 		void PasteActor(OvCore::ECS::Actor* p_parent = nullptr);

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -909,11 +909,11 @@ void OvEditor::Core::EditorActions::PasteActor(OvCore::ECS::Actor* p_parent)
 	{
 		auto* destinationParent = p_parent;
 
-		// Pasting on the copied actor itself falls back to its current parent,
-		// preserving the "duplicate-like" behavior by default.
-		if (destinationParent && destinationParent->GetGUID() == copiedActor->GetGUID())
+		// Pasted actors are always inserted next to the target actor (same parent),
+		// never as children.
+		if (destinationParent)
 		{
-			destinationParent = copiedActor->GetParent();
+			destinationParent = destinationParent->GetParent();
 		}
 
 		DuplicateActor(*copiedActor, destinationParent, true);


### PR DESCRIPTION
## Description
Fixes actor paste behavior that could unintentionally create a child hierarchy when pasting multiple times (`Ctrl+V`).

Paste now behaves as follows:
- if a target actor is selected, the new actor is pasted at the same level (same parent)
- if no target actor is selected, the actor is pasted at the root level

Also updates the `PasteActor` API comment to reflect this contract.

## Related Issue(s)
Fixes #763

## Review Guidance
What to verify:
- Copy an actor and press `Ctrl+V` multiple times: it should never create a child of the previously pasted copy
- The newly pasted actor should remain a sibling of the target actor (or be root if no target is selected)
- No other duplication/paste workflows should be affected

## Screenshots/GIFs
N/A

## AI Usage Disclosure
None

## Checklist
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)