### PR TITLE
Add Extract materials action to model contextual menu

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -744,9 +744,15 @@ namespace
 			if (!m_protected)
 			{
 				auto& generateMaterialsMenu = CreateWidget<OvUI::Widgets::Menu::MenuList>("Generate materials...");
+				auto& extractMaterialsAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Extract materials");
 
 				CreateMaterialCreationOption(generateMaterialsMenu, "Standard");
 				CreateMaterialCreationOption(generateMaterialsMenu, "Unlit");
+
+				extractMaterialsAction.ClickedEvent += [this]
+				{
+					ExtractMaterialFiles();
+				};
 			}
 
 			FileContextualMenu::CreateList();

--- a/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -680,6 +680,42 @@ namespace
 			}
 		}
 
+		void ExtractMaterialFiles()
+		{
+			auto& modelManager = OVSERVICE(OvCore::ResourceManagement::ModelManager);
+			auto& materialManager = OVSERVICE(OvCore::ResourceManagement::MaterialManager);
+			const std::string resourcePath = EDITOR_EXEC(GetResourcePath(filePath.string(), m_protected));
+
+			if (auto model = modelManager.GetResource(resourcePath))
+			{
+				const auto& embeddedMaterials = model->GetEmbeddedMaterials();
+				const auto& materialNames = model->GetMaterialNames();
+
+				for (size_t materialIndex = 0; materialIndex < embeddedMaterials.size(); ++materialIndex)
+				{
+					const std::string embeddedMaterialPath = OvRendering::Resources::Parsers::MakeEmbeddedMaterialPath(
+						resourcePath,
+						static_cast<uint32_t>(materialIndex)
+					);
+
+					auto* embeddedMaterial = materialManager.GetResource(embeddedMaterialPath);
+					if (!embeddedMaterial)
+					{
+						continue;
+					}
+
+					const bool hasNamedSlot = materialIndex < materialNames.size() && !materialNames[materialIndex].empty();
+					const std::string materialName = hasNamedSlot
+						? materialNames[materialIndex]
+						: std::format("embedded_material_{}", materialIndex);
+
+					const auto finalPath = FindAvailableFilePath(filePath.parent_path() / (materialName + ".ovmat"));
+					OvCore::Resources::Loaders::MaterialLoader::Save(*embeddedMaterial, finalPath.string());
+					DuplicateEvent.Invoke(finalPath);
+				}
+			}
+		}
+
 		void CreateMaterialCreationOption(OvUI::Internal::WidgetContainer& p_root, const std::string_view p_materialName)
 		{
 			const std::string materialName{ p_materialName };


### PR DESCRIPTION
## Description
This PR adds an `Extract materials` action to the model contextual menu in the Asset Browser.

When used on a model asset, the editor now:
- Resolves embedded materials from the selected model
- Saves each embedded material as a standalone `.ovmat` file next to the model
- Uses unique file paths to avoid overwriting existing files
- Refreshes the Asset Browser list via existing duplicate notifications

This provides a direct way to extract embedded materials and edit them as regular material assets.

## Related Issue(s)
Fixes #764

## Review Guidance
- In the Asset Browser, right-click a model file.
- Confirm the new `Extract materials` entry is present in the contextual menu.
- Click `Extract materials`.
- Verify `.ovmat` files are created next to the model (one per extracted embedded material).
- Verify existing files are not overwritten (unique naming is applied).

## Screenshots/GIFs
N/A

## AI Usage Disclosure
Generated new code

## Checklist
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [ ] ~~When applicable, I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)