### PR TITLE
Fixed a bug with folder delete propagation not working

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -1186,11 +1186,14 @@ std::string OvEditor::Core::EditorActions::GetRealPath(const std::string& p_path
 
 std::string OvEditor::Core::EditorActions::GetResourcePath(const std::string& p_path, bool p_isFromEngine)
 {
-	std::string result = p_path;
+	// Normalize to forward slashes so the comparison works regardless of whether
+	// the caller or the stored context paths use POSIX or Windows separators.
+	std::string result = std::filesystem::path(p_path).generic_string();
+	const std::string contextPath = (p_isFromEngine ? m_context.engineAssetsPath : m_context.projectAssetsPath).generic_string();
 
-	if (OvTools::Utils::String::Replace(result, p_isFromEngine ? m_context.engineAssetsPath.string() : m_context.projectAssetsPath.string(), ""))
+	if (OvTools::Utils::String::Replace(result, contextPath, ""))
 	{
-		if (result.starts_with(std::filesystem::path::preferred_separator))
+		if (result.starts_with('/'))
 		{
 			result = result.substr(1);
 		}
@@ -1204,19 +1207,18 @@ std::string OvEditor::Core::EditorActions::GetResourcePath(const std::string& p_
 	return result;
 }
 
-std::string OvEditor::Core::EditorActions::GetScriptPath(const std::string & p_path)
+std::string OvEditor::Core::EditorActions::GetScriptPath(const std::string& p_path)
 {
-	std::string result = p_path;
+	// Normalize to forward slashes so the comparison works regardless of separator style.
+	std::string result = std::filesystem::path(p_path).generic_string();
+	const std::string contextPath = m_context.projectAssetsPath.generic_string();
 
-	OvTools::Utils::String::Replace(result, m_context.projectAssetsPath.string(), "");
+	OvTools::Utils::String::Replace(result, contextPath, "");
 
-	if (result.starts_with(std::filesystem::path::preferred_separator))
+	if (result.starts_with('/'))
 	{
 		result = result.substr(1);
 	}
-
-	// Normalize to forward slashes for cross-platform consistency
-	std::replace(result.begin(), result.end(), '\\', '/');
 
 	return result;
 }

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -1254,7 +1254,7 @@ void OvEditor::Core::EditorActions::PropagateFolderDestruction(std::string p_fol
 	{
 		if (!p.is_directory())
 		{
-			PropagateFileRename(OvTools::Utils::PathParser::MakeWindowsStyle(p.path().string()), "?");
+			PropagateFileRename(OvTools::Utils::PathParser::MakeNonWindowsStyle(p.path().string()), "?");
 		}
 	}
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
- Safer `GetResourcePath` (now ignoring POSIX/non-POSIX differences)

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #(issue number)

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.

## AI Usage Disclosure
<!-- Replace with "None" if not used -->
Generated new code

## Checklist
<!-- Check all that apply -->
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
