### PR TITLE
Expose `Actor.GetGUID()` as hex string in Lua

### DIFF
--- a/Resources/Engine/Lua/Scene/Actor.lua
+++ b/Resources/Engine/Lua/Scene/Actor.lua
@@ -25,6 +25,10 @@ function Actor:SetTag(tag) end
 ---@return integer
 function Actor:GetID() end
 
+--- Returns the GUID of this actor as a hexadecimal string
+---@return string
+function Actor:GetGUID() end
+
 --- Returns children of this actor
 ---@return Actor[]
 function Actor:GetChildren() end

--- a/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaActorBindings.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaActorBindings.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <filesystem>
+#include <format>
 
 #include <sol/sol.hpp>
 
@@ -40,6 +41,7 @@ void BindLuaActor(sol::state& p_luaState)
 		"GetChildren", &Actor::GetChildren,
 		"SetTag", &Actor::SetTag,
 		"GetID", &Actor::GetID,
+		"GetGUID", [](Actor& p_actor) { return std::format("{:016X}", p_actor.GetGUID()); },
 		"GetParent", &Actor::GetParent,
 		"SetParent", &Actor::SetParent,
 		"DetachFromParent", &Actor::DetachFromParent,


### PR DESCRIPTION
## Description
This PR exposes `Actor::GetGUID()` to Lua through the Actor bindings and returns it as a fixed-width hexadecimal string (`{:016X}`).

## Related Issue(s)
Fixes #779

## Review Guidance
- Check `LuaActorBindings.cpp` for the new `GetGUID` Lua method.
- Confirm the return format is uppercase 16-char hexadecimal string.
- Check `Resources/Engine/Lua/Scene/Actor.lua` for the matching API stub update.

## Screenshots/GIFs
N/A

## AI Usage Disclosure
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
