### PR TITLE
Support spaces when opening files in external code editor

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -1042,6 +1042,8 @@ bool OvEditor::Core::EditorActions::OpenInCodeEditor(const std::filesystem::path
 		const std::string quotedWorkdir = std::format("\"{}\"", preferredWorkdir.string());
 		const std::string quotedPath = std::format("\"{}\"", preferredPath.string());
 
+		OvTools::Utils::String::ReplaceAll(command, "\"{workdir}\"", "{workdir}");
+		OvTools::Utils::String::ReplaceAll(command, "\"{path}\"", "{path}");
 		OvTools::Utils::String::ReplaceAll(command, "{workdir}", quotedWorkdir);
 		OvTools::Utils::String::ReplaceAll(command, "{path}", quotedPath);
 		if (!OvTools::Utils::SystemCalls::ExecuteCommand(command))

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -1036,8 +1036,14 @@ bool OvEditor::Core::EditorActions::OpenInCodeEditor(const std::filesystem::path
 			return false;
 		}
 
-		OvTools::Utils::String::ReplaceAll(command, "{workdir}", p_workdir ? p_workdir->string() : m_context.projectFolder.string());
-		OvTools::Utils::String::ReplaceAll(command, "{path}", p_path.string());
+		auto preferredWorkdir = p_workdir ? p_workdir.value() : m_context.projectFolder;
+		preferredWorkdir.make_preferred();
+
+		const std::string quotedWorkdir = std::format("\"{}\"", preferredWorkdir.string());
+		const std::string quotedPath = std::format("\"{}\"", preferredPath.string());
+
+		OvTools::Utils::String::ReplaceAll(command, "{workdir}", quotedWorkdir);
+		OvTools::Utils::String::ReplaceAll(command, "{path}", quotedPath);
 		if (!OvTools::Utils::SystemCalls::ExecuteCommand(command))
 		{
 			OVLOG_ERROR(std::format("Failed to open in code editor using command: \"{}\"", command));


### PR DESCRIPTION
## Description
This PR fixes a bug when opening files in the external code editor from the hierarchy.

Previously, when a script path contained spaces (for example `My Script.lua`), the command line argument substitution split the path, which caused VS Code to open incorrect files.

This change updates `OpenInCodeEditor` to:
- always replace `{workdir}` and `{path}` with quoted paths
- normalize already-quoted placeholders (`"{workdir}"`, `"{path}"`) before replacement to avoid double quoting in custom commands

The default setting command remains unchanged (`code {workdir} --goto {path}`), as expected in issue #780.

## Related Issue(s)
Fixes #780

## Review Guidance
Focus review on:
- `Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp` (`OpenInCodeEditor`)
- placeholder replacement logic for `{workdir}` / `{path}`
- behavior with custom commands that already include quoted placeholders

## Screenshots/GIFs
N/A

## AI Usage Disclosure
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [ ] ~~When applicable, I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~When applicable, I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)

