### PR TITLE
Fix actor paste parent selection in hierarchy and root context

### DIFF
--- a/Sources/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -222,9 +222,16 @@ namespace OvEditor::Core
 		* Duplicate an actor
 		* @param p_toDuplicate
 		* @param p_forcedParent
-		* @param bool
+		* @param p_focus
+		* @param p_keepSourceParentIfNoForcedParent
 		*/
-		void DuplicateActor(OvCore::ECS::Actor& p_toDuplicate, OvCore::ECS::Actor* p_forcedParent = nullptr, bool p_focus = true);
+		void DuplicateActor
+		(
+			OvCore::ECS::Actor& p_toDuplicate,
+			OvCore::ECS::Actor* p_forcedParent = nullptr,
+			bool p_focus = true,
+			bool p_keepSourceParentIfNoForcedParent = true
+		);
 		#pragma endregion
 
 		#pragma region ACTOR_MANIPULATION
@@ -235,7 +242,8 @@ namespace OvEditor::Core
 		void CopyActor(OvCore::ECS::Actor& p_actor);
 
 		/**
-		* Paste the copied actor next to the given actor (same parent), or at root if null
+		* Paste the copied actor next to the given actor (same parent), or at root if null.
+		* If the target actor is at root, the pasted actor is also pasted at root.
 		* @param p_parent
 		*/
 		void PasteActor(OvCore::ECS::Actor* p_parent = nullptr);

--- a/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -840,7 +840,13 @@ std::string FindDuplicatedActorUniqueName(OvCore::ECS::Actor& p_duplicated, OvCo
     return OvTools::Utils::String::GenerateUnique(p_duplicated.GetName(), availabilityChecker);
 }
 
-void OvEditor::Core::EditorActions::DuplicateActor(OvCore::ECS::Actor & p_toDuplicate, OvCore::ECS::Actor* p_forcedParent, bool p_focus)
+void OvEditor::Core::EditorActions::DuplicateActor
+(
+	OvCore::ECS::Actor& p_toDuplicate,
+	OvCore::ECS::Actor* p_forcedParent,
+	bool p_focus,
+	bool p_keepSourceParentIfNoForcedParent
+)
 {
 	tinyxml2::XMLDocument doc;
 	tinyxml2::XMLNode* actorsRoot = doc.NewElement("actors");
@@ -859,7 +865,7 @@ void OvEditor::Core::EditorActions::DuplicateActor(OvCore::ECS::Actor & p_toDupl
 	{
 		newActor.SetParent(*p_forcedParent);
 	}
-	else if (newActor.GetParentID() > 0)
+	else if (p_keepSourceParentIfNoForcedParent && newActor.GetParentID() > 0)
 	{
 		if (auto found = currentScene->FindActorByID(newActor.GetParentID()); found)
 		{
@@ -914,7 +920,7 @@ void OvEditor::Core::EditorActions::PasteActor(OvCore::ECS::Actor* p_parent)
 			destinationParent = destinationParent->GetParent();
 		}
 
-		DuplicateActor(*copiedActor, destinationParent, true);
+		DuplicateActor(*copiedActor, destinationParent, true, false);
 	}
 }
 

--- a/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -65,7 +65,7 @@ public:
 			auto& duplicateButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Duplicate");
 			duplicateButton.ClickedEvent += [this]
 			{
-				EDITOR_EXEC(DelayAction(EDITOR_BIND(DuplicateActor, std::ref(*m_target), nullptr, true), 0));
+				EDITOR_EXEC(DelayAction(EDITOR_BIND(DuplicateActor, std::ref(*m_target), nullptr, true, true), 0));
 			};
 
 			auto& pasteButton = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Paste");


### PR DESCRIPTION
## Description
This PR fixes actor copy/paste behavior in the Hierarchy panel.

Previously, pasting a copied actor could reattach it using the copied actor's original parent when pasting into root-level contexts. As a result, paste did not always respect the destination location.

This change makes paste behavior explicit:
- Paste always uses the destination context (same parent as target actor, or root when target is root/null)
- No implicit fallback to the copied actor's original parent during paste

Additionally, this PR updates one `DuplicateActor` bind call in `Hierarchy.cpp` to match the updated method signature and restore clean compilation.

## Related Issue(s)
Fixes #781

## Review Guidance
Please review:
- `EditorActions::DuplicateActor` new explicit control for source-parent reuse
- `EditorActions::PasteActor` now disabling source-parent fallback
- `Hierarchy` duplicate action bind updated for signature compatibility

Expected manual behavior:
1. Copy a child actor
2. Paste on a root-level actor
3. Pasted actor appears under the destination parent context (not under the copied actor's former parent)

## Screenshots/GIFs
N/A

## AI Usage Disclosure
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)

