### PR TITLE
Replace spaces with underscores in generated default table name

### DIFF
--- a/Sources/OvCore/src/OvCore/Scripting/Lua/LuaScriptEngine.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/LuaScriptEngine.cpp
@@ -17,6 +17,7 @@
 #include <OvCore/Scripting/ScriptEngine.h>
 #include <OvCore/ECS/Components/Behaviour.h>
 #include <OvCore/ECS/Actor.h>
+#include <OvTools/Utils/String.h>
 
 void BindLuaActor(sol::state& p_state);
 void BindLuaComponents(sol::state& p_state);
@@ -173,19 +174,22 @@ std::unordered_set<std::string> OvCore::Scripting::LuaScriptEngineBase::GetValid
 template<>
 std::string OvCore::Scripting::LuaScriptEngineBase::GetDefaultScriptContent(const std::string& p_name)
 {
+	std::string scriptTableName = p_name;
+	OvTools::Utils::String::ReplaceAll(scriptTableName, " ", "_");
+
 	return
-		"---@class " + p_name + " : Behaviour\n"
-		"local " + p_name + " =\n"
+		"---@class " + scriptTableName + " : Behaviour\n"
+		"local " + scriptTableName + " =\n"
 		"{\n"
 		"}\n"
 		"\n"
-		"function " + p_name + ":OnStart()\n"
+		"function " + scriptTableName + ":OnStart()\n"
 		"end\n"
 		"\n"
-		"function " + p_name + ":OnUpdate(deltaTime)\n"
+		"function " + scriptTableName + ":OnUpdate(deltaTime)\n"
 		"end\n"
 		"\n"
-		"return " + p_name;
+		"return " + scriptTableName;
 }
 
 template<>


### PR DESCRIPTION
## Description
This PR fixes the Lua default script template generation when a script filename contains spaces.

Previously, the generated identifier used the raw filename, which could produce invalid Lua syntax (e.g. `local My Script = {}`).
Now, spaces are replaced with underscores before generating the default Lua class/table/function identifiers.

## Related Issue(s)
Fixes #788

## Review Guidance
- Main change is in `LuaScriptEngineBase::GetDefaultScriptContent`:
  - `p_name` is sanitized with `" " -> "_"` before template generation.
- The sanitized name is used consistently in:
  - `---@class ...`
  - `local ... = {}`
  - `function ...:OnStart()`
  - `function ...:OnUpdate(deltaTime)`
  - `return ...`
- Scope is intentionally minimal and limited to default Lua template generation.

## Screenshots/GIFs
N/A

## AI Usage Disclosure
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [ ] ~~When applicable, I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
