### PR TITLE
Reduce per-draw shader/material overhead

### DIFF
--- a/Sources/OvRendering/include/OvRendering/Core/ABaseRenderer.h
+++ b/Sources/OvRendering/include/OvRendering/Core/ABaseRenderer.h
@@ -128,6 +128,7 @@ namespace OvRendering::Core
 		OvRendering::Resources::Mesh m_unitQuad;
 		OvRendering::Data::PipelineState m_basePipelineState;
 		bool m_isDrawing;
+		const Data::Material* m_lastBoundMaterial = nullptr;
 
 	private:
 		static std::atomic_bool s_isDrawing;

--- a/Sources/OvRendering/include/OvRendering/Core/ABaseRenderer.h
+++ b/Sources/OvRendering/include/OvRendering/Core/ABaseRenderer.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <atomic>
+#include <unordered_map>
 
 #include "OvRendering/Core/IRenderer.h"
 #include "OvRendering/Data/FrameInfo.h"
@@ -128,7 +129,7 @@ namespace OvRendering::Core
 		OvRendering::Resources::Mesh m_unitQuad;
 		OvRendering::Data::PipelineState m_basePipelineState;
 		bool m_isDrawing;
-		const Data::Material* m_lastBoundMaterial = nullptr;
+		std::unordered_map<uint32_t, const Data::Material*> m_lastBoundMaterialPerProgram;
 
 	private:
 		static std::atomic_bool s_isDrawing;

--- a/Sources/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/OvRendering/include/OvRendering/Data/Material.h
@@ -42,6 +42,8 @@ namespace OvRendering::Data
 	{
 		MaterialPropertyType value;
 		bool singleUse;
+		bool dirty;
+		bool pendingSingleUseReset;
 	};
 
 	/**
@@ -90,7 +92,8 @@ namespace OvRendering::Data
 			HAL::Texture* p_emptyTexture2D = nullptr,
 			HAL::Texture* p_emptyTextureCube = nullptr,
 			std::optional<const std::string_view> p_pass = std::nullopt,
-			OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride = std::nullopt
+			OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride = std::nullopt,
+			bool p_forceUniformUpload = true
 		);
 
 		/**
@@ -387,5 +390,7 @@ namespace OvRendering::Data
 
 		int m_gpuInstances = 1;
 		int m_drawOrder = 1000;
+		bool m_hasDirtyProperties = true;
+		HAL::ShaderProgram* m_lastBoundVariant = nullptr;
 	};
 }

--- a/Sources/OvRendering/include/OvRendering/HAL/OpenGL/GLShaderProgram.h
+++ b/Sources/OvRendering/include/OvRendering/HAL/OpenGL/GLShaderProgram.h
@@ -25,4 +25,10 @@ namespace OvRendering::HAL
 	};
 
 	using GLShaderProgram = TShaderProgram<Settings::EGraphicsBackend::OPENGL, GLShaderProgramContext, GLShaderStageContext>;
+
+	/**
+	* Invalidate the shader program binding cache.
+	* Useful when external code binds programs directly through OpenGL calls.
+	*/
+	void InvalidateGLShaderProgramBindingCache();
 }

--- a/Sources/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
+++ b/Sources/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
@@ -85,7 +85,7 @@ void OvRendering::Core::ABaseRenderer::BeginFrame(const Data::FrameDescriptor& p
 
 	p_frameDescriptor.camera->CacheMatrices(p_frameDescriptor.renderWidth, p_frameDescriptor.renderHeight);
 
-	m_lastBoundMaterial = nullptr;
+	m_lastBoundMaterialPerProgram.clear();
 	m_isDrawing = true;
 	s_isDrawing.store(true);
 }
@@ -101,7 +101,7 @@ void OvRendering::Core::ABaseRenderer::EndFrame()
 		m_frameDescriptor.outputBuffer.value().Unbind();
 	}
 
-	m_lastBoundMaterial = nullptr;
+	m_lastBoundMaterialPerProgram.clear();
 	m_isDrawing = false;
 	s_isDrawing.store(false);
 }
@@ -232,16 +232,30 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 		}
 	}
 
+	const auto featureSetOverride =
+		p_drawable.featureSetOverride.has_value() ?
+		OvTools::Utils::OptRef<const Data::FeatureSet>(p_drawable.featureSetOverride.value()) :
+		std::nullopt;
+
+	const auto currentVariant = p_drawable.material->GetVariant(p_drawable.pass, featureSetOverride);
+	OVASSERT(currentVariant, "Cannot draw a material without a valid shader variant");
+
+	const uint32_t currentProgramId = currentVariant->GetID();
 	const auto* currentMaterial = &p_drawable.material.value();
-	const bool forceUniformUpload = m_lastBoundMaterial != currentMaterial;
+
+	bool forceUniformUpload = true;
+	if (const auto boundMaterial = m_lastBoundMaterialPerProgram.find(currentProgramId);
+		boundMaterial != m_lastBoundMaterialPerProgram.end() &&
+		boundMaterial->second == currentMaterial)
+	{
+		forceUniformUpload = false;
+	}
 
 	p_drawable.material->Bind(
 		&m_emptyTexture2D,
 		&m_emptyTextureCube,
 		p_drawable.pass,
-		p_drawable.featureSetOverride.has_value() ?
-		OvTools::Utils::OptRef<const Data::FeatureSet>(p_drawable.featureSetOverride.value()) :
-		std::nullopt,
+		featureSetOverride,
 		forceUniformUpload
 	);
 
@@ -252,5 +266,5 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 		p_drawable.material->GetGPUInstances()
 	);
 
-	m_lastBoundMaterial = currentMaterial;
+	m_lastBoundMaterialPerProgram[currentProgramId] = currentMaterial;
 }

--- a/Sources/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
+++ b/Sources/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
@@ -85,6 +85,7 @@ void OvRendering::Core::ABaseRenderer::BeginFrame(const Data::FrameDescriptor& p
 
 	p_frameDescriptor.camera->CacheMatrices(p_frameDescriptor.renderWidth, p_frameDescriptor.renderHeight);
 
+	m_lastBoundMaterial = nullptr;
 	m_isDrawing = true;
 	s_isDrawing.store(true);
 }
@@ -100,6 +101,7 @@ void OvRendering::Core::ABaseRenderer::EndFrame()
 		m_frameDescriptor.outputBuffer.value().Unbind();
 	}
 
+	m_lastBoundMaterial = nullptr;
 	m_isDrawing = false;
 	s_isDrawing.store(false);
 }
@@ -230,13 +232,17 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 		}
 	}
 
+	const auto* currentMaterial = &p_drawable.material.value();
+	const bool forceUniformUpload = m_lastBoundMaterial != currentMaterial;
+
 	p_drawable.material->Bind(
 		&m_emptyTexture2D,
 		&m_emptyTextureCube,
 		p_drawable.pass,
 		p_drawable.featureSetOverride.has_value() ?
 		OvTools::Utils::OptRef<const Data::FeatureSet>(p_drawable.featureSetOverride.value()) :
-		std::nullopt
+		std::nullopt,
+		forceUniformUpload
 	);
 
 	m_driver.Draw(
@@ -246,5 +252,5 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 		p_drawable.material->GetGPUInstances()
 	);
 
-	p_drawable.material->Unbind();
+	m_lastBoundMaterial = currentMaterial;
 }

--- a/Sources/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/OvRendering/src/OvRendering/Data/Material.cpp
@@ -176,6 +176,7 @@ void OvRendering::Data::Material::Bind(
 	}
 
 	int textureSlot = 0;
+	bool hasDirtyPropertiesAfterBind = false;
 
 	for (auto& [name, prop] : m_properties)
 	{
@@ -189,6 +190,7 @@ void OvRendering::Data::Material::Bind(
 		// Skip this property if the current program isn't using its associated uniform
 		if (!uniformData)
 		{
+			hasDirtyPropertiesAfterBind = hasDirtyPropertiesAfterBind || prop.dirty;
 			continue;
 		}
 
@@ -265,15 +267,11 @@ void OvRendering::Data::Material::Bind(
 		{
 			prop.dirty = false;
 		}
+
+		hasDirtyPropertiesAfterBind = hasDirtyPropertiesAfterBind || prop.dirty;
 	}
 
-	m_hasDirtyProperties = std::any_of(
-		m_properties.begin(),
-		m_properties.end(),
-		[](const auto& property) {
-			return property.second.dirty;
-		}
-	);
+	m_hasDirtyProperties = hasDirtyPropertiesAfterBind;
 
 	m_lastBoundVariant = &program;
 }

--- a/Sources/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/OvRendering/src/OvRendering/Data/Material.cpp
@@ -4,6 +4,7 @@
 * @licence: MIT
 */
 
+#include <algorithm>
 #include <format>
 #include <ranges>
 
@@ -71,6 +72,7 @@ OvRendering::Data::Material::Material(OvRendering::Resources::Shader* p_shader)
 void OvRendering::Data::Material::SetShader(OvRendering::Resources::Shader* p_shader)
 {
 	m_shader = p_shader;
+	m_lastBoundVariant = nullptr;
 
 	if (m_shader)
 	{
@@ -80,6 +82,7 @@ void OvRendering::Data::Material::SetShader(OvRendering::Resources::Shader* p_sh
 	else
 	{
 		m_properties.clear();
+		m_hasDirtyProperties = false;
 	}
 }
 
@@ -119,7 +122,9 @@ void OvRendering::Data::Material::UpdateProperties()
 			{
 				m_properties.emplace(name, MaterialProperty{
 					.value = UniformToPropertyValue(uniformInfo.defaultValue),
-					.singleUse = false
+					.singleUse = false,
+					.dirty = true,
+					.pendingSingleUseReset = false
 				});
 			}
 		}
@@ -128,6 +133,14 @@ void OvRendering::Data::Material::UpdateProperties()
 	std::erase_if(m_properties, [&usedUniforms](const auto& property) {
 		return !usedUniforms.contains(property.first);
 	});
+
+	m_hasDirtyProperties = std::any_of(
+		m_properties.begin(),
+		m_properties.end(),
+		[](const auto& property) {
+			return property.second.dirty;
+		}
+	);
 }
 
 // Note: this function is critical for performance, as it may be called many times during a frame.
@@ -136,7 +149,8 @@ void OvRendering::Data::Material::Bind(
 	HAL::Texture* p_emptyTexture,
 	HAL::Texture* p_emptyTextureCube,
 	std::optional<const std::string_view> p_pass,
-	OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride
+	OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride,
+	bool p_forceUniformUpload
 )
 {
 	ZoneScoped;
@@ -151,12 +165,25 @@ void OvRendering::Data::Material::Bind(
 		p_featureSetOverride.value_or(m_features)
 	);
 
+	const bool variantChanged = m_lastBoundVariant != &program;
+	const bool forceUniformUpload = p_forceUniformUpload || variantChanged;
+
 	program.Bind();
+
+	if (!forceUniformUpload && !m_hasDirtyProperties)
+	{
+		return;
+	}
 
 	int textureSlot = 0;
 
 	for (auto& [name, prop] : m_properties)
 	{
+		if (!forceUniformUpload && !prop.dirty)
+		{
+			continue;
+		}
+
 		const auto uniformData = program.GetUniformInfo(name);
 
 		// Skip this property if the current program isn't using its associated uniform
@@ -223,9 +250,32 @@ void OvRendering::Data::Material::Bind(
 
 		if (prop.singleUse)
 		{
-			value = UniformToPropertyValue(uniformData->defaultValue);
+			if (prop.pendingSingleUseReset)
+			{
+				value = UniformToPropertyValue(uniformData->defaultValue);
+				prop.pendingSingleUseReset = false;
+				prop.dirty = true;
+			}
+			else
+			{
+				prop.dirty = false;
+			}
+		}
+		else
+		{
+			prop.dirty = false;
 		}
 	}
+
+	m_hasDirtyProperties = std::any_of(
+		m_properties.begin(),
+		m_properties.end(),
+		[](const auto& property) {
+			return property.second.dirty;
+		}
+	);
+
+	m_lastBoundVariant = &program;
 }
 
 void OvRendering::Data::Material::Unbind() const
@@ -244,12 +294,15 @@ void OvRendering::Data::Material::SetProperty(const std::string p_name, const Ma
 {
 	OVASSERT(IsValid(), "Attempting to SetProperty on an invalid material.");
 	OVASSERT(HasProperty(p_name), "Attempting to SetProperty on a non-existing property.");
-	const auto property = 
 
 	m_properties[p_name] = MaterialProperty{
-		p_value,
-		p_singleUse
+		.value = p_value,
+		.singleUse = p_singleUse,
+		.dirty = true,
+		.pendingSingleUseReset = p_singleUse
 	};
+
+	m_hasDirtyProperties = true;
 }
 
 bool OvRendering::Data::Material::TrySetProperty(const std::string& p_name, const MaterialPropertyType& p_value, bool p_singleUse)

--- a/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLBackend.cpp
+++ b/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLBackend.cpp
@@ -14,6 +14,7 @@
 #include <OvDebug/Logger.h>
 #include <OvDebug/Assertion.h>
 #include <OvRendering/HAL/OpenGL/GLBackend.h>
+#include <OvRendering/HAL/OpenGL/GLShaderProgram.h>
 #include <OvRendering/HAL/OpenGL/GLTypes.h>
 #include <OvRendering/Utils/Conversions.h>
 
@@ -220,6 +221,8 @@ namespace OvRendering::HAL
 	template<>
 	std::optional<Data::PipelineState> GLBackend::Init(bool debug)
 	{
+		InvalidateGLShaderProgramBindingCache();
+
 		const int error = gladLoadGL();
 
 		if (error == 0)
@@ -248,6 +251,7 @@ namespace OvRendering::HAL
 	template<>
 	void GLBackend::OnFrameCompleted()
 	{
+		InvalidateGLShaderProgramBindingCache();
 		TracyGpuCollect;
 	}
 

--- a/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLShaderProgram.cpp
+++ b/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLShaderProgram.cpp
@@ -26,6 +26,11 @@ namespace
 	}
 }
 
+void OvRendering::HAL::InvalidateGLShaderProgramBindingCache()
+{
+	g_boundProgramId = 0;
+}
+
 template<>
 OvRendering::HAL::GLShaderProgram::TShaderProgram() : m_context{ .id = glCreateProgram() }
 {

--- a/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLShaderProgram.cpp
+++ b/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLShaderProgram.cpp
@@ -4,8 +4,8 @@
 * @licence: MIT
 */
 
-#include <array>
 #include <algorithm>
+#include <array>
 
 #include <glad.h>
 
@@ -18,6 +18,8 @@
 
 namespace
 {
+	uint32_t g_boundProgramId = 0;
+
 	constexpr bool IsReservedUniform(std::string_view p_name)
 	{
 		return p_name.starts_with("ubo_") || p_name.starts_with("ReflectionUBO");
@@ -33,19 +35,32 @@ OvRendering::HAL::GLShaderProgram::TShaderProgram() : m_context{ .id = glCreateP
 template<>
 OvRendering::HAL::GLShaderProgram::~TShaderProgram()
 {
+	if (g_boundProgramId == m_context.id)
+	{
+		g_boundProgramId = 0;
+	}
+
 	glDeleteProgram(m_context.id);
 }
 
 template<>
 void OvRendering::HAL::GLShaderProgram::Bind() const
 {
-	glUseProgram(m_context.id);
+	if (g_boundProgramId != m_context.id)
+	{
+		glUseProgram(m_context.id);
+		g_boundProgramId = m_context.id;
+	}
 }
 
 template<>
 void OvRendering::HAL::GLShaderProgram::Unbind() const
 {
-	glUseProgram(0);
+	if (g_boundProgramId != 0)
+	{
+		glUseProgram(0);
+		g_boundProgramId = 0;
+	}
 }
 
 template<>
@@ -91,12 +106,9 @@ template<> \
 type OvRendering::HAL::GLShaderProgram::GetUniform<type>(const std::string& p_name) \
 { \
 	type result{}; \
-	if (m_context.uniformsLocationCache.contains(p_name)) \
+	if (const auto location = m_context.uniformsLocationCache.find(p_name); location != m_context.uniformsLocationCache.end()) \
 	{ \
-		if (const uint32_t location = m_context.uniformsLocationCache.at(p_name)) \
-		{ \
-			func(m_context.id, location, reinterpret_cast<glType*>(&result)); \
-		} \
+		func(m_context.id, static_cast<GLint>(location->second), reinterpret_cast<glType*>(&result)); \
 	} \
 	return result; \
 }
@@ -114,9 +126,9 @@ template<> \
 template<> \
 void OvRendering::HAL::GLShaderProgram::SetUniform<type>(const std::string& p_name, const type& value) \
 { \
-	if (m_context.uniformsLocationCache.contains(p_name)) \
+	if (const auto location = m_context.uniformsLocationCache.find(p_name); location != m_context.uniformsLocationCache.end()) \
 	{ \
-		func(m_context.uniformsLocationCache.at(p_name), __VA_ARGS__); \
+		func(static_cast<GLint>(location->second), __VA_ARGS__); \
 	} \
 }
 


### PR DESCRIPTION
## Description
This PR addresses the CPU overhead reported in issue #793 by removing redundant shader/material work on the draw path.

Changes included:
- Cache OpenGL program binding to skip redundant `glUseProgram` calls.
- Avoid material unbind/rebind churn for every draw in `ABaseRenderer`.
- Upload material uniforms only when properties are dirty, while preserving single-use uniform behavior.

Overall, FPS drops less frequently and framerate remains more stable in heavy rendering scenarios.

## Related Issue(s)
Fixes #793

## Review Guidance
Please focus review on the rendering hot path changes:
- `OvRendering/HAL/OpenGL/GLShaderProgram.cpp`
- `OvRendering/Data/Material.cpp`
- `OvRendering/Core/ABaseRenderer.cpp`

## Screenshots/GIFs
N/A

## AI Usage Disclosure
Generate new code

## Checklist
- [x] My code follows the project's code style guidelines
- [ ] ~~When applicable, I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~When applicable, I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)

