### PR TITLE
Prevent OvEditor crash on unhandled sol::error after Lua runtime errors

### DIFF
--- a/Sources/OvCore/src/OvCore/Scripting/Lua/LuaScriptEngine.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/LuaScriptEngine.cpp
@@ -45,15 +45,22 @@ namespace
 
 		const sol::table& table = *static_cast<OvCore::Scripting::LuaScript&>(context.value()).GetContext().table;
 
-		if (table[p_functionName].valid())
+		try
 		{
-			sol::protected_function pfr = table[p_functionName];
-			auto pfrResult = pfr.call(table, std::forward<Args>(p_args)...);
-			if (!pfrResult.valid())
+			if (table[p_functionName].valid())
 			{
-				sol::error err = pfrResult;
-				OVLOG_ERROR(err.what());
+				sol::protected_function pfr = table[p_functionName];
+				auto pfrResult = pfr.call(table, std::forward<Args>(p_args)...);
+				if (!pfrResult.valid())
+				{
+					sol::error err = pfrResult;
+					OVLOG_ERROR(err.what());
+				}
 			}
+		}
+		catch (const sol::error& p_error)
+		{
+			OVLOG_ERROR(p_error.what());
 		}
 	}
 


### PR DESCRIPTION
## Description
This PR fixes a crash in OvEditor when a Lua runtime error triggers an unhandled `sol::error` during behaviour callback execution.

The Lua callback lookup/call path is now guarded to catch `sol::error` and log it instead of letting the exception propagate and terminate the editor.

Scope is intentionally minimal:
- Updated only `LuaScriptEngine.cpp`
- No API change
- No legacy fallback introduced

## Related Issue(s)
Fixes #797

## Review Guidance
Please focus on `ExecuteLuaFunction(...)` in:
`Sources/OvCore/src/OvCore/Scripting/Lua/LuaScriptEngine.cpp`

What changed:
- Wrapped Lua callback resolution/execution with a `try/catch (const sol::error&)`
- Preserved existing logging behavior for invalid protected call results

Expected behavior after this change:
- Lua runtime errors are logged
- Faulty script execution is interrupted
- OvEditor keeps running

## Screenshots/GIFs
N/A

## AI Usage Disclosure
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [ ] ~~When applicable, I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~When applicable, I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
