### PR TITLE
Add Actor::FindChild method and expose it to Lua

### DIFF
--- a/Resources/Engine/Lua/Scene/Actor.lua
+++ b/Resources/Engine/Lua/Scene/Actor.lua
@@ -33,6 +33,12 @@ function Actor:GetGUID() end
 ---@return Actor[]
 function Actor:GetChildren() end
 
+--- Finds a child actor by name
+---@param name string
+---@param recursive boolean
+---@return Actor|nil
+function Actor:FindChild(name, recursive) end
+
 --- Returns the parent (or nil) of this actor
 ---@return Actor|nil
 function Actor:GetParent() end

--- a/Sources/OvCore/include/OvCore/ECS/Actor.h
+++ b/Sources/OvCore/include/OvCore/ECS/Actor.h
@@ -176,6 +176,13 @@ namespace OvCore::ECS
 		std::vector<Actor*>& GetChildren();
 
 		/**
+		* Finds a child actor by name
+		* @param p_name
+		* @param p_recursive
+		*/
+		Actor* FindChild(const std::string& p_name, bool p_recursive) const;
+
+		/**
 		* Mark the Actor as "Destroyed". A "Destroyed" actor will be removed from the scene by the scene itself
 		*/
 		void MarkAsDestroy();

--- a/Sources/OvCore/src/OvCore/ECS/Actor.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Actor.cpp
@@ -247,6 +247,30 @@ std::vector<OvCore::ECS::Actor*>& OvCore::ECS::Actor::GetChildren()
 	return m_children;
 }
 
+OvCore::ECS::Actor* OvCore::ECS::Actor::FindChild(const std::string& p_name, bool p_recursive) const
+{
+	for (auto child : m_children)
+	{
+		if (child->GetName() == p_name)
+		{
+			return child;
+		}
+	}
+
+	if (p_recursive)
+	{
+		for (auto child : m_children)
+		{
+			if (auto found = child->FindChild(p_name, true); found)
+			{
+				return found;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
 void OvCore::ECS::Actor::MarkAsDestroy()
 {
 	m_destroyed = true;

--- a/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaActorBindings.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaActorBindings.cpp
@@ -39,6 +39,7 @@ void BindLuaActor(sol::state& p_luaState)
 		"SetName", &Actor::SetName,
 		"GetTag", &Actor::GetTag,
 		"GetChildren", &Actor::GetChildren,
+		"FindChild", &Actor::FindChild,
 		"SetTag", &Actor::SetTag,
 		"GetID", &Actor::GetID,
 		"GetGUID", [](Actor& p_actor) { return std::format("{:016X}", p_actor.GetGUID()); },


### PR DESCRIPTION
## Description
This PR adds a new `Actor::FindChild` method to search a child actor by name within an actor hierarchy.

Changes included:
- Added `Actor::FindChild(const std::string& p_name, bool p_recursive) const` to the C++ `Actor` API.
- Implemented the search logic in `Actor.cpp`:
  - first checks direct children,
  - then checks descendants recursively when `p_recursive` is `true`,
  - returns the first matching actor or `nullptr`.
- Exposed `FindChild` to Lua in `LuaActorBindings`.
- Updated Lua API stubs (`Resources/Engine/Lua/Scene/Actor.lua`) with the new method signature.

## Related Issue(s)
Fixes #798

## Review Guidance
Please review in this order:
1. `Sources/OvCore/include/OvCore/ECS/Actor.h` (new method declaration)
2. `Sources/OvCore/src/OvCore/ECS/Actor.cpp` (method implementation)
3. `Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaActorBindings.cpp` (Lua binding)
4. `Resources/Engine/Lua/Scene/Actor.lua` (Lua API stub update)

## Screenshots/GIFs
N/A

## AI Usage Disclosure
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
