### PR TITLE
Fix hierarchy actor creation menu target resolution

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -228,7 +228,7 @@ public:
 
 		OvEditor::Utils::ActorCreationMenu::GenerateActorCreationMenu(
 			createActor,
-			GetTargetActor(),
+			m_targetActor,
 			onItemClicked
 		);
 	}


### PR DESCRIPTION
## Description
This PR fixes the actor target used by the Hierarchy panel creation menu.

`ActorCreationMenu::GenerateActorCreationMenu` now receives `m_targetActor` directly instead of `GetTargetActor()`, ensuring the creation action consistently uses the current hierarchy target actor context.

## Related Issue(s)
Fixes #799

## Review Guidance
- Open the Hierarchy panel.
- Trigger the actor creation menu from different hierarchy contexts.
- Verify the created actor is associated with the expected target actor context.

## Screenshots/GIFs
N/A

## AI Usage Disclosure
Debug

## Checklist
- [x] My code follows the project's code style guidelines
- [ ] ~~When applicable, I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~When applicable, I have updated the documentation accordingly~~
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)

