### PR TITLE
Reduced material bind invocations by caching bind context

### DIFF
--- a/Sources/OvCore/include/OvCore/Rendering/SceneRenderer.h
+++ b/Sources/OvCore/include/OvCore/Rendering/SceneRenderer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 
 #include <OvRendering/Core/CompositeRenderer.h>
@@ -39,29 +40,29 @@ namespace OvCore::Rendering
 		struct DrawOrder
 		{
 			const int order;
+			const uintptr_t materialKey; // Only used in FRONT_TO_BACK to group same-material drawables
 			const float distance;
 
 			/**
 			* Determines the order of the drawables.
-			* Current order is: order -> distance
+			* For FRONT_TO_BACK (opaque): order -> materialKey -> distance (front-to-back within material group)
+			* For BACK_TO_FRONT (transparent/UI): order -> distance (back-to-front, strict)
 			* @param p_other
 			*/
 			bool operator<(const DrawOrder& p_other) const
 			{
-				if (order == p_other.order)
+				if (order != p_other.order)
+					return order < p_other.order;
+
+				if constexpr (OrderingMode == EOrderingMode::FRONT_TO_BACK)
 				{
-					if constexpr (OrderingMode == EOrderingMode::BACK_TO_FRONT)
-					{
-						return distance > p_other.distance;
-					}
-					else
-					{
-						return distance < p_other.distance;
-					}
+					if (materialKey != p_other.materialKey)
+						return materialKey < p_other.materialKey;
+					return distance < p_other.distance;
 				}
 				else
 				{
-					return order < p_other.order;
+					return distance > p_other.distance;
 				}
 			}
 		};

--- a/Sources/OvCore/src/OvCore/Rendering/SceneRenderer.cpp
+++ b/Sources/OvCore/src/OvCore/Rendering/SceneRenderer.cpp
@@ -436,6 +436,7 @@ SceneRenderer::SceneFilteredDrawablesDescriptor OvCore::Rendering::SceneRenderer
 		{
 			output.ui.emplace(decltype(decltype(output.ui)::value_type::first){
 				.order = drawableCopy.material->GetDrawOrder(),
+				.materialKey = 0,
 				.distance = distanceToCamera
 			}, drawableCopy);
 		}
@@ -443,6 +444,7 @@ SceneRenderer::SceneFilteredDrawablesDescriptor OvCore::Rendering::SceneRenderer
 		{
 			output.transparents.emplace(decltype(decltype(output.transparents)::value_type::first){
 				.order = drawableCopy.material->GetDrawOrder(),
+				.materialKey = 0,
 				.distance = distanceToCamera
 			}, drawableCopy);
 		}
@@ -450,6 +452,7 @@ SceneRenderer::SceneFilteredDrawablesDescriptor OvCore::Rendering::SceneRenderer
 		{
 			output.opaques.emplace(decltype(decltype(output.opaques)::value_type::first){
 				.order = drawableCopy.material->GetDrawOrder(),
+				.materialKey = reinterpret_cast<uintptr_t>(&drawableCopy.material.value()),
 				.distance = distanceToCamera
 			}, drawableCopy);
 		}

--- a/Sources/OvCore/src/OvCore/Resources/Material.cpp
+++ b/Sources/OvCore/src/OvCore/Resources/Material.cpp
@@ -125,6 +125,8 @@ void OvCore::Resources::Material::OnDeserialize(tinyxml2::XMLDocument& p_doc, ti
 {
 	using namespace OvCore::Helpers;
 
+	UpdateBindCacheVersion();
+
 	tinyxml2::XMLNode* settingsNode = p_node->FirstChildElement("settings");
 	
 	if (settingsNode)

--- a/Sources/OvRendering/include/OvRendering/Core/ABaseRenderer.h
+++ b/Sources/OvRendering/include/OvRendering/Core/ABaseRenderer.h
@@ -120,6 +120,13 @@ namespace OvRendering::Core
 			const Entities::Drawable& p_drawable
 		);
 
+		/**
+		* Reset the cached material bind context signature, forcing material.Bind calls
+		* even if the material was previously bound. It's recommended to invalidate the cache
+		* after other code-paths changed the graphics API context.
+		*/
+		virtual void InvalidateMaterialBindContextCache();
+
 	protected:
 		Data::FrameDescriptor m_frameDescriptor;
 		Context::Driver& m_driver;
@@ -128,6 +135,7 @@ namespace OvRendering::Core
 		OvRendering::Resources::Mesh m_unitQuad;
 		OvRendering::Data::PipelineState m_basePipelineState;
 		bool m_isDrawing;
+		std::size_t m_cachedMaterialBindContextHash;
 
 	private:
 		static std::atomic_bool s_isDrawing;

--- a/Sources/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/OvRendering/include/OvRendering/Data/Material.h
@@ -9,7 +9,6 @@
 #include <any>
 #include <map>
 #include <optional>
-#include <set>
 #include <variant>
 
 #include <OvMaths/FMatrix3.h>
@@ -95,9 +94,9 @@ namespace OvRendering::Data
 		* Calculate a hash for the material based on a given bind context, used for caching purposes.
 		* @param p_bindContext
 		*/
-		std::size_t CalculateBindContextHash(
+		[[nodiscard]] std::size_t CalculateBindContextHash(
 			const MaterialBindContext& p_bindContext
-		);
+		) const;
 
 		/**
 		* Bind the material and send its uniform data to the GPU
@@ -384,8 +383,8 @@ namespace OvRendering::Data
 	protected:
 		OvRendering::Resources::Shader* m_shader = nullptr;
 		PropertyMap m_properties;
-		std::set<std::string> m_mutableProperties;
 		Data::FeatureSet m_features;
+		bool m_hasMutableProperties = false;
 
 		bool m_supportOrthographic = true;
 		bool m_supportPerspective = true;

--- a/Sources/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/OvRendering/include/OvRendering/Data/Material.h
@@ -91,7 +91,8 @@ namespace OvRendering::Data
 		void UpdateProperties();
 
 		/**
-		* Calculate a hash for the material based on a given bind context, used for caching purposes.
+		* Calculate a hash for the material's stable (non-mutable) bind state, used for caching purposes.
+		* This hash is always computed regardless of whether mutable properties are present.
 		* @param p_bindContext
 		*/
 		[[nodiscard]] std::size_t CalculateBindContextHash(
@@ -99,10 +100,25 @@ namespace OvRendering::Data
 		) const;
 
 		/**
+		* Returns true if the material has mutable (singleUse) properties pending upload.
+		*/
+		[[nodiscard]] bool HasMutableProperties() const;
+
+		/**
 		* Bind the material and send its uniform data to the GPU
 		* @param p_bindContext
 		*/
 		void Bind(
+			const MaterialBindContext& p_bindContext
+		);
+
+		/**
+		* Re-upload only the mutable (singleUse) properties to an already-bound program.
+		* Call this instead of Bind() when the stable bind context hash hasn't changed
+		* but HasMutableProperties() is true.
+		* @param p_bindContext
+		*/
+		void BindMutableProperties(
 			const MaterialBindContext& p_bindContext
 		);
 

--- a/Sources/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/OvRendering/include/OvRendering/Data/Material.h
@@ -9,6 +9,7 @@
 #include <any>
 #include <map>
 #include <optional>
+#include <set>
 #include <variant>
 
 #include <OvMaths/FMatrix3.h>
@@ -42,6 +43,17 @@ namespace OvRendering::Data
 	{
 		MaterialPropertyType value;
 		bool singleUse;
+	};
+
+	/**
+	* Context required by materials when bound.
+	*/
+	struct MaterialBindContext
+	{
+		HAL::Texture* emptyTexture2D = nullptr; // p_emptyTexture2D (The texture to use if a texture uniform is null)
+		HAL::Texture* emptyTextureCube = nullptr; // p_emptyTextureCube (The texture to use if a texture uniform is null)
+		std::optional<const std::string_view> pass = std::nullopt;
+		OvTools::Utils::OptRef<const Data::FeatureSet> featureSetOverride = std::nullopt;
 	};
 
 	/**
@@ -80,17 +92,19 @@ namespace OvRendering::Data
 		void UpdateProperties();
 
 		/**
+		* Calculate a hash for the material based on a given bind context, used for caching purposes.
+		* @param p_bindContext
+		*/
+		std::size_t CalculateBindContextHash(
+			const MaterialBindContext& p_bindContext
+		);
+
+		/**
 		* Bind the material and send its uniform data to the GPU
-		* @param p_emptyTexture2D (The texture to use if a texture uniform is null)
-		* @param p_emptyTextureCube (The texture to use if a texture uniform is null)
-		* @param p_pass
-		* @param p_featureSetOverride
+		* @param p_bindContext
 		*/
 		void Bind(
-			HAL::Texture* p_emptyTexture2D = nullptr,
-			HAL::Texture* p_emptyTextureCube = nullptr,
-			std::optional<const std::string_view> p_pass = std::nullopt,
-			OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride = std::nullopt
+			const MaterialBindContext& p_bindContext
 		);
 
 		/**
@@ -365,8 +379,12 @@ namespace OvRendering::Data
 		bool SupportsProjectionMode(OvRendering::Settings::EProjectionMode p_projectionMode) const;
 
 	protected:
+		void UpdateBindCacheVersion();
+
+	protected:
 		OvRendering::Resources::Shader* m_shader = nullptr;
 		PropertyMap m_properties;
+		std::set<std::string> m_mutableProperties;
 		Data::FeatureSet m_features;
 
 		bool m_supportOrthographic = true;
@@ -387,5 +405,9 @@ namespace OvRendering::Data
 
 		int m_gpuInstances = 1;
 		int m_drawOrder = 1000;
+
+		// For caching purposes. If the material properties changed between 2 binds,
+		// this will ensure the material hash also changes.
+		std::size_t m_bindCacheVersion = 0;
 	};
 }

--- a/Sources/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
+++ b/Sources/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
@@ -39,7 +39,8 @@ OvRendering::Core::ABaseRenderer::ABaseRenderer(Context::Driver& p_driver) :
 	m_isDrawing(false),
 	m_emptyTexture2D{ Settings::ETextureType::TEXTURE_2D },
 	m_emptyTextureCube{ Settings::ETextureType::TEXTURE_CUBE },
-	m_unitQuad(kUnitQuadVertices, kUnitQuadIndices)
+	m_unitQuad(kUnitQuadVertices, kUnitQuadIndices),
+	m_cachedMaterialBindContextHash(0UL)
 {
 	const auto kEmptyTextureDesc = Settings::TextureDesc{
 		.width = 1,
@@ -65,6 +66,8 @@ void OvRendering::Core::ABaseRenderer::BeginFrame(const Data::FrameDescriptor& p
 
 	OVASSERT(!s_isDrawing, "Cannot call BeginFrame() when previous frame hasn't finished.");
 	OVASSERT(p_frameDescriptor.IsValid(), "Invalid FrameDescriptor!");
+
+	InvalidateMaterialBindContextCache();
 
 	m_frameDescriptor = p_frameDescriptor;
 
@@ -230,14 +233,24 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 		}
 	}
 
-	p_drawable.material->Bind(
-		&m_emptyTexture2D,
-		&m_emptyTextureCube,
-		p_drawable.pass,
-		p_drawable.featureSetOverride.has_value() ?
-		OvTools::Utils::OptRef<const Data::FeatureSet>(p_drawable.featureSetOverride.value()) :
-		std::nullopt
-	);
+	const Data::MaterialBindContext bindContext{
+		.emptyTexture2D = &m_emptyTexture2D,
+		.emptyTextureCube = &m_emptyTextureCube,
+		.pass = p_drawable.pass,
+		.featureSetOverride = 
+			p_drawable.featureSetOverride.has_value() ?
+			OvTools::Utils::OptRef<const Data::FeatureSet>(p_drawable.featureSetOverride.value()) :
+			std::nullopt
+	};
+
+	const std::size_t bindContextHash = p_drawable.material->CalculateBindContextHash(bindContext);
+
+	if (bindContextHash == 0 || bindContextHash != m_cachedMaterialBindContextHash)
+	{
+		p_drawable.material->Bind(bindContext);
+	}
+
+	m_cachedMaterialBindContextHash = bindContextHash;
 
 	m_driver.Draw(
 		p_pso,
@@ -246,3 +259,9 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 		p_drawable.material->GetGPUInstances()
 	);
 }
+
+void OvRendering::Core::ABaseRenderer::InvalidateMaterialBindContextCache()
+{
+	m_cachedMaterialBindContextHash = 0;
+}
+

--- a/Sources/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
+++ b/Sources/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
@@ -243,14 +243,17 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 			std::nullopt
 	};
 
-	const std::size_t bindContextHash = p_drawable.material->CalculateBindContextHash(bindContext);
+	const std::size_t stableHash = p_drawable.material->CalculateBindContextHash(bindContext);
 
-	if (bindContextHash == 0 || bindContextHash != m_cachedMaterialBindContextHash)
+	if (stableHash == 0 || stableHash != m_cachedMaterialBindContextHash)
 	{
 		p_drawable.material->Bind(bindContext);
+		m_cachedMaterialBindContextHash = stableHash;
 	}
-
-	m_cachedMaterialBindContextHash = bindContextHash;
+	else if (p_drawable.material->HasMutableProperties())
+	{
+		p_drawable.material->BindMutableProperties(bindContext);
+	}
 
 	m_driver.Draw(
 		p_pso,

--- a/Sources/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/OvRendering/src/OvRendering/Data/Material.cpp
@@ -21,6 +21,14 @@
 
 namespace
 {
+	OvRendering::HAL::TextureHandle* GetTextureHandle(const OvRendering::Data::MaterialPropertyType& p_value)
+	{
+		if (auto h = std::get_if<OvRendering::HAL::TextureHandle*>(&p_value)) return *h;
+		if (auto t = std::get_if<OvRendering::Resources::Texture*>(&p_value))
+			if (*t) return &(*t)->GetTexture();
+		return nullptr;
+	}
+
 	OvRendering::Data::MaterialPropertyType UniformToPropertyValue(const std::any& p_uniformValue)
 	{
 		using namespace OvMaths;
@@ -140,12 +148,6 @@ std::size_t OvRendering::Data::Material::CalculateBindContextHash(
 
 	std::size_t hash{};
 
-	// Materials with mutable properties (singleUse) cannot be cached to avoid unnecessary binds.
-	if (m_hasMutableProperties)
-	{
-		return hash;
-	}
-
 	// Self pointer
 	OvTools::Utils::HashCombine(hash, this);
 
@@ -238,23 +240,78 @@ void OvRendering::Data::Material::Bind(
 		}
 		else if (uniformType == SAMPLER_2D || uniformType == SAMPLER_CUBE)
 		{
-			HAL::TextureHandle* handle = nullptr;
-			if (auto textureHandle = std::get_if<HAL::TextureHandle*>(&value))
-			{
-				handle = *textureHandle;
-			}
-			else if (auto texture = std::get_if<Resources::Texture*>(&value))
-			{
-				if (*texture != nullptr)
-				{
-					handle = &(*texture)->GetTexture();
-				}
-			}
-			BindTexture(program, name, handle, uniformType == SAMPLER_2D ? p_bindContext.emptyTexture2D : p_bindContext.emptyTextureCube, textureSlot);
+			BindTexture(program, name, GetTextureHandle(value), uniformType == SAMPLER_2D ? p_bindContext.emptyTexture2D : p_bindContext.emptyTextureCube, textureSlot);
 		}
 
 		if (prop.singleUse)
 		{
+			value = UniformToPropertyValue(uniformData->defaultValue);
+		}
+	}
+
+	m_hasMutableProperties = false;
+}
+
+bool OvRendering::Data::Material::HasMutableProperties() const
+{
+	return m_hasMutableProperties;
+}
+
+void OvRendering::Data::Material::BindMutableProperties(
+	const OvRendering::Data::MaterialBindContext& p_bindContext
+)
+{
+	ZoneScoped;
+
+	using namespace OvMaths;
+	using enum OvRendering::Settings::EUniformType;
+
+	OVASSERT(IsValid(), "Attempting to BindMutableProperties on an invalid material.");
+
+	auto& program = m_shader->GetVariant(
+		p_bindContext.pass,
+		p_bindContext.featureSetOverride.value_or(m_features)
+	);
+
+	// Iterate all properties in the same order as Bind() to maintain correct texture slot indices.
+	// Non-mutable texture slots are counted but not rebound (still bound from the prior full Bind call).
+	int textureSlot = 0;
+
+	for (auto& [name, prop] : m_properties)
+	{
+		const auto uniformData = program.GetUniformInfo(name);
+		if (!uniformData) continue;
+
+		auto& value = prop.value;
+		const auto uniformType = uniformData->type;
+		const bool isTexture = (uniformType == SAMPLER_2D || uniformType == SAMPLER_CUBE);
+
+		if (isTexture)
+		{
+			auto* fallback = uniformType == SAMPLER_2D ? p_bindContext.emptyTexture2D : p_bindContext.emptyTextureCube;
+
+			if (prop.singleUse)
+			{
+				BindTexture(program, name, GetTextureHandle(value), fallback, textureSlot);
+				value = UniformToPropertyValue(uniformData->defaultValue);
+			}
+			else
+			{
+				// Count the slot without rebinding; the texture is still bound from the prior full Bind.
+				if (GetTextureHandle(value) || fallback) ++textureSlot;
+			}
+		}
+		else if (prop.singleUse)
+		{
+			if (uniformType == BOOL)            program.SetUniform<int>(name, static_cast<int>(std::get<bool>(value)));
+			else if (uniformType == INT)        program.SetUniform<int>(name, std::get<int>(value));
+			else if (uniformType == FLOAT)      program.SetUniform<float>(name, std::get<float>(value));
+			else if (uniformType == FLOAT_VEC2) program.SetUniform<FVector2>(name, std::get<FVector2>(value));
+			else if (uniformType == FLOAT_VEC3) program.SetUniform<FVector3>(name, std::get<FVector3>(value));
+			else if (uniformType == FLOAT_VEC4) program.SetUniform<FVector4>(name, std::get<FVector4>(value));
+			else if (uniformType == FLOAT_MAT3) program.SetUniform<FMatrix3>(name, std::get<FMatrix3>(value));
+			else if (uniformType == FLOAT_MAT4) program.SetUniform<FMatrix4>(name, std::get<FMatrix4>(value));
+
 			value = UniformToPropertyValue(uniformData->defaultValue);
 		}
 	}

--- a/Sources/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/OvRendering/src/OvRendering/Data/Material.cpp
@@ -4,7 +4,6 @@
 * @licence: MIT
 */
 
-#include <format>
 #include <ranges>
 
 #include <tracy/Tracy.hpp>
@@ -17,6 +16,7 @@
 #include <OvRendering/HAL/TextureHandle.h>
 #include <OvRendering/Resources/Texture.h>
 
+#include <OvTools/Utils/Hash.h>
 #include <OvTools/Utils/OptRef.h>
 
 namespace
@@ -70,6 +70,8 @@ OvRendering::Data::Material::Material(OvRendering::Resources::Shader* p_shader)
 
 void OvRendering::Data::Material::SetShader(OvRendering::Resources::Shader* p_shader)
 {
+	UpdateBindCacheVersion();
+
 	m_shader = p_shader;
 
 	if (m_shader)
@@ -130,13 +132,43 @@ void OvRendering::Data::Material::UpdateProperties()
 	});
 }
 
+std::size_t OvRendering::Data::Material::CalculateBindContextHash(
+	const OvRendering::Data::MaterialBindContext& p_bindContext
+)
+{
+	ZoneScoped;
+
+	std::size_t hash{};
+
+	// Materials with mutable properties (singleUse) cannot be cached to avoid unnecessary binds.
+	if (!m_mutableProperties.empty())
+	{
+		return hash;
+	}
+
+	// Self pointer
+	OvTools::Utils::HashCombine(hash, this);
+
+	// Cache version (ensures property changes invalidate the hash)
+	OvTools::Utils::HashCombine(hash, m_bindCacheVersion);
+
+	// Texture pointers
+	OvTools::Utils::HashCombine(hash, p_bindContext.emptyTexture2D);
+	OvTools::Utils::HashCombine(hash, p_bindContext.emptyTextureCube);
+
+	// Pass
+	OvTools::Utils::HashCombine(hash, p_bindContext.pass);
+
+	// FeatureSet
+	OvTools::Utils::HashCombine(hash, FeatureSetHash{}(p_bindContext.featureSetOverride.value_or(m_features)));
+
+	return hash;
+}
+
 // Note: this function is critical for performance, as it may be called many times during a frame.
 // Avoid using any heavy operations or allocations inside this function.
 void OvRendering::Data::Material::Bind(
-	HAL::Texture* p_emptyTexture,
-	HAL::Texture* p_emptyTextureCube,
-	std::optional<const std::string_view> p_pass,
-	OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride
+	const OvRendering::Data::MaterialBindContext& p_bindContext
 )
 {
 	ZoneScoped;
@@ -147,8 +179,8 @@ void OvRendering::Data::Material::Bind(
 	OVASSERT(IsValid(), "Attempting to bind an invalid material.");
 
 	auto& program = m_shader->GetVariant(
-		p_pass,
-		p_featureSetOverride.value_or(m_features)
+		p_bindContext.pass,
+		p_bindContext.featureSetOverride.value_or(m_features)
 	);
 
 	program.Bind();
@@ -218,7 +250,7 @@ void OvRendering::Data::Material::Bind(
 					handle = &(*texture)->GetTexture();
 				}
 			}
-			BindTexture(program, name, handle, uniformType == SAMPLER_2D ? p_emptyTexture : p_emptyTextureCube, textureSlot);
+			BindTexture(program, name, handle, uniformType == SAMPLER_2D ? p_bindContext.emptyTexture2D : p_bindContext.emptyTextureCube, textureSlot);
 		}
 
 		if (prop.singleUse)
@@ -226,6 +258,8 @@ void OvRendering::Data::Material::Bind(
 			value = UniformToPropertyValue(uniformData->defaultValue);
 		}
 	}
+
+	m_mutableProperties.clear();
 }
 
 void OvRendering::Data::Material::Unbind() const
@@ -245,10 +279,17 @@ void OvRendering::Data::Material::SetProperty(const std::string p_name, const Ma
 	OVASSERT(IsValid(), "Attempting to SetProperty on an invalid material.");
 	OVASSERT(HasProperty(p_name), "Attempting to SetProperty on a non-existing property.");
 
+	UpdateBindCacheVersion();
+
 	m_properties[p_name] = MaterialProperty{
 		p_value,
 		p_singleUse
 	};
+
+	if (p_singleUse)
+	{
+		m_mutableProperties.insert(p_name);
+	}
 }
 
 bool OvRendering::Data::Material::TrySetProperty(const std::string& p_name, const MaterialPropertyType& p_value, bool p_singleUse)
@@ -453,16 +494,19 @@ OvRendering::Data::FeatureSet& OvRendering::Data::Material::GetFeatures()
 
 void OvRendering::Data::Material::SetFeatures(const Data::FeatureSet& p_features)
 {
+	UpdateBindCacheVersion();
 	m_features = p_features;
 }
 
 void OvRendering::Data::Material::AddFeature(const std::string& p_feature)
 {
+	UpdateBindCacheVersion();
 	m_features.insert(p_feature);
 }
 
 void OvRendering::Data::Material::RemoveFeature(const std::string& p_feature)
 {
+	UpdateBindCacheVersion();
 	m_features.erase(p_feature);
 }
 
@@ -504,4 +548,9 @@ bool OvRendering::Data::Material::SupportsProjectionMode(OvRendering::Settings::
 	}
 
 	return true;
+}
+
+void OvRendering::Data::Material::UpdateBindCacheVersion()
+{
+	++m_bindCacheVersion;
 }

--- a/Sources/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/OvRendering/src/OvRendering/Data/Material.cpp
@@ -134,14 +134,14 @@ void OvRendering::Data::Material::UpdateProperties()
 
 std::size_t OvRendering::Data::Material::CalculateBindContextHash(
 	const OvRendering::Data::MaterialBindContext& p_bindContext
-)
+) const
 {
 	ZoneScoped;
 
 	std::size_t hash{};
 
 	// Materials with mutable properties (singleUse) cannot be cached to avoid unnecessary binds.
-	if (!m_mutableProperties.empty())
+	if (m_hasMutableProperties)
 	{
 		return hash;
 	}
@@ -259,7 +259,7 @@ void OvRendering::Data::Material::Bind(
 		}
 	}
 
-	m_mutableProperties.clear();
+	m_hasMutableProperties = false;
 }
 
 void OvRendering::Data::Material::Unbind() const
@@ -279,8 +279,6 @@ void OvRendering::Data::Material::SetProperty(const std::string p_name, const Ma
 	OVASSERT(IsValid(), "Attempting to SetProperty on an invalid material.");
 	OVASSERT(HasProperty(p_name), "Attempting to SetProperty on a non-existing property.");
 
-	UpdateBindCacheVersion();
-
 	m_properties[p_name] = MaterialProperty{
 		p_value,
 		p_singleUse
@@ -288,7 +286,12 @@ void OvRendering::Data::Material::SetProperty(const std::string p_name, const Ma
 
 	if (p_singleUse)
 	{
-		m_mutableProperties.insert(p_name);
+		// singleUse bypasses the bind cache (hash=0), so no need to bump the version.
+		m_hasMutableProperties = true;
+	}
+	else
+	{
+		UpdateBindCacheVersion();
 	}
 }
 

--- a/Sources/OvTools/include/OvTools/Utils/Hash.h
+++ b/Sources/OvTools/include/OvTools/Utils/Hash.h
@@ -13,9 +13,9 @@ namespace OvTools::Utils
 	template<typename T>
 	inline void HashCombine(std::size_t& seed, const T& value)
 	{
-		// A large odd constant derived from the golden ratio.
+		// A large odd constant derived from the golden ratio (64-bit variant).
 		// It helps distribute bits more uniformly and reduce clustering/collisions.
-		constexpr std::size_t kHashCombineConstant = 0x9e3779b9;
+		constexpr std::size_t kHashCombineConstant = 0x9e3779b97f4a7c15ULL;
 
 		seed ^= std::hash<T>{}(value)
 			+ kHashCombineConstant 

--- a/Sources/OvTools/include/OvTools/Utils/Hash.h
+++ b/Sources/OvTools/include/OvTools/Utils/Hash.h
@@ -1,0 +1,28 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <functional>
+
+namespace OvTools::Utils
+{
+	template<typename T>
+	inline void HashCombine(std::size_t& seed, const T& value)
+	{
+		// A large odd constant derived from the golden ratio.
+		// It helps distribute bits more uniformly and reduce clustering/collisions.
+		constexpr std::size_t kHashCombineConstant = 0x9e3779b9;
+
+		seed ^= std::hash<T>{}(value)
+			+ kHashCombineConstant 
+			// Bit mixing. They spread entropy from earlier values so order matters
+			// and nearby hashes don’t collapse into similar outputs.
+			+ (seed << 6)
+			+ (seed >> 2);
+	}
+}
+


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Reduced material bind invocations by caching bind context.

Currently mostly help with trivial render pass that aren't using mutable properties (e.g. shadows, reflections).

## To-Do
- [ ] Improve caching when using mutable properties
  - Maybe a light `Bind` version could be added that would only update mutable properties

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #445

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

<img width="1029" height="104" alt="image" src="https://github.com/user-attachments/assets/ab0281aa-3413-4647-a55b-2885c3545f15" />

_Single Bind for the entire shadow pass_

## AI Usage Disclosure
<!-- Replace with "None" if not used -->
None

## Checklist
<!-- Check all that apply -->
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
