### PR TITLE
Reduced shader program state changes & property uploads

### DIFF
--- a/Sources/OvCore/include/OvCore/Rendering/SceneRenderer.h
+++ b/Sources/OvCore/include/OvCore/Rendering/SceneRenderer.h
@@ -35,21 +35,29 @@ namespace OvCore::Rendering
 			FRONT_TO_BACK,
 		};
 
-		template<EOrderingMode OrderingMode>
+		template<EOrderingMode OrderingMode, bool BatchMaterial>
 		struct DrawOrder
 		{
 			const int order;
+			const uintptr_t materialKey;
 			const float distance;
 
 			/**
 			* Determines the order of the drawables.
-			* Current order is: order -> distance
 			* @param p_other
 			*/
 			bool operator<(const DrawOrder& p_other) const
 			{
 				if (order == p_other.order)
 				{
+					if constexpr (BatchMaterial)
+					{
+						if (materialKey != p_other.materialKey)
+						{
+							return materialKey < p_other.materialKey;
+						}
+					}
+
 					if constexpr (OrderingMode == EOrderingMode::BACK_TO_FRONT)
 					{
 						return distance > p_other.distance;
@@ -66,8 +74,8 @@ namespace OvCore::Rendering
 			}
 		};
 
-		template<EOrderingMode OrderingMode>
-		using DrawableMap = std::multimap<DrawOrder<OrderingMode>, OvRendering::Entities::Drawable>;
+		template<EOrderingMode OrderingMode, bool BatchMaterial = false>
+		using DrawableMap = std::multimap<DrawOrder<OrderingMode, BatchMaterial>, OvRendering::Entities::Drawable>;
 
 		/**
 		* Input data for the scene renderer.
@@ -108,7 +116,7 @@ namespace OvCore::Rendering
 		*/
 		struct SceneFilteredDrawablesDescriptor
 		{
-			DrawableMap<EOrderingMode::FRONT_TO_BACK> opaques;
+			DrawableMap<EOrderingMode::FRONT_TO_BACK, true> opaques;
 			DrawableMap<EOrderingMode::BACK_TO_FRONT> transparents;
 			DrawableMap<EOrderingMode::BACK_TO_FRONT> ui;
 		};

--- a/Sources/OvCore/src/OvCore/Rendering/SceneRenderer.cpp
+++ b/Sources/OvCore/src/OvCore/Rendering/SceneRenderer.cpp
@@ -436,6 +436,7 @@ SceneRenderer::SceneFilteredDrawablesDescriptor OvCore::Rendering::SceneRenderer
 		{
 			output.ui.emplace(decltype(decltype(output.ui)::value_type::first){
 				.order = drawableCopy.material->GetDrawOrder(),
+				.materialKey = reinterpret_cast<uintptr_t>(&drawableCopy.material.value()),
 				.distance = distanceToCamera
 			}, drawableCopy);
 		}
@@ -443,6 +444,7 @@ SceneRenderer::SceneFilteredDrawablesDescriptor OvCore::Rendering::SceneRenderer
 		{
 			output.transparents.emplace(decltype(decltype(output.transparents)::value_type::first){
 				.order = drawableCopy.material->GetDrawOrder(),
+				.materialKey = reinterpret_cast<uintptr_t>(&drawableCopy.material.value()),
 				.distance = distanceToCamera
 			}, drawableCopy);
 		}
@@ -450,6 +452,7 @@ SceneRenderer::SceneFilteredDrawablesDescriptor OvCore::Rendering::SceneRenderer
 		{
 			output.opaques.emplace(decltype(decltype(output.opaques)::value_type::first){
 				.order = drawableCopy.material->GetDrawOrder(),
+				.materialKey = reinterpret_cast<uintptr_t>(&drawableCopy.material.value()),
 				.distance = distanceToCamera
 			}, drawableCopy);
 		}

--- a/Sources/OvRendering/include/OvRendering/Core/ABaseRenderer.h
+++ b/Sources/OvRendering/include/OvRendering/Core/ABaseRenderer.h
@@ -128,6 +128,7 @@ namespace OvRendering::Core
 		OvRendering::Resources::Mesh m_unitQuad;
 		OvRendering::Data::PipelineState m_basePipelineState;
 		bool m_isDrawing;
+		std::optional<std::size_t> m_lastEntitySignature = std::nullopt;
 
 	private:
 		static std::atomic_bool s_isDrawing;

--- a/Sources/OvRendering/include/OvRendering/Core/ABaseRenderer.h
+++ b/Sources/OvRendering/include/OvRendering/Core/ABaseRenderer.h
@@ -128,7 +128,7 @@ namespace OvRendering::Core
 		OvRendering::Resources::Mesh m_unitQuad;
 		OvRendering::Data::PipelineState m_basePipelineState;
 		bool m_isDrawing;
-		std::optional<std::size_t> m_lastEntitySignature = std::nullopt;
+		std::optional<OvRendering::Data::MaterialSignatureSet> m_previousMaterialSignature = std::nullopt;
 
 	private:
 		static std::atomic_bool s_isDrawing;

--- a/Sources/OvRendering/include/OvRendering/Core/CompositeRenderer.h
+++ b/Sources/OvRendering/include/OvRendering/Core/CompositeRenderer.h
@@ -6,8 +6,9 @@
 
 #pragma once
 
-#include <typeindex>
+#include <map>
 #include <memory>
+#include <typeindex>
 
 #include <OvRendering/Core/ABaseRenderer.h>
 #include <OvRendering/Core/ARenderPass.h>

--- a/Sources/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/OvRendering/include/OvRendering/Data/Material.h
@@ -45,6 +45,16 @@ namespace OvRendering::Data
 	};
 
 	/**
+	* Signature set for a material, used for caching purposes
+	*/
+	struct MaterialSignatureSet
+	{
+		std::size_t bindSignature;
+		std::size_t stablePropertySignature;
+		std::size_t singleUsePropertySignature;
+	};
+
+	/**
 	* A material is a combination of a shader and some settings (Material settings and shader settings)
 	*/
 	class Material
@@ -81,19 +91,19 @@ namespace OvRendering::Data
 
 		/**
 		* Bind the appropriate shader program based on a given pass and potential feature set override
-		* @return Material signature, so that subsequent draw can use it for caching purposes.
+		* @return Material signature, used to skip redundant binding/upload operations
 		* @param p_pass
 		* @param p_featureSetOverride
 		* @param p_emptyTexture2D (The texture to use if a texture uniform is null)
 		* @param p_emptyTextureCube (The texture to use if a texture uniform is null)
-		* @param p_lastBindSignature (Can be used to skip binding if the signature is the same as the last bind)
+		* @param p_previousMaterialSignature (Can be used to skip binding)
 		*/
-		std::size_t Bind(
+		MaterialSignatureSet Bind(
 			std::optional<const std::string_view> p_pass = std::nullopt,
 			OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride = std::nullopt,
 			HAL::Texture* p_emptyTexture2D = nullptr,
 			HAL::Texture* p_emptyTextureCube = nullptr,
-			std::optional<std::size_t> p_lastBindSignature = std::nullopt
+			std::optional<MaterialSignatureSet> p_previousMaterialSignature = std::nullopt
 		);
 
 		/**
@@ -385,7 +395,7 @@ namespace OvRendering::Data
 	protected:
 		void InvalidatePropertySignature();
 
-		std::size_t CalculateSignature(
+		MaterialSignatureSet CalculateSignature(
 			OvRendering::HAL::ShaderProgram& p_selectedProgram,
 			HAL::Texture* p_emptyTexture2D = nullptr,
 			HAL::Texture* p_emptyTextureCube = nullptr
@@ -395,7 +405,8 @@ namespace OvRendering::Data
 		OvRendering::Resources::Shader* m_shader = nullptr;
 		PropertyMap m_properties;
 		Data::FeatureSet m_features;
-		size_t m_propertySignatureVersion = 0ULL;
+		size_t m_stablePropertySignatureVersion = 0ULL;
+		size_t m_singleUsePropertySignatureVersion = 0ULL;
 		OvTools::Utils::OptRef<OvRendering::HAL::ShaderProgram> m_programInUse = std::nullopt;
 
 		bool m_supportOrthographic = true;

--- a/Sources/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/OvRendering/include/OvRendering/Data/Material.h
@@ -6,9 +6,8 @@
 
 #pragma once
 
-#include <any>
-#include <map>
 #include <optional>
+#include <unordered_map>
 #include <variant>
 
 #include <OvMaths/FMatrix3.h>
@@ -41,6 +40,7 @@ namespace OvRendering::Data
 	struct MaterialProperty
 	{
 		MaterialPropertyType value;
+		MaterialPropertyType defaultValue;
 		bool singleUse;
 	};
 
@@ -60,7 +60,7 @@ namespace OvRendering::Data
 	class Material
 	{
 	public:
-		using PropertyMap = std::map<std::string, MaterialProperty>;
+		using PropertyMap = std::unordered_map<std::string, MaterialProperty>;
 
 		/**
 		* Creates a material

--- a/Sources/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/OvRendering/include/OvRendering/Data/Material.h
@@ -80,23 +80,41 @@ namespace OvRendering::Data
 		void UpdateProperties();
 
 		/**
-		* Bind the material and send its uniform data to the GPU
-		* @param p_emptyTexture2D (The texture to use if a texture uniform is null)
-		* @param p_emptyTextureCube (The texture to use if a texture uniform is null)
+		* Bind the appropriate shader program based on a given pass and potential feature set override
+		* @return Material signature, so that subsequent draw can use it for caching purposes.
 		* @param p_pass
 		* @param p_featureSetOverride
+		* @param p_emptyTexture2D (The texture to use if a texture uniform is null)
+		* @param p_emptyTextureCube (The texture to use if a texture uniform is null)
+		* @param p_lastBindSignature (Can be used to skip binding if the signature is the same as the last bind)
 		*/
-		void Bind(
+		std::size_t Bind(
+			std::optional<const std::string_view> p_pass = std::nullopt,
+			OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride = std::nullopt,
 			HAL::Texture* p_emptyTexture2D = nullptr,
 			HAL::Texture* p_emptyTextureCube = nullptr,
-			std::optional<const std::string_view> p_pass = std::nullopt,
-			OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride = std::nullopt
+			std::optional<std::size_t> p_lastBindSignature = std::nullopt
+		);
+
+		/**
+		* Upload the material properties to the GPU.
+		* @param bool uploadStableProperties
+		* @parma bool uploadSingleUseProperties
+		* @param p_emptyTexture2D (The texture to use if a texture uniform is null)
+		* @param p_emptyTextureCube (The texture to use if a texture uniform is null)
+		*/
+		void UploadProperties(
+			bool uploadStableProperties,
+			bool uploadSingleUseProperties,
+			HAL::Texture* p_emptyTexture2D = nullptr,
+			HAL::Texture* p_emptyTextureCube = nullptr
 		);
 
 		/**
 		* Unbind the material
+		* @param p_resetBoundProgram (ensures the last used program is fully unbound to minimize context leaks, only use after your done drawing with this material)
 		*/
-		void Unbind() const;
+		void Unbind(bool p_resetBoundProgram = false);
 
 		/**
 		* Returns true if the material has a given property
@@ -365,9 +383,20 @@ namespace OvRendering::Data
 		bool SupportsProjectionMode(OvRendering::Settings::EProjectionMode p_projectionMode) const;
 
 	protected:
+		void InvalidatePropertySignature();
+
+		std::size_t CalculateSignature(
+			OvRendering::HAL::ShaderProgram& p_selectedProgram,
+			HAL::Texture* p_emptyTexture2D = nullptr,
+			HAL::Texture* p_emptyTextureCube = nullptr
+		);
+
+	protected:
 		OvRendering::Resources::Shader* m_shader = nullptr;
 		PropertyMap m_properties;
 		Data::FeatureSet m_features;
+		size_t m_propertySignatureVersion = 0ULL;
+		OvTools::Utils::OptRef<OvRendering::HAL::ShaderProgram> m_programInUse = std::nullopt;
 
 		bool m_supportOrthographic = true;
 		bool m_supportPerspective = true;

--- a/Sources/OvRendering/include/OvRendering/Settings/UniformInfo.h
+++ b/Sources/OvRendering/include/OvRendering/Settings/UniformInfo.h
@@ -21,5 +21,6 @@ namespace OvRendering::Settings
 		EUniformType type;
 		std::string name;
 		std::any defaultValue;
+		uint32_t textureSlot;
 	};
 }

--- a/Sources/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
+++ b/Sources/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
@@ -66,6 +66,8 @@ void OvRendering::Core::ABaseRenderer::BeginFrame(const Data::FrameDescriptor& p
 	OVASSERT(!s_isDrawing, "Cannot call BeginFrame() when previous frame hasn't finished.");
 	OVASSERT(p_frameDescriptor.IsValid(), "Invalid FrameDescriptor!");
 
+	m_lastEntitySignature.reset();
+
 	m_frameDescriptor = p_frameDescriptor;
 
 	if (p_frameDescriptor.outputBuffer)
@@ -230,14 +232,24 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 		}
 	}
 
-	p_drawable.material->Bind(
-		&m_emptyTexture2D,
-		&m_emptyTextureCube,
+	const std::size_t signature = p_drawable.material->Bind(
 		p_drawable.pass,
 		p_drawable.featureSetOverride.has_value() ?
-		OvTools::Utils::OptRef<const Data::FeatureSet>(p_drawable.featureSetOverride.value()) :
-		std::nullopt
+			OvTools::Utils::OptRef<const Data::FeatureSet>(p_drawable.featureSetOverride.value()) :
+			std::nullopt,
+		&m_emptyTexture2D,
+		&m_emptyTextureCube,
+		m_lastEntitySignature
 	);
+
+	p_drawable.material->UploadProperties(
+		!m_lastEntitySignature.has_value() || signature != m_lastEntitySignature.value(),
+		true,
+		&m_emptyTexture2D,
+		&m_emptyTextureCube
+	);
+
+	m_lastEntitySignature = signature;
 
 	m_driver.Draw(
 		p_pso,
@@ -245,4 +257,6 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 		p_drawable.primitiveMode,
 		p_drawable.material->GetGPUInstances()
 	);
+
+	p_drawable.material->Unbind();
 }

--- a/Sources/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
+++ b/Sources/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
@@ -66,7 +66,7 @@ void OvRendering::Core::ABaseRenderer::BeginFrame(const Data::FrameDescriptor& p
 	OVASSERT(!s_isDrawing, "Cannot call BeginFrame() when previous frame hasn't finished.");
 	OVASSERT(p_frameDescriptor.IsValid(), "Invalid FrameDescriptor!");
 
-	m_lastEntitySignature.reset();
+	m_previousMaterialSignature.reset();
 
 	m_frameDescriptor = p_frameDescriptor;
 
@@ -232,24 +232,30 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 		}
 	}
 
-	const std::size_t signature = p_drawable.material->Bind(
+	const auto signature = p_drawable.material->Bind(
 		p_drawable.pass,
 		p_drawable.featureSetOverride.has_value() ?
 			OvTools::Utils::OptRef<const Data::FeatureSet>(p_drawable.featureSetOverride.value()) :
 			std::nullopt,
 		&m_emptyTexture2D,
 		&m_emptyTextureCube,
-		m_lastEntitySignature
+		m_previousMaterialSignature
 	);
 
-	p_drawable.material->UploadProperties(
-		!m_lastEntitySignature.has_value() || signature != m_lastEntitySignature.value(),
-		true,
-		&m_emptyTexture2D,
-		&m_emptyTextureCube
-	);
+	const bool uploadStableProperties = !m_previousMaterialSignature.has_value() || signature.stablePropertySignature != m_previousMaterialSignature->stablePropertySignature;
+	const bool uploadSingleUseProperties = !m_previousMaterialSignature.has_value() || signature.singleUsePropertySignature != m_previousMaterialSignature->singleUsePropertySignature;
 
-	m_lastEntitySignature = signature;
+	if (uploadStableProperties || uploadSingleUseProperties)
+	{
+		p_drawable.material->UploadProperties(
+			uploadStableProperties,
+			uploadSingleUseProperties,
+			&m_emptyTexture2D,
+			&m_emptyTextureCube
+		);
+	}
+
+	m_previousMaterialSignature = signature;
 
 	m_driver.Draw(
 		p_pso,

--- a/Sources/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/OvRendering/src/OvRendering/Data/Material.cpp
@@ -147,12 +147,12 @@ void OvRendering::Data::Material::UpdateProperties()
 	});
 }
 
-std::size_t OvRendering::Data::Material::Bind(
+OvRendering::Data::MaterialSignatureSet OvRendering::Data::Material::Bind(
 	std::optional<const std::string_view> p_pass,
 	OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride,
 	HAL::Texture* p_emptyTexture2D,
 	HAL::Texture* p_emptyTextureCube,
-	std::optional<std::size_t> p_lastBindSignature
+	std::optional<MaterialSignatureSet> p_previousMaterialSignature
 )
 {
 	ZoneScoped;
@@ -164,13 +164,13 @@ std::size_t OvRendering::Data::Material::Bind(
 		p_featureSetOverride.value_or(m_features)
 	);
 
-	std::size_t signature = CalculateSignature(
+	const auto signature = CalculateSignature(
 		program,
 		p_emptyTexture2D,
 		p_emptyTextureCube
 	);
 
-	if (!p_lastBindSignature || signature != p_lastBindSignature.value())
+	if (!p_previousMaterialSignature || signature.bindSignature != p_previousMaterialSignature->bindSignature)
 	{
 		program.Bind();
 	}
@@ -303,9 +303,13 @@ void OvRendering::Data::Material::SetProperty(const std::string p_name, const Ma
 		p_singleUse
 	};
 
-	if (!p_singleUse)
+	if (p_singleUse)
 	{
-		InvalidatePropertySignature();
+		++m_singleUsePropertySignatureVersion;
+	}
+	else
+	{
+		++m_stablePropertySignatureVersion;
 	}
 }
 
@@ -566,10 +570,11 @@ bool OvRendering::Data::Material::SupportsProjectionMode(OvRendering::Settings::
 
 void OvRendering::Data::Material::InvalidatePropertySignature()
 {
-	++m_propertySignatureVersion;
+	++m_stablePropertySignatureVersion;
+	++m_singleUsePropertySignatureVersion;
 }
 
-std::size_t OvRendering::Data::Material::CalculateSignature(
+OvRendering::Data::MaterialSignatureSet OvRendering::Data::Material::CalculateSignature(
 	OvRendering::HAL::ShaderProgram& p_selectedProgram,
 	HAL::Texture* p_emptyTexture2D,
 	HAL::Texture* p_emptyTextureCube
@@ -577,19 +582,24 @@ std::size_t OvRendering::Data::Material::CalculateSignature(
 {
 	ZoneScoped;
 
-	std::size_t hash{};
+	MaterialSignatureSet signature;
 
-	// Material + shader pointer
-	HashCombine(hash, this);
-	HashCombine(hash, &p_selectedProgram);
+	// Bind
+	HashCombine(signature.bindSignature, this);
+	HashCombine(signature.bindSignature, &p_selectedProgram);
 
-	// Cache version (ensures property changes invalidate the hash)
-	HashCombine(hash, m_propertySignatureVersion);
+	// Stable Properties
+	signature.stablePropertySignature = signature.bindSignature;
+	HashCombine(signature.stablePropertySignature, m_stablePropertySignatureVersion);
+	HashCombine(signature.stablePropertySignature, p_emptyTexture2D);
+	HashCombine(signature.stablePropertySignature, p_emptyTextureCube);
 
-	// Texture pointers
-	HashCombine(hash, p_emptyTexture2D);
-	HashCombine(hash, p_emptyTextureCube);
+	// Single Use Properties
+	signature.singleUsePropertySignature = signature.bindSignature;
+	HashCombine(signature.singleUsePropertySignature, m_singleUsePropertySignatureVersion);
+	HashCombine(signature.singleUsePropertySignature, p_emptyTexture2D);
+	HashCombine(signature.singleUsePropertySignature, p_emptyTextureCube);
 
-	return hash;
+	return signature;
 }
 

--- a/Sources/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/OvRendering/src/OvRendering/Data/Material.cpp
@@ -30,13 +30,15 @@ namespace
 		seed ^= std::hash<T>{}(value)
 			+ kHashCombineConstant 
 			// Bit mixing. They spread entropy from earlier values so order matters
-			// and nearby hashes don’t collapse into similar outputs.
+			// and nearby hashes don't collapse into similar outputs.
 			+ (seed << 6)
 			+ (seed >> 2);
 	}
 
 	OvRendering::Data::MaterialPropertyType UniformToPropertyValue(const std::any& p_uniformValue)
 	{
+		ZoneScoped;
+
 		using namespace OvMaths;
 		using namespace OvRendering;
 
@@ -134,8 +136,10 @@ void OvRendering::Data::Material::UpdateProperties()
 
 			if (!m_properties.contains(name))
 			{
+				const auto defaultValue = UniformToPropertyValue(uniformInfo.defaultValue);
 				m_properties.emplace(name, MaterialProperty{
-					.value = UniformToPropertyValue(uniformInfo.defaultValue),
+					.value = defaultValue,
+					.defaultValue = defaultValue,
 					.singleUse = false
 				});
 			}
@@ -267,7 +271,7 @@ void OvRendering::Data::Material::UploadProperties(
 
 		if (prop.singleUse)
 		{
-			value = UniformToPropertyValue(uniformData->defaultValue);
+			value = prop.defaultValue;
 		}
 	}
 }
@@ -298,10 +302,8 @@ void OvRendering::Data::Material::SetProperty(const std::string p_name, const Ma
 	OVASSERT(IsValid(), "Attempting to SetProperty on an invalid material.");
 	OVASSERT(HasProperty(p_name), "Attempting to SetProperty on a non-existing property.");
 
-	m_properties[p_name] = MaterialProperty{
-		p_value,
-		p_singleUse
-	};
+	m_properties[p_name].value = p_value;
+	m_properties[p_name].singleUse = p_singleUse;
 
 	if (p_singleUse)
 	{

--- a/Sources/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/OvRendering/src/OvRendering/Data/Material.cpp
@@ -4,7 +4,6 @@
 * @licence: MIT
 */
 
-#include <format>
 #include <ranges>
 
 #include <tracy/Tracy.hpp>
@@ -21,6 +20,21 @@
 
 namespace
 {
+	template<typename T>
+	inline void HashCombine(std::size_t& seed, const T& value)
+	{
+		// A large odd constant derived from the golden ratio (64-bit variant).
+		// It helps distribute bits more uniformly and reduce clustering/collisions.
+		constexpr std::size_t kHashCombineConstant = 0x9e3779b97f4a7c15ULL;
+
+		seed ^= std::hash<T>{}(value)
+			+ kHashCombineConstant 
+			// Bit mixing. They spread entropy from earlier values so order matters
+			// and nearby hashes don’t collapse into similar outputs.
+			+ (seed << 6)
+			+ (seed >> 2);
+	}
+
 	OvRendering::Data::MaterialPropertyType UniformToPropertyValue(const std::any& p_uniformValue)
 	{
 		using namespace OvMaths;
@@ -52,13 +66,13 @@ namespace
 		const std::string& p_uniformName,
 		OvRendering::HAL::TextureHandle* p_texture,
 		OvRendering::HAL::TextureHandle* p_fallback,
-		int& p_textureSlot
+		uint32_t p_textureSlot
 	)
 	{
 		if (auto target = p_texture ? p_texture : p_fallback)
 		{
 			target->Bind(p_textureSlot);
-			p_shader.SetUniform<int>(p_uniformName, p_textureSlot++);
+			p_shader.SetUniform<int>(p_uniformName, p_textureSlot);
 		}
 	}
 }
@@ -80,6 +94,7 @@ void OvRendering::Data::Material::SetShader(OvRendering::Resources::Shader* p_sh
 	else
 	{
 		m_properties.clear();
+		InvalidatePropertySignature();
 	}
 }
 
@@ -101,6 +116,8 @@ OvTools::Utils::OptRef<OvRendering::HAL::ShaderProgram> OvRendering::Data::Mater
 
 void OvRendering::Data::Material::UpdateProperties()
 {
+	InvalidatePropertySignature();
+
 	// Collect all uniform names currently used by the shader
 	std::unordered_set<std::string> usedUniforms;
 
@@ -130,19 +147,15 @@ void OvRendering::Data::Material::UpdateProperties()
 	});
 }
 
-// Note: this function is critical for performance, as it may be called many times during a frame.
-// Avoid using any heavy operations or allocations inside this function.
-void OvRendering::Data::Material::Bind(
-	HAL::Texture* p_emptyTexture,
-	HAL::Texture* p_emptyTextureCube,
+std::size_t OvRendering::Data::Material::Bind(
 	std::optional<const std::string_view> p_pass,
-	OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride
+	OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride,
+	HAL::Texture* p_emptyTexture2D,
+	HAL::Texture* p_emptyTextureCube,
+	std::optional<std::size_t> p_lastBindSignature
 )
 {
 	ZoneScoped;
-
-	using namespace OvMaths;
-	using enum OvRendering::Settings::EUniformType;
 
 	OVASSERT(IsValid(), "Attempting to bind an invalid material.");
 
@@ -151,12 +164,43 @@ void OvRendering::Data::Material::Bind(
 		p_featureSetOverride.value_or(m_features)
 	);
 
-	program.Bind();
+	std::size_t signature = CalculateSignature(
+		program,
+		p_emptyTexture2D,
+		p_emptyTextureCube
+	);
 
-	int textureSlot = 0;
+	if (!p_lastBindSignature || signature != p_lastBindSignature.value())
+	{
+		program.Bind();
+	}
+
+	m_programInUse = program;
+
+	return signature;
+}
+
+void OvRendering::Data::Material::UploadProperties(
+	bool uploadStableProperties,
+	bool uploadSingleUseProperties,
+	HAL::Texture* p_emptyTexture2D,
+	HAL::Texture* p_emptyTextureCube
+)
+{
+	ZoneScoped;
+
+	OVASSERT(m_programInUse.has_value(), "Cannot upload properties before binding");
+
+	using namespace OvMaths;
+	using enum OvRendering::Settings::EUniformType;
+
+	auto& program = m_programInUse.value();
 
 	for (auto& [name, prop] : m_properties)
 	{
+		if (!uploadStableProperties && !prop.singleUse) continue;
+		if (!uploadSingleUseProperties && prop.singleUse) continue;
+
 		const auto uniformData = program.GetUniformInfo(name);
 
 		// Skip this property if the current program isn't using its associated uniform
@@ -218,7 +262,7 @@ void OvRendering::Data::Material::Bind(
 					handle = &(*texture)->GetTexture();
 				}
 			}
-			BindTexture(program, name, handle, uniformType == SAMPLER_2D ? p_emptyTexture : p_emptyTextureCube, textureSlot);
+			BindTexture(program, name, handle, uniformType == SAMPLER_2D ? p_emptyTexture2D : p_emptyTextureCube, uniformData->textureSlot);
 		}
 
 		if (prop.singleUse)
@@ -228,10 +272,19 @@ void OvRendering::Data::Material::Bind(
 	}
 }
 
-void OvRendering::Data::Material::Unbind() const
+void OvRendering::Data::Material::Unbind(bool p_resetBoundProgram)
 {
+	ZoneScoped;
+
 	OVASSERT(IsValid(), "Attempting to unbind an invalid material.");
-	m_shader->GetVariant().Unbind();
+	OVASSERT(m_programInUse.has_value(), "Attempting to unbind a material that hasn't been bound");
+
+	if (p_resetBoundProgram)
+	{
+		m_programInUse->Unbind();
+	}
+
+	m_programInUse.reset();
 }
 
 bool OvRendering::Data::Material::HasProperty(const std::string& p_name) const
@@ -249,6 +302,11 @@ void OvRendering::Data::Material::SetProperty(const std::string p_name, const Ma
 		p_value,
 		p_singleUse
 	};
+
+	if (!p_singleUse)
+	{
+		InvalidatePropertySignature();
+	}
 }
 
 bool OvRendering::Data::Material::TrySetProperty(const std::string& p_name, const MaterialPropertyType& p_value, bool p_singleUse)
@@ -505,3 +563,33 @@ bool OvRendering::Data::Material::SupportsProjectionMode(OvRendering::Settings::
 
 	return true;
 }
+
+void OvRendering::Data::Material::InvalidatePropertySignature()
+{
+	++m_propertySignatureVersion;
+}
+
+std::size_t OvRendering::Data::Material::CalculateSignature(
+	OvRendering::HAL::ShaderProgram& p_selectedProgram,
+	HAL::Texture* p_emptyTexture2D,
+	HAL::Texture* p_emptyTextureCube
+)
+{
+	ZoneScoped;
+
+	std::size_t hash{};
+
+	// Material + shader pointer
+	HashCombine(hash, this);
+	HashCombine(hash, &p_selectedProgram);
+
+	// Cache version (ensures property changes invalidate the hash)
+	HashCombine(hash, m_propertySignatureVersion);
+
+	// Texture pointers
+	HashCombine(hash, p_emptyTexture2D);
+	HashCombine(hash, p_emptyTextureCube);
+
+	return hash;
+}
+

--- a/Sources/OvRendering/src/OvRendering/Features/DebugShapeRenderFeature.cpp
+++ b/Sources/OvRendering/src/OvRendering/Features/DebugShapeRenderFeature.cpp
@@ -114,8 +114,6 @@ void OvRendering::Features::DebugShapeRenderFeature::DrawLine(
 	drawable.primitiveMode = Settings::EPrimitiveMode::LINES;
 
 	m_renderer.DrawEntity(p_pso, drawable);
-
-	m_lineShader->GetVariant().Unbind();
 }
 
 void OvRendering::Features::DebugShapeRenderFeature::DrawBox(

--- a/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLShaderProgram.cpp
+++ b/Sources/OvRendering/src/OvRendering/HAL/OpenGL/GLShaderProgram.cpp
@@ -138,6 +138,8 @@ void OvRendering::HAL::GLShaderProgram::QueryUniforms()
 	GLint activeUniformCount = 0;
 	glGetProgramiv(m_context.id, GL_ACTIVE_UNIFORMS, &activeUniformCount);
 
+	uint32_t textureSlotCounter = 0;
+
 	for (GLint i = 0; i < activeUniformCount; ++i)
 	{
 		GLint arraySize = 0;
@@ -180,10 +182,15 @@ void OvRendering::HAL::GLShaderProgram::QueryUniforms()
 		// Only add the uniform if it has a value (unsupported uniform types will be ignored)
 		if (uniformValue.has_value())
 		{
+			const bool isTexture =
+				uniformType == Settings::EUniformType::SAMPLER_2D ||
+				uniformType == Settings::EUniformType::SAMPLER_CUBE;
+
 			m_context.uniforms.emplace(name, Settings::UniformInfo{
 				.type = uniformType,
 				.name = name,
-				.defaultValue = uniformValue
+				.defaultValue = uniformValue,
+				.textureSlot = isTexture ? textureSlotCounter++ : 0
 			});
 		}
 	}

--- a/Sources/OvRendering/src/OvRendering/Resources/Shader.cpp
+++ b/Sources/OvRendering/src/OvRendering/Resources/Shader.cpp
@@ -7,6 +7,8 @@
 #include <format>
 #include <ranges>
 
+#include <tracy/Tracy.hpp>
+
 #include <OvDebug/Assertion.h>
 #include <OvRendering/Resources/Shader.h>
 
@@ -21,21 +23,27 @@ namespace
 
 OvRendering::HAL::ShaderProgram& OvRendering::Resources::Shader::GetVariant(std::optional<const std::string_view> p_pass, const Data::FeatureSet& p_featureSet)
 {
-	const std::string pass = std::string{ p_pass.value_or("") };
+	ZoneScoped;
 
-	if (!m_variants.contains(pass))
+	const std::string pass{ p_pass.value_or("") };
+
+	auto passIt = m_variants.find(pass);
+	if (passIt == m_variants.end())
 	{
-		OVASSERT(m_variants[{}].contains({}), "No default program found for the default pass");
-		return *m_variants[{}][{}];
+		auto defaultPassIt = m_variants.find("");
+		OVASSERT(defaultPassIt != m_variants.end() && defaultPassIt->second.contains({}), "No default program found for the default pass");
+		return *defaultPassIt->second.at({});
 	}
 
-	if (!m_variants[pass].contains(p_featureSet))
+	auto featureIt = passIt->second.find(p_featureSet);
+	if (featureIt == passIt->second.end())
 	{
-		OVASSERT(m_variants[pass].contains({}), std::format("No default program found for pass: {}", pass));
-		return *m_variants[pass][{}];
+		auto defaultFeatureIt = passIt->second.find({});
+		OVASSERT(defaultFeatureIt != passIt->second.end(), std::format("No default program found for pass: {}", pass));
+		return *defaultFeatureIt->second;
 	}
 
-	return *m_variants[pass][p_featureSet];
+	return *featureIt->second;
 }
 
 const OvRendering::Data::FeatureSet& OvRendering::Resources::Shader::GetFeatures() const


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Supersedes https://github.com/Overload-Technologies/Overload/pull/811.

This PR aims to reduce shader program state changes & property uploads by:
- Re-ordering opaque pass draw calls by material key
- Reducing unnecessary shader program changes by keeping track of the last used program
- Keeping track of property changes, to efficiently skip uploads if the data didn't change
- Re-writing the `GetVariant` method
- Added a `defaultValue` to `MaterialProperty` instead of calling the expensive `UniformToPropertyValue` every time a single use property need to be reset

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #445

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

### DrawFrame (Cargo)
- RTX 2080 ti
- Ryzen 9 3900X
- 1920x1080p editor, default layout

Went from ~7.79ms to 3.78ms.

| Before | After |
| - | - |
| <img width="1120" height="878" alt="image" src="https://github.com/user-attachments/assets/641fc15d-3aa8-4bc6-b68e-0b7943c30999" /> | <img width="1080" height="867" alt="image" src="https://github.com/user-attachments/assets/c96d3ce4-9cf5-4d4d-87ce-f56e5c88ac48" /> |

### DrawEntity

Went from expensive draws...

<img width="824" height="76" alt="image" src="https://github.com/user-attachments/assets/92fbb2ea-54bd-4cea-8a93-27d808be5a85" />

to one initial draw, and cheap subsequent draws, thanks to property caching.

<img width="1223" height="90" alt="image" src="https://github.com/user-attachments/assets/faec4786-10d3-46db-b8d1-bb395ce3efb5" />




## AI Usage Disclosure
<!-- Replace with "None" if not used -->
None

## Checklist
<!-- Check all that apply -->
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
