### PR TITLE
Support External Animation Sources for Skinned Meshes

### DIFF
--- a/Resources/Engine/Lua/Components/SkinnedMeshRenderer.lua
+++ b/Resources/Engine/Lua/Components/SkinnedMeshRenderer.lua
@@ -55,6 +55,18 @@ function SkinnedMeshRenderer:SetTime(timeSeconds) end
 ---@return number
 function SkinnedMeshRenderer:GetTime() end
 
+--- Sets an external model used as animation source, or nil to use the rendered model
+---@param model Model|nil
+function SkinnedMeshRenderer:SetAnimationSourceModel(model) end
+
+--- Returns the external animation source model, or nil when the rendered model is used
+---@return Model|nil
+function SkinnedMeshRenderer:GetAnimationSourceModel() end
+
+--- Returns whether the current animation source is compatible with the rendered model skeleton
+---@return boolean
+function SkinnedMeshRenderer:IsAnimationSourceCompatible() end
+
 --- Returns the number of available animation clips
 ---@return integer
 function SkinnedMeshRenderer:GetAnimationCount() end

--- a/Sources/OvCore/include/OvCore/ECS/Components/CSkinnedMeshRenderer.h
+++ b/Sources/OvCore/include/OvCore/ECS/Components/CSkinnedMeshRenderer.h
@@ -15,6 +15,7 @@
 #include <OvMaths/FMatrix4.h>
 #include <OvMaths/FQuaternion.h>
 #include <OvMaths/FVector3.h>
+#include <OvTools/Eventing/Event.h>
 
 namespace OvCore::ECS { class Actor; }
 namespace OvRendering::Resources { class Model; }
@@ -118,6 +119,22 @@ namespace OvCore::ECS::Components
 		* Returns the current playback time in seconds
 		*/
 		float GetTime() const;
+
+		/**
+		* Sets the external model used as animation source. Pass nullptr to use the rendered model animations.
+		* @param p_model
+		*/
+		void SetAnimationSourceModel(OvRendering::Resources::Model* p_model);
+
+		/**
+		* Returns the external animation source model, or nullptr when the rendered model is used
+		*/
+		OvRendering::Resources::Model* GetAnimationSourceModel() const;
+
+		/**
+		* Returns true if the current animation source can be applied to the rendered model skeleton
+		*/
+		bool IsAnimationSourceCompatible() const;
 
 		/**
 		* Returns the number of available animations
@@ -246,6 +263,8 @@ namespace OvCore::ECS::Components
 
 	private:
 		bool HasCompatibleModel() const;
+		bool HasCompatibleAnimationSource() const;
+		const OvRendering::Resources::Model* GetAnimationModel() const;
 		void SyncWithModel();
 		void RebuildRuntimeData();
 		void EvaluatePose();
@@ -256,6 +275,8 @@ namespace OvCore::ECS::Components
 
 	private:
 		const OvRendering::Resources::Model* m_model = nullptr;
+		OvRendering::Resources::Model* m_animationSourceModel = nullptr;
+		OvTools::Eventing::Event<> m_animationSourceChangedEvent;
 
 		bool m_playing = true;
 		bool m_looping = true;
@@ -272,6 +293,7 @@ namespace OvCore::ECS::Components
 		bool m_manualPoseOverride = false;
 
 		std::vector<std::string> m_animationNames;
+		std::vector<int32_t> m_animationNodeMap;
 		std::vector<OvMaths::FMatrix4> m_localPose;
 		std::vector<OvMaths::FMatrix4> m_globalPose;
 		std::vector<OvMaths::FMatrix4> m_boneMatrices;

--- a/Sources/OvCore/src/OvCore/ECS/Components/CSkinnedMeshRenderer.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/CSkinnedMeshRenderer.cpp
@@ -17,6 +17,7 @@
 #include <OvCore/ECS/Components/CSkinnedMeshRenderer.h>
 #include <OvCore/Helpers/GUIDrawer.h>
 #include <OvCore/Helpers/Serializer.h>
+#include <OvDebug/Logger.h>
 #include <OvMaths/FMatrix3.h>
 #include <OvMaths/FTransform.h>
 #include <OvUI/Plugins/DataDispatcher.h>
@@ -147,11 +148,166 @@ namespace
 
 		p_rotation = OvMaths::FQuaternion(rotationMatrix);
 	}
+
+	bool AreMatricesClose(const OvMaths::FMatrix4& p_left, const OvMaths::FMatrix4& p_right)
+	{
+		constexpr float kSkeletonTransformTolerance = 0.0001f;
+
+		for (uint8_t i = 0; i < 16; ++i)
+		{
+			if (std::abs(p_left.data[i] - p_right.data[i]) > kSkeletonTransformTolerance)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool CollectRequiredSkinningNodes(
+		const OvRendering::Animation::Skeleton& p_skeleton,
+		std::vector<bool>& p_requiredNodes
+	)
+	{
+		p_requiredNodes.assign(p_skeleton.nodes.size(), false);
+
+		for (const auto& bone : p_skeleton.bones)
+		{
+			if (bone.nodeIndex >= p_skeleton.nodes.size())
+			{
+				return false;
+			}
+
+			int32_t nodeIndex = static_cast<int32_t>(bone.nodeIndex);
+			while (nodeIndex >= 0)
+			{
+				const auto currentNodeIndex = static_cast<size_t>(nodeIndex);
+				if (currentNodeIndex >= p_skeleton.nodes.size())
+				{
+					return false;
+				}
+
+				if (p_requiredNodes[currentNodeIndex])
+				{
+					break;
+				}
+
+				p_requiredNodes[currentNodeIndex] = true;
+				nodeIndex = p_skeleton.nodes[currentNodeIndex].parentIndex;
+			}
+		}
+
+		return true;
+	}
+
+	bool BuildAnimationNodeMap(
+		const OvRendering::Animation::Skeleton& p_targetSkeleton,
+		const OvRendering::Animation::Skeleton& p_sourceSkeleton,
+		std::vector<int32_t>& p_nodeMap
+	)
+	{
+		p_nodeMap.assign(p_sourceSkeleton.nodes.size(), -1);
+
+		if (p_targetSkeleton.nodes.empty() || p_sourceSkeleton.nodes.empty() || p_targetSkeleton.bones.empty())
+		{
+			return false;
+		}
+
+		std::vector<bool> requiredNodes;
+		if (!CollectRequiredSkinningNodes(p_targetSkeleton, requiredNodes))
+		{
+			return false;
+		}
+
+		for (size_t targetNodeIndex = 0; targetNodeIndex < requiredNodes.size(); ++targetNodeIndex)
+		{
+			if (!requiredNodes[targetNodeIndex])
+			{
+				continue;
+			}
+
+			const auto& targetNode = p_targetSkeleton.nodes[targetNodeIndex];
+			const auto sourceNodeIndex = p_sourceSkeleton.FindNodeIndex(targetNode.name);
+			if (!sourceNodeIndex.has_value() || *sourceNodeIndex >= p_sourceSkeleton.nodes.size())
+			{
+				return false;
+			}
+
+			const auto& sourceNode = p_sourceSkeleton.nodes[*sourceNodeIndex];
+			const int32_t targetParentIndex = targetNode.parentIndex;
+			const int32_t sourceParentIndex = sourceNode.parentIndex;
+			const bool hasRequiredTargetParent =
+				targetParentIndex >= 0 &&
+				static_cast<size_t>(targetParentIndex) < requiredNodes.size() &&
+				requiredNodes[static_cast<size_t>(targetParentIndex)];
+
+			if (targetParentIndex >= 0 && static_cast<size_t>(targetParentIndex) >= requiredNodes.size())
+			{
+				return false;
+			}
+
+			if (hasRequiredTargetParent)
+			{
+				if (
+					sourceParentIndex < 0 ||
+					static_cast<size_t>(sourceParentIndex) >= p_sourceSkeleton.nodes.size() ||
+					p_sourceSkeleton.nodes[static_cast<size_t>(sourceParentIndex)].name != p_targetSkeleton.nodes[static_cast<size_t>(targetParentIndex)].name
+				)
+				{
+					return false;
+				}
+			}
+			else if (sourceParentIndex >= 0)
+			{
+				return false;
+			}
+
+			if (!AreMatricesClose(targetNode.localBindTransform, sourceNode.localBindTransform))
+			{
+				return false;
+			}
+
+			p_nodeMap[*sourceNodeIndex] = static_cast<int32_t>(targetNodeIndex);
+		}
+
+		if (!p_sourceSkeleton.bones.empty())
+		{
+			if (p_sourceSkeleton.bones.size() != p_targetSkeleton.bones.size())
+			{
+				return false;
+			}
+
+			for (const auto& targetBone : p_targetSkeleton.bones)
+			{
+				const auto sourceBoneIndex = p_sourceSkeleton.FindBoneIndex(targetBone.name);
+				if (!sourceBoneIndex.has_value() || *sourceBoneIndex >= p_sourceSkeleton.bones.size())
+				{
+					return false;
+				}
+
+				const auto& sourceBone = p_sourceSkeleton.bones[*sourceBoneIndex];
+				if (
+					sourceBone.nodeIndex >= p_nodeMap.size() ||
+					p_nodeMap[sourceBone.nodeIndex] != static_cast<int32_t>(targetBone.nodeIndex)
+				)
+				{
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
 }
 
 OvCore::ECS::Components::CSkinnedMeshRenderer::CSkinnedMeshRenderer(ECS::Actor& p_owner) :
 	AComponent(p_owner)
 {
+	m_animationSourceChangedEvent += [this]()
+	{
+		RebuildRuntimeData();
+	};
+
 	NotifyModelChanged();
 }
 
@@ -173,7 +329,9 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::NotifyModelChanged()
 
 bool OvCore::ECS::Components::CSkinnedMeshRenderer::HasSkinningData() const
 {
-	return HasCompatibleModel() && !m_boneMatrices.empty() && (m_animationIndex.has_value() || m_manualPoseOverride);
+	return HasCompatibleModel() &&
+		!m_boneMatrices.empty() &&
+		((m_animationIndex.has_value() && HasCompatibleAnimationSource()) || m_manualPoseOverride);
 }
 
 void OvCore::ECS::Components::CSkinnedMeshRenderer::Play()
@@ -234,12 +392,12 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::SetMeshBoundsScale(float p_s
 
 void OvCore::ECS::Components::CSkinnedMeshRenderer::SetTime(float p_timeSeconds)
 {
-	if (!HasCompatibleModel() || !m_animationIndex.has_value())
+	if (!HasCompatibleAnimationSource() || !m_animationIndex.has_value())
 	{
 		return;
 	}
 
-	const auto& animation = m_model->GetAnimations().at(*m_animationIndex);
+	const auto& animation = GetAnimationModel()->GetAnimations().at(*m_animationIndex);
 	const float ticksPerSecond = animation.GetEffectiveTicksPerSecond();
 
 	m_currentTimeTicks = p_timeSeconds * ticksPerSecond;
@@ -258,14 +416,35 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::SetTime(float p_timeSeconds)
 
 float OvCore::ECS::Components::CSkinnedMeshRenderer::GetTime() const
 {
-	if (!HasCompatibleModel() || !m_animationIndex.has_value())
+	if (!HasCompatibleAnimationSource() || !m_animationIndex.has_value())
 	{
 		return 0.0f;
 	}
 
-	const auto& animation = m_model->GetAnimations().at(*m_animationIndex);
+	const auto& animation = GetAnimationModel()->GetAnimations().at(*m_animationIndex);
 	const float ticksPerSecond = animation.GetEffectiveTicksPerSecond();
 	return m_currentTimeTicks / ticksPerSecond;
+}
+
+void OvCore::ECS::Components::CSkinnedMeshRenderer::SetAnimationSourceModel(OvRendering::Resources::Model* p_model)
+{
+	if (m_animationSourceModel == p_model)
+	{
+		return;
+	}
+
+	m_animationSourceModel = p_model;
+	RebuildRuntimeData();
+}
+
+OvRendering::Resources::Model* OvCore::ECS::Components::CSkinnedMeshRenderer::GetAnimationSourceModel() const
+{
+	return m_animationSourceModel;
+}
+
+bool OvCore::ECS::Components::CSkinnedMeshRenderer::IsAnimationSourceCompatible() const
+{
+	return HasCompatibleAnimationSource();
 }
 
 uint32_t OvCore::ECS::Components::CSkinnedMeshRenderer::GetAnimationCount() const
@@ -295,7 +474,7 @@ bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetAnimation(std::optional<u
 		return true;
 	}
 
-	if (!HasCompatibleModel() || *p_index >= m_model->GetAnimations().size())
+	if (!HasCompatibleAnimationSource() || *p_index >= GetAnimationModel()->GetAnimations().size())
 	{
 		return false;
 	}
@@ -310,12 +489,12 @@ bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetAnimation(std::optional<u
 
 bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetAnimation(const std::string& p_name)
 {
-	if (!HasCompatibleModel())
+	if (!HasCompatibleAnimationSource())
 	{
 		return false;
 	}
 
-	const auto& animations = m_model->GetAnimations();
+	const auto& animations = GetAnimationModel()->GetAnimations();
 
 	const auto found = std::find_if(animations.begin(), animations.end(), [&p_name](const auto& p_animation)
 	{
@@ -551,6 +730,7 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::OnSerialize(tinyxml2::XMLDoc
 	OvCore::Helpers::Serializer::SerializeFloat(p_doc, p_node, "mesh_bounds_scale", m_meshBoundsScale);
 	OvCore::Helpers::Serializer::SerializeFloat(p_doc, p_node, "pose_eval_rate", m_poseEvaluationRate);
 	OvCore::Helpers::Serializer::SerializeFloat(p_doc, p_node, "time_ticks", m_currentTimeTicks);
+	OvCore::Helpers::Serializer::SerializeModel(p_doc, p_node, "animation_source", m_animationSourceModel);
 	OvCore::Helpers::Serializer::SerializeString(p_doc, p_node, "animation", GetActiveAnimationName().value_or(std::string{}));
 }
 
@@ -562,6 +742,7 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::OnDeserialize(tinyxml2::XMLD
 	OvCore::Helpers::Serializer::DeserializeFloat(p_doc, p_node, "mesh_bounds_scale", m_meshBoundsScale);
 	OvCore::Helpers::Serializer::DeserializeFloat(p_doc, p_node, "pose_eval_rate", m_poseEvaluationRate);
 	OvCore::Helpers::Serializer::DeserializeFloat(p_doc, p_node, "time_ticks", m_currentTimeTicks);
+	OvCore::Helpers::Serializer::DeserializeModel(p_doc, p_node, "animation_source", m_animationSourceModel);
 	OvCore::Helpers::Serializer::DeserializeString(p_doc, p_node, "animation", m_deserializedAnimationName);
 	SetMeshBoundsScale(m_meshBoundsScale);
 	m_poseEvaluationRate = std::max(0.0f, m_poseEvaluationRate);
@@ -592,6 +773,8 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::OnInspector(OvUI::Internal::
 		std::max(GetAnimationDurationSeconds(), 3600.0f)
 	);
 
+	GUIDrawer::DrawMesh(p_root, "Animation Source", m_animationSourceModel, &m_animationSourceChangedEvent);
+
 	GUIDrawer::CreateTitle(p_root, "Active Animation");
 	const int currentAnimIndex = GetActiveAnimationIndex().has_value() ? static_cast<int>(*GetActiveAnimationIndex()) : -1;
 	auto& animationChoice = p_root.CreateWidget<OvUI::Widgets::Selection::ComboBox>(currentAnimIndex);
@@ -618,15 +801,35 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::OnInspector(OvUI::Internal::
 	{
 		p_root.CreateWidget<OvUI::Widgets::Texts::Text>("No skinned model assigned");
 	}
+	else if (m_animationSourceModel && !HasCompatibleAnimationSource())
+	{
+		p_root.CreateWidget<OvUI::Widgets::Texts::Text>("Animation source skeleton is not compatible with model");
+	}
 	else if (m_animationNames.empty())
 	{
-		p_root.CreateWidget<OvUI::Widgets::Texts::Text>("Model has no animation clips");
+		p_root.CreateWidget<OvUI::Widgets::Texts::Text>(m_animationSourceModel ? "Animation source has no animation clips" : "Model has no animation clips");
 	}
 }
 
 bool OvCore::ECS::Components::CSkinnedMeshRenderer::HasCompatibleModel() const
 {
 	return m_model && m_model->IsSkinned() && m_model->GetSkeleton().has_value();
+}
+
+bool OvCore::ECS::Components::CSkinnedMeshRenderer::HasCompatibleAnimationSource() const
+{
+	if (!HasCompatibleModel())
+	{
+		return false;
+	}
+
+	const auto animationModel = GetAnimationModel();
+	return animationModel && animationModel->GetSkeleton().has_value() && !m_animationNodeMap.empty();
+}
+
+const OvRendering::Resources::Model* OvCore::ECS::Components::CSkinnedMeshRenderer::GetAnimationModel() const
+{
+	return m_animationSourceModel ? m_animationSourceModel : m_model;
 }
 
 void OvCore::ECS::Components::CSkinnedMeshRenderer::SyncWithModel()
@@ -650,6 +853,7 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::RebuildRuntimeData()
 	const std::string requestedAnimationName = m_deserializedAnimationName;
 
 	m_animationNames.clear();
+	m_animationNodeMap.clear();
 	m_localPose.clear();
 	m_globalPose.clear();
 	m_boneMatrices.clear();
@@ -665,20 +869,35 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::RebuildRuntimeData()
 	}
 
 	const auto& skeleton = m_model->GetSkeleton().value();
-	const auto& animations = m_model->GetAnimations();
+	const auto animationModel = GetAnimationModel();
 
 	m_localPose.resize(skeleton.nodes.size(), OvMaths::FMatrix4::Identity);
 	m_globalPose.resize(skeleton.nodes.size(), OvMaths::FMatrix4::Identity);
 	m_boneMatrices.resize(skeleton.bones.size(), OvMaths::FMatrix4::Identity);
 	m_boneMatricesTransposed.resize(skeleton.bones.size(), OvMaths::FMatrix4::Identity);
 
-	m_animationNames.reserve(animations.size());
-	for (const auto& animation : animations)
+	if (
+		animationModel &&
+		animationModel->GetSkeleton().has_value() &&
+		BuildAnimationNodeMap(skeleton, animationModel->GetSkeleton().value(), m_animationNodeMap)
+	)
 	{
-		m_animationNames.push_back(animation.name);
+		const auto& animations = animationModel->GetAnimations();
+
+		m_animationNames.reserve(animations.size());
+		for (const auto& animation : animations)
+		{
+			m_animationNames.push_back(animation.name);
+		}
+	}
+	else if (m_animationSourceModel)
+	{
+		OVLOG_WARNING("SkinnedMeshRenderer: Animation source model '" + m_animationSourceModel->path + "' is not compatible with target model '" + m_model->path + "'.");
 	}
 
-	if (!animations.empty())
+	const auto& animations = GetAnimationModel()->GetAnimations();
+
+	if (!m_animationNames.empty())
 	{
 		if (!requestedAnimationName.empty())
 		{
@@ -687,13 +906,13 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::RebuildRuntimeData()
 				std::optional<uint32_t>{ static_cast<uint32_t>(std::distance(m_animationNames.begin(), found)) } :
 				std::optional<uint32_t>{ 0 };
 		}
-		else if (preservedAnimationIndex.has_value() && *preservedAnimationIndex < animations.size())
+		else if (preservedAnimationIndex.has_value() && *preservedAnimationIndex < m_animationNames.size())
 		{
 			m_animationIndex = *preservedAnimationIndex;
 		}
 	}
 
-	if (m_animationIndex.has_value() && *m_animationIndex < animations.size())
+	if (HasCompatibleAnimationSource() && m_animationIndex.has_value() && *m_animationIndex < animations.size())
 	{
 		const auto& animation = animations.at(*m_animationIndex);
 		if (m_looping)
@@ -728,9 +947,11 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::EvaluatePose()
 		m_localPose[nodeIndex] = skeleton.nodes[nodeIndex].localBindTransform;
 	}
 
-	if (m_animationIndex.has_value() && *m_animationIndex < m_model->GetAnimations().size())
+	const auto animationModel = GetAnimationModel();
+	if (HasCompatibleAnimationSource() && m_animationIndex.has_value() && *m_animationIndex < animationModel->GetAnimations().size())
 	{
-		const auto& animation = m_model->GetAnimations().at(*m_animationIndex);
+		const auto& animation = animationModel->GetAnimations().at(*m_animationIndex);
+		const auto& animationSkeleton = animationModel->GetSkeleton().value();
 		const float duration = std::max(animation.duration, 0.0f);
 		const float sampleTime =
 			duration > 0.0f ?
@@ -739,12 +960,18 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::EvaluatePose()
 
 		for (const auto& track : animation.tracks)
 		{
-			if (track.nodeIndex >= m_localPose.size())
+			if (track.nodeIndex >= animationSkeleton.nodes.size() || track.nodeIndex >= m_animationNodeMap.size())
 			{
 				continue;
 			}
 
-			const auto& node = skeleton.nodes[track.nodeIndex];
+			const int32_t targetNodeIndex = m_animationNodeMap[track.nodeIndex];
+			if (targetNodeIndex < 0 || static_cast<size_t>(targetNodeIndex) >= m_localPose.size())
+			{
+				continue;
+			}
+
+			const auto& node = skeleton.nodes[static_cast<size_t>(targetNodeIndex)];
 
 			const OvMaths::FVector3 sampledPosition = SampleKeys(
 				track.positionKeys,
@@ -774,7 +1001,7 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::EvaluatePose()
 			);
 
 			const OvMaths::FTransform sampled(sampledPosition, sampledRotation, sampledScale);
-			m_localPose[track.nodeIndex] = sampled.GetLocalMatrix();
+			m_localPose[static_cast<size_t>(targetNodeIndex)] = sampled.GetLocalMatrix();
 		}
 	}
 
@@ -847,23 +1074,23 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::RecomputeBoneMatricesFromLoc
 
 float OvCore::ECS::Components::CSkinnedMeshRenderer::GetAnimationDurationSeconds() const
 {
-	if (!HasCompatibleModel() || !m_animationIndex.has_value())
+	if (!HasCompatibleAnimationSource() || !m_animationIndex.has_value())
 	{
 		return 0.0f;
 	}
 
-	const auto& animation = m_model->GetAnimations().at(*m_animationIndex);
+	const auto& animation = GetAnimationModel()->GetAnimations().at(*m_animationIndex);
 	return animation.GetDurationSeconds();
 }
 
 void OvCore::ECS::Components::CSkinnedMeshRenderer::UpdatePlayback(float p_deltaTime)
 {
-	if (!HasCompatibleModel() || !m_animationIndex.has_value())
+	if (!HasCompatibleAnimationSource() || !m_animationIndex.has_value())
 	{
 		return;
 	}
 
-	const auto& animation = m_model->GetAnimations().at(*m_animationIndex);
+	const auto& animation = GetAnimationModel()->GetAnimations().at(*m_animationIndex);
 	if (animation.duration <= 0.0f)
 	{
 		return;

--- a/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaComponentsBindings.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaComponentsBindings.cpp
@@ -105,6 +105,9 @@ void BindLuaComponents(sol::state& p_luaState)
 		"GetMeshBoundsScale", &CSkinnedMeshRenderer::GetMeshBoundsScale,
 		"SetTime", &CSkinnedMeshRenderer::SetTime,
 		"GetTime", &CSkinnedMeshRenderer::GetTime,
+		"SetAnimationSourceModel", &CSkinnedMeshRenderer::SetAnimationSourceModel,
+		"GetAnimationSourceModel", &CSkinnedMeshRenderer::GetAnimationSourceModel,
+		"IsAnimationSourceCompatible", &CSkinnedMeshRenderer::IsAnimationSourceCompatible,
 		"GetAnimationCount", &CSkinnedMeshRenderer::GetAnimationCount,
 		"GetAnimationName", &CSkinnedMeshRenderer::GetAnimationName,
 		"SetAnimation", sol::overload(

--- a/Sources/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
+++ b/Sources/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
@@ -995,12 +995,13 @@ bool OvRendering::Resources::Parsers::AssimpParser::LoadModel(
 	{
 		hasBones = scene->mMeshes[i] && scene->mMeshes[i]->HasBones();
 	}
+	const bool hasAnimations = scene->mNumAnimations > 0;
 
 	p_skeleton.reset();
 	p_animations.clear();
 	std::unordered_map<const aiNode*, uint32_t> nodeIndexByPointer;
 
-	if (hasBones)
+	if (hasBones || hasAnimations)
 	{
 		p_skeleton.emplace();
 		nodeIndexByPointer.reserve(512);
@@ -1013,15 +1014,15 @@ bool OvRendering::Resources::Parsers::AssimpParser::LoadModel(
 		scene,
 		p_meshes,
 		p_skeleton ? &p_skeleton.value() : nullptr,
-		hasBones ? &nodeIndexByPointer : nullptr
+		p_skeleton ? &nodeIndexByPointer : nullptr
 	);
 
-	if (hasBones && p_skeleton.has_value())
+	if (hasAnimations && p_skeleton.has_value())
 	{
 		ProcessAnimations(scene, p_skeleton.value(), p_animations);
 	}
 
-	if (p_skeleton && p_skeleton->bones.empty())
+	if (p_skeleton && p_skeleton->bones.empty() && p_animations.empty())
 	{
 		p_skeleton.reset();
 		p_animations.clear();


### PR DESCRIPTION
## Description
Adds external animation sources to `CSkinnedMeshRenderer`, with skeleton compatibility mapping, serialization, inspector UI, Lua bindings, and animation-only Assimp imports.

## Related Issue(s)
Fixes #809

## Review Guidance
Review skeleton mapping and animation-only import handling.

## Screenshots/GIFs
N/A

## AI Usage Disclosure
Documentation (Lua API) / Generate new code

## Checklist
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
